### PR TITLE
📚 Add 13 missing decoder cards to complete all 38 tactics

### DIFF
--- a/book/chapters/08-decoder-cards.md
+++ b/book/chapters/08-decoder-cards.md
@@ -664,6 +664,410 @@ Withdraw emotional labor. That is the REAL boundary.
 
 ---
 
+## Card 26: Interruption as Dominance
+
+**The Pattern:** They interrupt your focused activities
+
+**What They Say/Do:**
+- Interrupting your meditation, reading, or work
+- Creating noise when you're trying to concentrate
+- Starting conversations the moment you begin something for yourself
+- "Are you seriously still doing that?"
+- Finding "emergencies" whenever you have alone time
+
+**What's Really Happening:**
+
+Your attention is being claimed as their property. They're demonstrating that your focus belongs to them, not to you. Independent activity threatens their control. Your ability to be content without them is intolerable.
+
+**How It Hooks You:**
+
+You feel guilty for wanting solitude. You start to believe your needs for focus or rest are selfish. You give up activities that nourish you to keep the peace. You stop meditating, reading, or pursuing hobbies.
+
+**Your Power Move:**
+
+"I'm going to finish this. We can talk when I'm done." Then finish. Do not explain, justify, or apologize for having your own activities. Your attention is yours to direct.
+
+*See also: Tactic 1 (Chapter 3)*
+
+> *"He'll break your meditation to prove your focus belongs to him."*
+
+---
+
+## Card 27: "We Need to Talk" Urgency
+
+**The Pattern:** Creating anxiety through ominous announcements
+
+**What They Say/Do:**
+- "We need to talk" (with no context)
+- "I have something important to discuss"
+- Creating artificial emergencies requiring immediate attention
+- "Call me NOW"
+- "Something happened. Can't explain over text."
+
+**What's Really Happening:**
+
+They're hijacking your nervous system. The ambiguous phrase triggers anxiety, pulling you out of your own rhythm and into theirs. Your peace becomes conditional on resolving their manufactured crisis. This is deliberate destabilization.
+
+**How It Hooks You:**
+
+Anxiety spikes immediately. You drop everything. You start rehearsing what you might have done wrong. You're off-balance before the conversation even begins. You spend hours worrying about nothing.
+
+**Your Power Move:**
+
+"What specifically did you want to discuss?" Refuse to enter anxiety without information. If they can't or won't tell you, say: "Let me know when you're ready to have a specific conversation." Don't let vague statements control your emotional state.
+
+*See also: Tactic 2 (Chapter 3)*
+
+---
+
+## Card 28: Physical Intimidation
+
+**The Pattern:** Using physical presence as a threat
+
+**What They Say/Do:**
+- Getting physically close when angry
+- Standing over you, blocking doorways
+- Making a fist near you (not hitting, just showing)
+- "I could snap your neck with one hand"
+- Grabbing their hand around your throat without squeezing
+- "You're so small/weak/fragile"
+
+**What's Really Happening:**
+
+They're using the implicit threat of physical harm to establish dominance. You don't have to be hit to be controlled by the possibility of being hit. The fear is the point. By demonstrating your physical vulnerability, they remind you who has power—and that your safety depends on their restraint.
+
+**How It Hooks You:**
+
+Your nervous system goes into freeze or fawn mode. You become very, very careful. You monitor their physical state constantly. You stop saying things that might trigger their proximity. You feel trapped even in open spaces.
+
+**Your Power Move:**
+
+**This is abuse.** Physical intimidation is domestic violence even without contact. Document everything. Tell someone you trust. Create a safety plan. Know your exit routes.
+
+**National Domestic Violence Hotline: 1-800-799-7233**
+
+This is not something you manage—this is something you get safe from.
+
+*See also: Tactic 4 (Chapter 3)*
+
+> *"The threat is the tactic. You don't have to be hit to be controlled by the possibility."*
+
+---
+
+## Card 29: Chaos as Camouflage
+
+**The Pattern:** Constant crisis and disorder
+
+**What They Say/Do:**
+- Their environment is consistently messy, loud, or crisis-filled
+- There's always something going wrong
+- Always some drama demanding attention
+- "Everything is falling apart"
+- Thriving in chaos while you can barely cope
+
+**What's Really Happening:**
+
+External chaos mirrors and masks internal chaos. If everything around you is in crisis, you can't center yourself. You can't think clearly. You become dependent on them to navigate the very turbulence they created.
+
+**How It Hooks You:**
+
+You become the one who manages, cleans, fixes, soothes. Your energy goes toward putting out fires instead of building your own life. You feel responsible for restoring order. You're too exhausted to question the relationship.
+
+**Your Power Move:**
+
+Stop trying to organize their chaos. Create clear, protected space for yourself—even if it's just one room, one corner, one hour. Chaos is their problem, not yours to solve.
+
+*See also: Tactic 5 (Chapter 3)*
+
+> *"His environment reflects the chaos he refuses to clean inside."*
+
+---
+
+## Card 30: Shame Inversion
+
+**The Pattern:** Making you feel ashamed of their behavior
+
+**What They Say/Do:**
+- "I feel bad for you"
+- "You're too sensitive"
+- "I worry about you"
+- "That's a you problem"
+- "You should really work on that"
+- "Most people wouldn't react that way"
+
+**What's Really Happening:**
+
+Their shame is intolerable to them, so they deposit it in you. By positioning you as the one with the problem, they offload their own discomfort. The shame they should feel for their behavior becomes shame you feel for your reactions.
+
+**How It Hooks You:**
+
+You start to believe you really are the problem. You work harder on yourself while they change nothing. You apologize for having feelings about their treatment of you. You feel broken.
+
+**Your Power Move:**
+
+Internal mantra: "I return this shame to its source."
+
+Out loud: "I don't experience myself that way, but thank you for your concern."
+
+You are not responsible for carrying their disowned emotions.
+
+*See also: Tactic 6 (Chapter 3)*
+
+---
+
+## Card 31: Mockery Voice
+
+**The Pattern:** Mimicking you in a mocking tone
+
+**What They Say/Do:**
+- Repeating your words in a whiny, exaggerated voice
+- Mimicking your expressions mockingly
+- Making your sincere statements sound ridiculous
+- Baby talk when you express needs
+- "Oh, so now you're going to cry about it?"
+
+**What's Really Happening:**
+
+They're teaching you that earnestness will be punished. By making you sound foolish, they undermine your confidence in expressing yourself. Over time, you stop sharing how you really feel. Your voice becomes silenced.
+
+**How It Hooks You:**
+
+You feel humiliated. You start pre-editing your words to avoid being mocked. You become afraid to be sincere or vulnerable. You stop expressing needs because it never goes well.
+
+**Your Power Move:**
+
+"When you repeat my words that way, it tells me you're not interested in understanding. Let me know when you're ready for an adult conversation."
+
+Then stop talking until they shift. Don't perform sincerity for someone committed to mocking it.
+
+*See also: Tactic 7 (Chapter 3)*
+
+---
+
+## Card 32: Financial Superiority
+
+**The Pattern:** Using money as control and leverage
+
+**What They Say/Do:**
+- Constantly referencing how much they paid for things
+- "I provide for this family"
+- "You wouldn't have this without me"
+- Reminding you of what they've bought you
+- Controlling access to money or financial information
+- "Good luck affording your lifestyle without me"
+
+**What's Really Happening:**
+
+Money becomes a substitute for emotional maturity. Instead of developing real relational skills, they use financial leverage to maintain control. Economic dependence ensures you stay. Generosity becomes a ledger of debt.
+
+**How It Hooks You:**
+
+You feel indebted. You think you can't leave because you can't afford to. You minimize bad behavior because at least they're "a good provider." You lose track of your own financial capacity.
+
+**Your Power Move:**
+
+Develop financial independence or literacy, even in small ways. Know what's in the accounts. Have money that is yours. Build skills and income sources.
+
+Remember: Financial contribution never entitles someone to mistreat you. Providing money doesn't purchase the right to control.
+
+*See also: Tactic 8 (Chapter 3)*
+
+---
+
+## Card 33: Projection
+
+**The Pattern:** Accusing you of what they're doing
+
+**What They Say/Do:**
+- "You're so selfish" (they're selfish)
+- "You're not listening" (they never listen)
+- "You're cheating on me" (they're cheating)
+- "You're always lying" (they lie constantly)
+- "You're so controlling" (they control everything)
+
+**What's Really Happening:**
+
+They can't tolerate their own shadow. Rather than face their flaws, they project them onto you. Now they can attack those flaws from the outside rather than dealing with them internally. It's confession disguised as accusation.
+
+**How It Hooks You:**
+
+You spend all your energy defending against accusations that aren't even true. You introspect obsessively about whether you're really selfish/dishonest/lazy, while they continue being exactly that. You're so busy defending that you don't notice their behavior.
+
+**Your Power Move:**
+
+When an accusation comes out of nowhere, ask yourself: "Is this actually true of me, or is this true of them?"
+
+Often, projection is a confession. What they accuse you of is what they're doing or feeling. Don't defend—observe.
+
+*See also: Tactic 15 (Chapter 3)*
+
+---
+
+## Card 34: Minimization
+
+**The Pattern:** Shrinking the impact of their behavior
+
+**What They Say/Do:**
+- "It's not that big a deal"
+- "You're overreacting"
+- "It's a 15-minute fix"
+- "I didn't hit you, so what's the problem?"
+- "Other people have it worse"
+- "Why do you always blow things out of proportion?"
+
+**What's Really Happening:**
+
+Your pain is being sized down to make it manageable for them. They don't want to deal with the real impact of their behavior, so they shrink it until it's dismissible. Your experience is being edited to fit their comfort level.
+
+**How It Hooks You:**
+
+You start doubting whether your feelings are proportionate. You minimize your own experiences. You stop bringing things up because "it's probably not that big a deal." You lose trust in your own emotional responses.
+
+**Your Power Move:**
+
+"It's a big deal to me."
+
+Your experience doesn't need to be validated by their scale. Your pain is valid regardless of how they measure it. Stop outsourcing your emotional reality to someone invested in shrinking it.
+
+*See also: Tactic 16 (Chapter 3)*
+
+---
+
+## Card 35: Authority Hijack
+
+**The Pattern:** Interpreting your inner world for you
+
+**What They Say/Do:**
+- "What you're really feeling is..."
+- "That's not what you meant"
+- "Your intuition is telling you [their interpretation]"
+- "I know you better than you know yourself"
+- Telling you what your dreams mean
+- Correcting your emotions
+
+**What's Really Happening:**
+
+Your inner authority is being colonized. By becoming the interpreter of your inner world, they insert themselves between you and your own truth. They become the expert on you, which means your self-knowledge must pass through them.
+
+**How It Hooks You:**
+
+You start deferring to their interpretation of your experience. You trust their reading of you more than your reading of you. Your spiritual and emotional life passes through them. You forget how to know yourself directly.
+
+**Your Power Move:**
+
+"I appreciate your perspective, but I'm the authority on my own experience."
+
+No one gets to tell you what you feel. Your inner world is sovereign territory. Their interpretations are projections, not truth.
+
+*See also: Tactic 26 (Chapter 3)*
+
+---
+
+## Card 36: Control Through Fatigue
+
+**The Pattern:** Exhausting you into compliance
+
+**What They Say/Do:**
+- Late-night arguments that go for hours
+- Constant contact that leaves no room for rest
+- Emotional intensity that depletes your reserves
+- "We have to resolve this NOW"
+- Always something requiring your immediate attention
+- Won't let you sleep until it's "settled"
+
+**What's Really Happening:**
+
+Exhaustion is a control tool. When you're depleted, you're more compliant. You don't have energy to fight, to think critically, or to leave. They may not consciously plan this, but they benefit from it. Tired people don't resist.
+
+**How It Hooks You:**
+
+You're too tired to trust your own judgment. You agree to things you wouldn't normally accept. You can't imagine having the energy to leave. You just want the argument to end—so you capitulate.
+
+**Your Power Move:**
+
+Protect your rest fiercely. Arguments that "have to happen tonight" almost never do.
+
+"I'm not discussing this when I'm exhausted. We'll talk tomorrow."
+
+Then actually go to sleep. Your rested self makes better decisions than your depleted self.
+
+*See also: Tactic 27 (Chapter 3)*
+
+---
+
+## Card 37: Suicide Threats
+
+**The Pattern:** Threatening self-harm to control you
+
+**What They Say/Do:**
+- "If you leave, I'll kill myself"
+- "I can't live without you"
+- "I'll jump off this balcony right now"
+- "You're the only reason I'm still alive"
+- References to methods or dramatic gestures
+- "My blood will be on your hands"
+
+**What's Really Happening:**
+
+They're taking you emotionally hostage. By making you responsible for their life, they trap you in the relationship through fear and guilt. The threat weaponizes your empathy. Whether or not they mean it, the effect is the same: you're paralyzed.
+
+**How It Hooks You:**
+
+You're terrified something will happen and it will be your fault. You stay to keep them alive. You abandon your own needs because "at least they'll be safe." You become their suicide prevention plan instead of their partner.
+
+**Your Power Move:**
+
+**You are not responsible for another adult's choice to live or die.**
+
+If they threaten suicide:
+1. Call 911 or a crisis line immediately
+2. Contact their family or friends
+3. Do not try to manage this yourself
+4. Then still leave if you need to leave
+
+**National Suicide Prevention Lifeline: 988**
+**Crisis Text Line: Text HOME to 741741**
+
+If they were genuinely suicidal, they need professional help you cannot provide. If they're using the threat to control you, they need you to stop rewarding the manipulation.
+
+*See also: Tactic 29 (Chapter 3)*
+
+> *"Making you responsible for their life is the ultimate control. You cannot save someone by sacrificing yourself."*
+
+---
+
+## Card 38: Withholding Belongings
+
+**The Pattern:** Keeping your possessions hostage
+
+**What They Say/Do:**
+- Won't return your things after separation
+- Making excuses and delays
+- "I'll give it back when you [condition]"
+- Creating complications around retrieval
+- Your belongings become an ongoing negotiation
+- "Come get them yourself" (creating forced contact)
+
+**What's Really Happening:**
+
+Your possessions have become leverage. As long as they have something of yours, they have a reason to stay in contact, a way to keep you engaged, a power play that extends the relationship beyond its end. The "stuff" is an excuse for continued control.
+
+**How It Hooks You:**
+
+You need your things. You keep reaching out. Each interaction gives them another opportunity to manipulate, test, or re-engage you. You can't fully close the chapter while your belongings are still there.
+
+**Your Power Move:**
+
+Decide what's worth the engagement:
+- For valuable items: Use a third party (friend, courier, mediator) to retrieve them
+- For lower-value items: Consider whether peace of letting go outweighs the object's worth
+
+Don't let possessions become chains. Your freedom is worth more than your stuff.
+
+*See also: Tactic 34 (Chapter 3)*
+
+---
+
 ## The Decoder Card Emergency Protocol
 
 When activated and confused, use this sequence:


### PR DESCRIPTION
Added decoder cards for:
- Card 26: Interruption as Dominance
- Card 27: "We Need to Talk" Urgency
- Card 28: Physical Intimidation
- Card 29: Chaos as Camouflage
- Card 30: Shame Inversion
- Card 31: Mockery Voice
- Card 32: Financial Superiority
- Card 33: Projection
- Card 34: Minimization
- Card 35: Authority Hijack
- Card 36: Control Through Fatigue
- Card 37: Suicide Threats
- Card 38: Withholding Belongings

All cards now match the 38 tactics in Chapter 3: The Narcissist Playbook. Each card includes cross-references to corresponding tactics.