### PR TITLE
📚 Expand and deepen Volume 4 chapters 13-14 and all appendices

### DIFF
--- a/book/vol-4-embodied-leadership/appendices/appendix-a-field-hygiene-menu.md
+++ b/book/vol-4-embodied-leadership/appendices/appendix-a-field-hygiene-menu.md
@@ -2,7 +2,7 @@
 
 ## Choose-Your-Own Practices
 
-Use this menu to select practices based on your state, time, and context.
+Use this menu to select practices based on your state, time, and context. Not every practice is needed every day. The menu is here so you can choose what serves you now.
 
 ---
 
@@ -19,6 +19,11 @@ Use this menu to select practices based on your state, time, and context.
 | Persistently drained | Cord Check (10 min) |
 | Need weekly reset | Weekly Hygiene Practice (20-60 min) |
 | Need monthly reset | Full Hygiene Reset (2+ hours) |
+| Flooding and can't think | Emergency Grounding (30 sec) |
+| About to have difficult conversation | Pre-Conversation Protocol (2 min) |
+| Just left a difficult person | Contact Recovery (5 min) |
+| Can't sleep, mind spinning | Evening Release Ritual (10 min) |
+| Woke up already anxious | Morning Anchor (3 min) |
 
 ---
 
@@ -26,108 +31,318 @@ Use this menu to select practices based on your state, time, and context.
 
 ### 60-Second Field Scan
 
-**When:** Start of day, before entering charged spaces
+**When:** Start of day, before entering charged spaces, whenever you feel "off"
+
+**Purpose:** To return awareness to yourself, notice what you're carrying, establish baseline
 
 **How:**
-1. Stand or sit. Close eyes.
-2. Imagine your field as a bubble around you.
-3. Scan: Front, back, left, right, above, below.
-4. Notice without changing: Where is it clear? Cluttered? Defended?
-5. Three breaths. Return to room.
+1. Stand or sit. Close eyes if possible.
+2. Imagine your field as a bubble around you—extending about arm's length in all directions.
+3. Scan systematically: Front. Back. Left. Right. Above. Below.
+4. Notice without changing: Where is it clear? Cluttered? Defended? Open? Contracted?
+5. Three slow breaths. Notice any shifts.
+6. Return to the room.
+
+**What you might notice:**
+- Heaviness in certain areas (often where you absorb from others)
+- Openness in front, defended in back (common pattern)
+- Sense of leaking or diffusing outward
+- Tight spots that correspond to body tension
+
+**The practice is noticing, not fixing.** Just seeing clearly is already shifting something.
 
 ---
 
 ### Pre-Day Seal
 
-**When:** Each morning before engaging with the world
+**When:** Each morning before engaging with the world—before phone, email, or interaction
+
+**Purpose:** To establish your field as yours before you encounter others' energy
 
 **How:**
-1. Stand or sit. Three deep breaths.
-2. Feel your field—the space around your body.
-3. Say internally: *"Today I move through the world in my own field. I can perceive without absorbing. What I encounter stays with me only by my choice."*
-4. Visualize your field becoming clear, coherent.
-5. Begin your day.
+1. Stand or sit. Three deep breaths—in through nose, out through mouth.
+2. Feel your field—the space around your body. It exists whether you sense it or not.
+3. Say internally (or aloud if alone): *"Today I move through the world in my own field. I can perceive without absorbing. What I encounter stays with me only by my choice."*
+4. Visualize your field becoming clear, coherent, gently bounded—not a wall, but a membrane.
+5. Feel the difference between open (permeable) and porous (leaking).
+6. Begin your day.
+
+**Variation for challenging days:**
+Add: *"Today I may encounter [name person/situation]. I can be present without being absorbed. Their state is theirs. Mine is mine."*
 
 ---
 
 ### Return to Sender
 
-**When:** After absorbing energy that isn't yours
+**When:** After absorbing energy that isn't yours—you feel heavier after contact, carrying someone's mood, drained without reason
+
+**Purpose:** To release what isn't yours without hostility or drama
 
 **How:**
-1. Notice you're carrying something foreign.
-2. Hand on chest. Say internally: *"This is not mine. I release it with compassion. Return to sender."*
-3. Imagine the energy lifting from your field—without hostility.
-4. Fill the space with your own breath.
+1. Notice you're carrying something foreign. Name it: "I'm carrying something that isn't mine."
+2. Hand on chest (or belly, whichever feels more grounding).
+3. Say internally: *"This is not mine. I release it with compassion. Return to sender."*
+4. Imagine the energy lifting from your field—not with force, but like steam rising. No hostility, no rejection—just release.
+5. Fill the space with your own breath. Imagine your own energy returning to the vacated space.
+6. Check: Is there more? Repeat if needed.
+
+**Important distinctions:**
+- This is not about rejecting the person—just the energy that lodged in you
+- Compassion is key. "Return to sender" isn't a curse—it's a release
+- Their energy isn't bad—it's just not yours to carry
+
+**For specific situations:**
+- After a difficult conversation: "I release what was transferred. What happened stays with them."
+- After absorbing a group mood: "I release the collective heaviness. It is not mine."
+- After time with a draining person: "I return what was deposited. My field is my own."
 
 ---
 
 ### 90-Second Vagal Reset
 
-**When:** Activated and need to regulate quickly
+**When:** Activated and need to regulate quickly—before meetings, after conflict, when you notice fight/flight/freeze
+
+**Purpose:** To shift from sympathetic (activated) to ventral vagal (safe/social) state
 
 **How:**
-1. Stop whatever you're doing.
-2. Orient: Slowly look around the room without urgency.
-3. Breathe: Inhale 4 counts, exhale 6-8 counts. Repeat 4-5 times.
-4. Ground: Feel feet on floor, weight of body.
-5. Check: Has your state shifted?
+1. Stop whatever you're doing. This takes 90 seconds. You have 90 seconds.
+2. **Orient:** Slowly look around the room without urgency. Let your eyes land on objects. No rush. The slow gaze signals safety to the nervous system.
+3. **Breathe:** Inhale 4 counts, exhale 6-8 counts. Repeat 4-5 times. Longer exhales activate the parasympathetic nervous system.
+4. **Ground:** Feel feet on floor, weight of body in chair, hands on thighs. Name what you're touching (silently or aloud).
+5. **Check:** Has your state shifted? Usually, even small shift is noticeable.
+
+**Physiological explanation:**
+- The slow orientation tells your brainstem "no predator present"
+- Extended exhale stimulates the vagus nerve, slowing heart rate
+- Physical grounding brings attention to body, out of spinning thoughts
+
+**If 90 seconds isn't enough:**
+- Repeat the cycle
+- Add cold water on wrists or face (cold activates dive reflex, slows heart)
+- Add humming or singing (vibrates vagus nerve)
 
 ---
 
 ### Post-Day Clearing
 
-**When:** Each evening before rest
+**When:** Each evening before rest—at least 15 minutes before bed
+
+**Purpose:** To discharge what you absorbed, clear before sleep, wake cleaner
 
 **How:**
 1. Sit or lie down. Close eyes.
-2. Scan body and field for heaviness or unfamiliarity.
-3. Ask: "What am I carrying that isn't mine?"
-4. With each exhale, release what isn't yours.
-5. When clearer, hand on chest: *"What remains is mine. I rest in myself."*
-6. Sleep.
+2. Scan body and field for heaviness, tension, or unfamiliarity. Where did the day land?
+3. Ask: "What am I carrying that isn't mine?" Wait for the body to answer. Don't think—feel.
+4. With each exhale, release what isn't yours. Imagine it leaving through your skin, returning to the earth.
+5. Continue until lighter. May take 5-10 breaths, may take 20.
+6. When clearer, hand on chest: *"What remains is mine. I rest in myself."*
+7. If anything needs processing (yours, not absorbed), acknowledge it: "I see you. I'll attend to you. Not tonight."
+8. Sleep.
+
+**Common issues:**
+- **Can't release:** Sometimes you need to process before releasing. Journal briefly before this practice.
+- **Fall asleep during:** That's okay. Your system needed rest more than clearing.
+- **Feel more activated:** You may have stirred up something that needs attention. Ground first, then journal.
 
 ---
 
-## Weekly Practices (20-60 Minutes)
+### Morning Anchor
+
+**When:** When you wake already anxious, spinning, or activated
+
+**Purpose:** To establish ground before the day starts
+
+**How:**
+1. Before getting up, place both hands on your belly.
+2. Feel the weight of your hands. Feel your breath moving under them.
+3. Say internally: *"I am here. In this body. In this moment. The day hasn't started yet. Right now, I am safe."*
+4. Take 5 slow breaths, feeling belly rise and fall.
+5. Before rising, set one intention for the day—keep it simple: "Today I stay grounded." "Today I notice my body." "Today I don't absorb."
+6. Rise slowly.
+
+---
+
+## Extended Practices (5-15 Minutes)
+
+### Pre-Conversation Protocol
+
+**When:** Before a difficult conversation, meeting with a challenging person, or entering a charged situation
+
+**Purpose:** To establish your field before contact so you don't absorb or collapse
+
+**How:**
+1. **Clear:** Spend 60 seconds releasing any residual activation from before. Don't enter already loaded.
+2. **Scan:** Where is your body right now? Where is tension? Breathe into it.
+3. **Intention:** "I enter this conversation in my own field. I can be present without absorbing. I can speak truth without requiring agreement."
+4. **Boundary:** Visualize your field boundary—not a wall, but a semi-permeable membrane. You can see and feel what's happening without it entering you.
+5. **Ground:** Feel feet, feel seat, feel breath. Establish contact with present moment.
+6. **Enter.**
+
+**During the conversation:**
+- Check periodically: "Am I still in my own field?"
+- If you notice absorption: silent "return to sender"
+- If you notice activation: longer exhale, feel feet
+- If you need to pause: "Give me a moment to think about that"
+
+---
+
+### Contact Recovery
+
+**When:** Just left a difficult person, draining meeting, or challenging family gathering
+
+**Purpose:** To clear what you absorbed before it settles
+
+**How:**
+1. Find a private space (bathroom works fine).
+2. **Shake:** Literally shake your body for 30 seconds. Arms, legs, shoulders. Animals do this after threat—it discharges activation.
+3. **Breathe:** 5 long exhales, releasing everything with the breath.
+4. **Clear:** "I release everything that is not mine. I return to my own field."
+5. **Separate:** "What happened there is theirs. I don't need to carry it."
+6. **Ground:** Feel feet. Look around slowly. Orient to present space.
+7. **Check:** What's still mine? If something of yours needs attention, note it. Attend later.
+
+**If you can't shake (public space):**
+- Clench and release fists under table
+- Press feet firmly into floor, release
+- Long exhales with sighing sound (quietly)
+
+---
 
 ### Cord Check Protocol
 
-**When:** Weekly, or when feeling energetically drained
+**When:** Weekly, or when feeling energetically drained without clear cause, or when you can't stop thinking about someone
+
+**Purpose:** To identify and release unhealthy energetic attachments
 
 **How:**
 1. Sit quietly. Close eyes.
 2. Scan for where attention is going:
    - Who are you thinking about without choosing to?
    - Who pulls at your energy when they're not present?
+   - Who do you feel even when they're not in the room?
 3. For each cord, ask:
    - Is this nourishing or draining?
    - Is this appropriate to the relationship?
-4. For draining cords, use release practice:
-   - *"I release this attachment to its right size. I am connected but not entangled."*
-5. Breathe. Feel the space.
+   - Am I attached, or am I entangled?
+4. For draining or inappropriate cords, use release practice:
+   - *"I release this attachment to its right size. I am connected but not entangled. I have my energy. They have theirs."*
+   - Visualize the cord softening, finding its appropriate length—not cut, but right-sized
+5. Breathe. Feel the space that returns.
+
+**Important:**
+- Not all cords are bad. Healthy connection creates healthy cords.
+- You're not cutting connection—you're right-sizing it
+- Some cords reform quickly. This is maintenance, not one-time fix.
+
+**Specific cord releases:**
+
+For family: *"I release the role I was assigned. I am connected by love, not by obligation. I return to my own ground."*
+
+For ex-partners: *"What we shared stays between us. I release what I'm carrying for you. We go forward in our own lives."*
+
+For those who drain: *"I release the pattern of over-giving. My energy is mine. Yours is yours."*
 
 ---
 
 ### Digital Audit
 
-**When:** Weekly
+**When:** Weekly—set a specific day
+
+**Purpose:** To clean your digital environment the way you clean physical space
 
 **How:**
-1. Review: What did I consume digitally this week?
-2. Notice: What groups/accounts consistently leave me feeling worse?
-3. Clean: Mute, unfollow, or leave as needed.
-4. Boundary: Set one digital boundary for next week.
+1. **Review:** What did I consume digitally this week? Social media, news, YouTube, podcasts, emails.
+2. **Notice:** What groups/accounts/follows consistently leave me feeling worse? What's the emotional residue of my digital intake?
+3. **Clean:** Mute, unfollow, unsubscribe, leave as needed. Be ruthless.
+4. **Boundary:** Set one digital boundary for next week:
+   - No phone first 30 minutes of day
+   - One specific platform only during specific hours
+   - Notification restrictions
+   - Night mode at specific time
+5. **Replace:** What would be nourishing? What replaces the draining input?
+
+**Digital hygiene questions:**
+- Does this account/group nourish or drain me?
+- Does this information serve my life or just activate my nervous system?
+- Am I consuming or being consumed?
+- Is this connection or compulsion?
 
 ---
 
+### Evening Release Ritual
+
+**When:** When you can't sleep and your mind is spinning, processing, or rehearsing
+
+**Purpose:** To discharge the day so sleep is possible
+
+**How:**
+1. Sit on edge of bed or in chair.
+2. **Body scan:** Move attention slowly from head to feet. Notice where the day lodged.
+3. **Name and release:** "I release the conversation with [name]." "I release the task I couldn't finish." "I release the worry about tomorrow."
+4. **Physical release:** Shake hands and arms. Roll shoulders. Let tension exit.
+5. **Transfer:** If thoughts need capturing, write them on paper. "I give this to the paper. It holds it until morning."
+6. **Boundary:** *"The day is complete. What remains waits until tomorrow. Tonight, I rest."*
+7. **Ground in bed:** Feel weight of body on mattress. Feel covers. Feel breath. This is all that's real right now.
+
+---
+
+## Weekly Practices (20-60 Minutes)
+
 ### Weekly Hygiene Practice (Choose One)
 
-- Extended meditation or body scan (20-30 min)
-- Epsom salt bath with clearing intention (30 min)
-- Nature immersion (30-60 min)
-- Movement practice: yoga, dance, long walk (30-60 min)
-- Extended breathwork session (20 min)
+The specific practice matters less than the consistency. Pick what works for you:
+
+**Extended meditation or body scan (20-30 min)**
+- Sit or lie down
+- Move attention through entire body slowly
+- Release each area with exhale
+- End with full-field awareness
+
+**Epsom salt bath with clearing intention (30 min)**
+- Add 2 cups Epsom salts to hot bath
+- Set intention: "This water draws out what isn't mine"
+- Soak in silence (no phone, no reading)
+- Imagine heaviness leaving through skin into water
+- Let water drain while still in tub (optional ritual: watch it leave)
+
+**Nature immersion (30-60 min)**
+- Leave phone behind or fully off
+- Walk without destination or podcast
+- Let attention move to natural elements: trees, sky, ground
+- Physically touch natural elements (tree bark, stone, water)
+- Allow field to expand into natural space
+
+**Movement practice (30-60 min)**
+- Yoga, dance, long walk, swimming
+- Focus on embodiment, not performance
+- Notice where energy moves, where it sticks
+- Finish with stillness to integrate
+
+**Extended breathwork session (20 min)**
+- Seated or lying
+- Choose pattern: box breathing, 4-7-8, or circular breathing
+- If emotions arise, let them move
+- End with 5 minutes of natural breath
+
+---
+
+### Weekly Review Practice
+
+Once weekly, answer these questions in writing:
+
+1. **Field quality:** How clean was my field this week? What did I absorb? What lingered?
+
+2. **Pattern check:** Did old identity patterns activate? When? What triggered them?
+
+3. **Boundary inventory:** Which boundaries held? Which softened? What needs reinforcement?
+
+4. **Energy audit:** Where did I spend energy wisely? Where did I leak or over-give?
+
+5. **Regulation score:** How often was I regulated vs. activated vs. collapsed?
+
+6. **Relationship review:** Which relationships nourished? Which depleted?
+
+7. **Next week:** What does next week need from me? What practice to emphasize?
 
 ---
 
@@ -135,24 +350,44 @@ Use this menu to select practices based on your state, time, and context.
 
 ### Full Hygiene Reset
 
+**Schedule this in advance. Treat it as non-negotiable maintenance.**
+
 **Elements to include:**
 
-1. **Physical space clearing:** Clean and reset your environment
-2. **Digital reset:** Major audit, unsubscribe, reorganize
-3. **Cord inventory:** Full review of all significant relationships
-4. **Longer practice:** Extended meditation, retreat, or nature time
-5. **Review:** What patterns ran this month? What needs attention?
+1. **Physical space clearing:** Clean and reset your environment. Clutter in space = clutter in field. Pay special attention to bedroom and workspace.
+
+2. **Digital reset:** Major audit. Unsubscribe from email lists. Leave dormant group chats. Unfollow accounts that drain. Organize files. Clear downloads folder.
+
+3. **Cord inventory:** Full review of all significant relationships. Use cord check protocol for each. Right-size attachments.
+
+4. **Longer practice:** Extended meditation (45+ min), retreat day, or extended nature time. Go deeper than weekly practice allows.
+
+5. **Pattern review:** What patterns ran this month? What needs attention? What's shifting?
+
+6. **Body care:** Massage, acupuncture, float tank, sauna—physical reset complements energetic reset.
+
+7. **Intention setting:** What does next month need? What am I practicing?
 
 ---
 
 ### Monthly Relationship Audit
 
-For each significant relationship:
-1. Do I feel more me around this person, or less?
-2. Is the energy mutual, or draining?
-3. Are my boundaries respected?
-4. Can we hold difference?
-5. Decision: Continue, adjust, reduce, or end?
+**For each significant relationship:**
+
+| Question | Answer |
+|----------|--------|
+| Do I feel more me around them, or less? | |
+| Is the energy mutual, or draining? | |
+| Are my boundaries respected? | |
+| Can we hold difference? | |
+| Is this relationship requiring self-abandonment? | |
+| **Decision:** Continue / Adjust / Reduce / End | |
+
+**After completing:**
+- What adjustments need to be made?
+- What conversations need to happen?
+- What boundaries need reinforcement?
+- What distance needs to increase?
 
 ---
 
@@ -160,26 +395,52 @@ For each significant relationship:
 
 ### When Flooding
 
-1. Name it: "I'm flooding."
-2. Ground: Feet on floor. Hand on surface.
-3. Breathe: Long exhales.
-4. Orient: Look around slowly.
-5. Delay: Don't act from flood.
+You're overwhelmed, can't think clearly, emotions are taking over.
+
+1. **Name it:** "I'm flooding." Naming creates tiny distance.
+2. **Ground immediately:** Feet hard on floor. Hand on surface. Name 5 things you can see.
+3. **Breathe:** Long exhales. 4 counts in, 8 counts out.
+4. **Orient:** Look around slowly. Let eyes land on different objects. There is no predator here.
+5. **Delay:** Don't act from flood. "I'll decide when I'm regulated."
+
+**The key:** Don't try to process while flooded. Regulate first. Think later.
+
+---
 
 ### When Absorbing
 
-1. Notice: "This isn't mine."
-2. Breathe: Create space in the body.
-3. Release: "Return to sender."
-4. Return: To your own body.
+You've taken on someone else's energy—their mood, anxiety, or pain is now in you.
+
+1. **Notice:** "This isn't mine." The noticing is crucial.
+2. **Separate:** "I can feel this without becoming it."
+3. **Breathe:** Create space in the body with breath.
+4. **Release:** "Return to sender" with each exhale.
+5. **Return:** Come back to your own body. Your own sensations. Your own ground.
+
+---
 
 ### When Activated Before Speaking
 
-1. Pause: Don't respond yet.
-2. Ground: Feet, breath.
-3. Check: What state am I in?
-4. Regulate: 3-5 slow breaths.
-5. Speak: From regulation, not activation.
+You're about to respond from activation, not from ground.
+
+1. **Pause:** Don't respond yet. One breath.
+2. **Ground:** Feet. Seat. Breath.
+3. **Check:** What state am I in? Is this activation or clarity?
+4. **Regulate:** 3-5 slow breaths. Longer exhale.
+5. **Ask:** What do I actually want to say? What serves?
+6. **Speak:** From regulation, not activation. Slower than feels natural.
+
+---
+
+### 30-Second Emergency Ground
+
+When you have almost no time and need to shift state immediately.
+
+1. Press feet hard into floor. Feel the ground.
+2. One long exhale with audible sigh.
+3. Name where you are: "I am in [location]."
+4. Place hand on chest. Feel heartbeat.
+5. Say internally: "I am here. Right now. That's all."
 
 ---
 
@@ -190,17 +451,25 @@ Combine practices for deeper effect:
 **Morning Stack (5 min):**
 - 60-Second Field Scan
 - Pre-Day Seal
-- State check
+- State check + intention
 
 **Evening Stack (10 min):**
 - Post-Day Clearing
 - Cord check (brief)
 - Gratitude for one sovereign moment
+- Evening release if needed
 
 **Weekly Stack (1 hour):**
-- Cord check protocol
+- Cord check protocol (full)
 - Digital audit
-- One extended practice
+- One extended practice (your choice)
+- Weekly review questions
+
+**Monthly Stack (half day):**
+- Full hygiene reset (all elements)
+- Relationship audit
+- Longer practice or mini-retreat
+- Intention setting for month ahead
 
 ---
 
@@ -208,15 +477,52 @@ Combine practices for deeper effect:
 
 Not every day needs every practice. Build your own routine:
 
-**Minimum daily:** Pre-day seal + post-day clearing (6 min total)
+**Minimum daily (6 min):**
+Pre-day seal (1 min) + post-day clearing (5 min)
 
-**Standard daily:** Add field scan + one reset as needed (10 min total)
+**Standard daily (15 min):**
+Add morning anchor (3 min) + field scan (1 min) + one reset as needed (5 min)
 
-**Full daily:** All practices as needed (15-20 min total)
+**Full daily (25 min):**
+All practices as needed, including pre-conversation protocols
 
-**Weekly:** Add cord check + hygiene practice (30-60 min)
+**Weekly (1-2 hours):**
+Cord check + digital audit + extended practice + review
 
-**Monthly:** Add full reset + relationship audit (2-4 hours)
+**Monthly (4+ hours):**
+Full reset + relationship audit + longer retreat/practice
+
+---
+
+## Building the Habit
+
+Start with minimum. Build from there.
+
+**Week 1-2:** Pre-day seal + post-day clearing only. Get these solid.
+
+**Week 3-4:** Add morning anchor or field scan. Choose based on your pattern.
+
+**Month 2:** Add weekly practice. One extended practice per week.
+
+**Month 3:** Add monthly reset. Schedule it in advance.
+
+**Ongoing:** Adjust based on what you need. The menu is here to serve you.
+
+---
+
+## Signs You Need More Hygiene
+
+- Consistently exhausted without physical cause
+- Carrying others' moods even when you don't want to
+- Difficulty knowing what's yours vs. others'
+- Boundary fatigue (saying no takes heroic effort)
+- Persistent cord connections (can't stop thinking about someone)
+- Digital overwhelm increasing
+- Field feels cluttered, dense, or defended
+- Sleep disrupted without clear cause
+- Emotional reactivity increasing
+
+**When these appear:** Increase your hygiene practices. You need more maintenance, not less.
 
 ---
 

--- a/book/vol-4-embodied-leadership/appendices/appendix-b-consent-ladder.md
+++ b/book/vol-4-embodied-leadership/appendices/appendix-b-consent-ladder.md
@@ -6,57 +6,97 @@ A tool for tracking your internal signal moment to moment.
 
 ---
 
+## Why This Tool Exists
+
+For many of us, consent wasn't something we learned.
+
+We learned to override our signals. To say yes when we meant no. To go along. To accommodate. To freeze and call it agreement.
+
+This tool helps you reconnect to what your body is actually saying—not what you think you should feel, not what makes others comfortable, but what is actually true for you in this moment.
+
+**The consent ladder is not about permission.** It's about awareness. It's learning to read your own signals clearly, so you can make choices that honor what's true.
+
+---
+
 ## The Four States
 
 ### YES
 
 **Body signals:**
-- Chest open
-- Breath full and deepening
-- Energy rising
-- Body moving toward
-- Warmth spreading
-- Presence increasing
+- Chest open and expansive
+- Breath full and deepening naturally
+- Energy rising, leaning forward
+- Body moving toward the person or experience
+- Warmth spreading through body
+- Presence increasing—you feel more here, not less
+- Softening in jaw, shoulders, belly
+- Ease in the body, not tension disguised as excitement
 
 **Internal experience:**
-- Clear desire
-- Openness
-- Curiosity
+- Clear desire without pressure
+- Openness and curiosity
 - Wanting to move forward
+- Feeling of rightness
+- Presence, not escape
+- This feels like choice, not obligation
 
 **What it sounds like:**
 - "Yes"
 - "I want this"
 - "I'm in"
+- "This feels good"
+- "Keep going"
+
+**The quality of yes:**
+A real yes has spaciousness. It doesn't feel frantic, obligated, or pressured. It feels like opening, not bracing.
+
+If your "yes" feels tight, urgent, or like you're convincing yourself—check again. That might be something else.
 
 ---
 
 ### MAYBE
 
 **Body signals:**
-- Mixed signals
-- Breath uncertain
+- Mixed signals in the body
+- Breath uncertain or variable
 - Some openness, some holding back
-- Body ambivalent
-- Neither moving toward nor pulling away
+- Body ambivalent—neither toward nor away
+- Part of you interested, part hesitant
+- Tension and openness coexisting
+- A sense of "something's not quite landing"
 
 **Internal experience:**
-- Curiosity with hesitation
-- Need more information
+- Curiosity mixed with hesitation
+- Need for more information
 - Not sure yet
 - Part yes, part unsure
+- Wanting to slow down
+- Waiting for something to become clear
 
 **What it sounds like:**
 - "I need to think about it"
 - "Can you tell me more?"
 - "I'm not sure yet"
 - "Part of me wants to, part of me isn't sure"
+- "Give me a minute"
+- "I need to check in with myself"
+- "Let me sit with that"
 
-**What to do:**
-- Slow down
-- Ask for what you need (more information, time, space)
-- Don't override the ambivalence
-- Check back in with your body
+**What to do with maybe:**
+
+**Slow down.** Maybe is not a problem to solve—it's information to honor.
+
+**Ask for what you need:**
+- More information
+- More time
+- More space
+- Something to change
+
+**Don't override the ambivalence.** The body knows something. Give it time to speak.
+
+**Check back in with your body.** Put your hand on your chest or belly. Ask: "What is actually true right now?" Wait for the answer—don't manufacture one.
+
+**Important:** Maybe is not a soft no you're too scared to say. Maybe is genuinely uncertain. If it's actually a no, name it as a no.
 
 ---
 
@@ -64,29 +104,42 @@ A tool for tracking your internal signal moment to moment.
 
 **Body signals:**
 - Chest closing or tightening
-- Breath shallow or held
-- Body pulling away
-- Tension increasing
-- Energy dropping or bracing
-- Urge to leave
+- Breath shallow, held, or constricted
+- Body pulling away, leaning back
+- Tension increasing, particularly in shoulders, jaw, belly
+- Energy dropping or bracing for impact
+- Urge to leave, escape, or withdraw
+- Contraction rather than expansion
+- A sense of wrongness, even if you can't articulate why
 
 **Internal experience:**
 - Don't want this
 - Resistance
 - Discomfort
 - Wanting to stop
+- A sense of wrongness
+- Feeling pressured
+- Relief at the thought of ending this
 
 **What it sounds like:**
 - "No"
 - "I don't want to"
 - "I'm not available for that"
 - "Stop"
+- "That's not going to work for me"
+- "I need to end this"
 
-**What to do:**
-- Honor the signal
-- Speak the no (if safe)
-- Remove yourself if needed
-- Don't override
+**What to do with no:**
+
+**Honor the signal.** This is the practice. Your body said no. The work is trusting that.
+
+**Speak the no (if safe).** A no doesn't need explanation or justification. "No" is a complete sentence.
+
+**Remove yourself if needed.** You can leave. You can stop. You can end the conversation, the encounter, the situation.
+
+**Don't override.** The pattern of overriding no is what got you here. Break the pattern.
+
+**No explanation required.** You don't owe anyone an explanation for your no. "I don't want to" is enough.
 
 ---
 
@@ -94,26 +147,38 @@ A tool for tracking your internal signal moment to moment.
 
 **Body signals:**
 - Desire present but timing off
-- Body wants to wait
+- Body wants to wait, not to refuse
 - Interest without urgency
 - Preference for future, not now
+- Openness that hasn't fully arrived yet
+- A sense of "not yet" rather than "not ever"
 
 **Internal experience:**
 - "Yes, but not now"
 - "I want this eventually"
 - "The timing isn't right"
 - "Not ready yet"
+- "This would be good, but not today"
+- "I need something else first"
 
 **What it sounds like:**
 - "Can we wait?"
 - "I'm not ready for that yet"
 - "Maybe later"
 - "Not tonight"
+- "I'd like to, but not right now"
+- "Ask me again another time"
+- "I want to, just not yet"
 
-**What to do:**
-- Name the timing without dismissing the desire
-- Set a future time if appropriate
-- Trust the timing signal
+**What to do with later:**
+
+**Name the timing without dismissing the desire.** "I want this—and not right now" honors both truths.
+
+**Set a future time if appropriate.** If you can, specify when later might be.
+
+**Trust the timing signal.** Your body knows something about pacing that your mind might not.
+
+**Don't let later become avoidance.** Check: Is this genuinely "later," or am I afraid to say no?
 
 ---
 
@@ -123,15 +188,24 @@ A tool for tracking your internal signal moment to moment.
 
 At any moment, check: **Where am I on this ladder right now?**
 
-Your position can change. That's allowed.
+Your position can change. That's allowed. That's expected. That's healthy.
 
-**If you shift from Yes to Maybe:** Slow down. Check in.
+**If you shift from Yes to Maybe:** Slow down. Check in. Say: "I want to pause for a moment."
 
-**If you shift from Yes to No:** Stop. Name it.
+**If you shift from Yes to No:** Stop. Name it. "I need to stop." You don't need to explain.
 
-**If you shift from Maybe to Yes:** Proceed consciously.
+**If you shift from Maybe to Yes:** Proceed consciously. Make sure it's a real yes, not relief at making a decision.
 
-**If you shift from Maybe to No:** Honor it without guilt.
+**If you shift from Maybe to No:** Honor it without guilt. "I've checked in, and it's a no."
+
+**If you shift from Later to Yes:** Great. Make sure nothing else changed to make you override yourself.
+
+**If you shift from Later to No:** Also valid. Later doesn't mean eventually. It means not now—and sometimes not now becomes never.
+
+**Checking in with yourself:**
+- Hand on belly: "What does my body say?"
+- One breath: Let the answer emerge
+- Trust what comes, even if it's inconvenient
 
 ---
 
@@ -139,13 +213,16 @@ Your position can change. That's allowed.
 
 Use the ladder for any decision or request:
 
-- Plans
-- Commitments
-- Conversations
-- Topics
-- Depth of sharing
+- Plans: "Do I want to go to this event?"
+- Commitments: "Do I want to agree to this obligation?"
+- Conversations: "Do I want to have this conversation right now?"
+- Topics: "Do I want to discuss this subject?"
+- Depth of sharing: "Do I want to share this much?"
+- Requests: "Do I want to do what they're asking?"
 
-Always track: **Is this a yes, a maybe, a no, or a later?**
+**Always track: Is this a yes, a maybe, a no, or a later?**
+
+The ladder isn't just for sexuality. It's for every choice where your body has information.
 
 ---
 
@@ -153,12 +230,24 @@ Always track: **Is this a yes, a maybe, a no, or a later?**
 
 Apply the same framework:
 
-- Projects
-- Meetings
-- Collaborations
-- Requests for your time
+- Projects: "Do I want to take this on?"
+- Meetings: "Do I need to be at this meeting?"
+- Collaborations: "Do I want to work with this person?"
+- Requests for your time: "Do I want to give this time?"
+- Deadlines: "Is this timeline realistic for me?"
+- Promotions: "Do I actually want this role?"
 
-Your internal signal applies everywhere.
+**Your internal signal applies everywhere.** The body doesn't distinguish between contexts. It just knows what it knows.
+
+---
+
+### In Friendship
+
+- Invitations: "Do I actually want to attend?"
+- Requests for support: "Do I have capacity for this?"
+- Depth of sharing: "Is this the person I want to share this with?"
+- Time together: "Do I want to spend time with this person right now?"
+- Emotional labor: "Do I want to hold space for their processing?"
 
 ---
 
@@ -169,75 +258,229 @@ A complementary tool for quick reference:
 ### 🟢 GREEN (Go)
 
 - Clear yes
-- Body open
+- Body open and moving toward
 - Desire present
-- Proceed
+- **Action:** Proceed
 
 ### 🟡 YELLOW (Pause)
 
 - Mixed signals
-- Slow down
-- Check in
-- Get more information
+- Uncertainty or ambivalence
+- Something needs clarification
+- **Action:** Slow down. Check in. Get more information.
 
 ### 🔴 RED (Stop)
 
 - Clear no
-- Body closing
-- Stop immediately
-- No explanation needed
+- Body closing or pulling away
+- Discomfort, resistance, wrongness
+- **Action:** Stop immediately. No explanation needed.
 
 ---
 
-## Teaching the Ladder to Partners
+## Communicating With the Ladder
+
+### Teaching the Ladder to Partners
 
 You can share this framework:
 
-**Script:**
-"I use this internal check-in where I track whether something is a yes, maybe, no, or later. It helps me stay present. Can I share with you where I am?"
+**Introduction script:**
+"I use this internal check-in where I track whether something is a yes, maybe, no, or later. It helps me stay present and honest. Can I share with you where I am when we're together?"
 
 **During intimacy:**
-"I'm at a maybe right now. Let me check in."
+- "I'm at a maybe right now. Let me check in."
+- "That moved me from yes to later."
+- "Green light. Keep going."
+- "I'm noticing some yellow. Can we slow down?"
+- "That's a no for me right now."
+- "I'm back to yes."
 
-"That moved me from yes to later."
-
-"Green light. Keep going."
+**Why this helps:**
+- Creates shared language
+- Removes pressure to guess what the other person wants
+- Makes consent a conversation, not a one-time question
+- Normalizes checking in and changing
 
 ---
 
-## Troubleshooting
+### Asking a Partner
+
+You can also use the ladder to check in with others:
+
+- "Where are you on the ladder right now?"
+- "Is this still a green light for you?"
+- "I noticed you got quiet—are you at a maybe?"
+- "Would you check in with yourself and tell me where you are?"
+
+**Important:** Their answer is information, not an invitation to convince them otherwise. If they're at a maybe, slow down. If they're at a no, stop. If they're at a later, respect the timing.
+
+---
+
+## Reclaiming Your Signals
+
+For many readers of this book, the signals are muted, confused, or distorted.
 
 ### "I can't feel my signals"
 
-This is common, especially after trauma. Start by:
-- Noticing after the fact ("That was a no and I didn't feel it")
-- Practicing in low-stakes situations
-- Slowing everything down
+This is common, especially after trauma or years of overriding.
 
-The signals strengthen with practice.
+**Start by:**
+- Noticing after the fact: "That was a no and I didn't feel it until later"
+- Practicing in low-stakes situations: Start with food, clothes, social invitations—not high-stakes intimacy
+- Slowing everything down: Speed is the enemy of awareness
 
-### "My signals change too fast"
+**What helps:**
+- Hand on body when making decisions (belly, chest)
+- Taking three breaths before answering any request
+- Asking yourself: "What does my body say?" and waiting for an answer
+- Practicing saying no in safe contexts to rebuild the neural pathway
 
-That's okay. They're allowed to change. The practice is noticing the changes, not having stable signals.
-
-### "My signals conflict with my thoughts"
-
-Trust the body. The body often knows before the mind does. Let the body lead.
-
-### "I don't want to disappoint them"
-
-Your signal matters more than their expectation. A clear no is kinder than a resentful yes.
+**The signals strengthen with practice.** You learned to override them. You can learn to feel them again.
 
 ---
 
-## Summary
+### "My signals change too fast"
 
-| State | Body | Action |
-|-------|------|--------|
-| YES | Open, toward | Proceed |
-| MAYBE | Mixed, uncertain | Slow down, check in |
-| NO | Closed, away | Stop |
-| LATER | Interest, wrong timing | Wait |
+That's okay. They're allowed to change.
+
+The practice isn't having stable signals—it's noticing the changes.
+
+**What helps:**
+- Accepting that signals can shift moment to moment
+- Checking in frequently rather than assuming the first signal is the only one
+- Communicating changes as they happen: "I shifted. Can we pause?"
+
+---
+
+### "My signals conflict with my thoughts"
+
+**Trust the body.** The body often knows before the mind does.
+
+Your mind might think: "I should want this." "They'll be disappointed." "We've already started."
+
+Your body might say: "No."
+
+**Let the body lead.** The mind can rationalize anything. The body doesn't lie.
+
+---
+
+### "I don't want to disappoint them"
+
+Your signal matters more than their expectation.
+
+**A clear no is kinder than a resentful yes.** A reluctant yes damages connection more than a compassionate no.
+
+You're not responsible for their disappointment. You're responsible for your honesty.
+
+---
+
+### "I've said yes and now I want to say no"
+
+**You can change your mind.** At any point. For any reason.
+
+- "I know I said yes, but I need to change that."
+- "I've checked in with myself and I'm at a no now."
+- "I want to stop."
+
+**You don't owe continuity.** Consent is ongoing, not a one-time agreement.
+
+---
+
+### "I said no but they're pressuring me"
+
+**Your no is still no.** Pressure doesn't transform no into yes—it transforms consent into coercion.
+
+**Scripts for held boundaries:**
+- "I've given you my answer."
+- "I'm not going to change my mind on this."
+- "Please stop asking."
+- "I need you to respect my no."
+- "This conversation is over."
+
+**If pressure continues:** Leave if you can. This is not a partner who respects your signals.
+
+---
+
+## The Body's Wisdom
+
+### What the Body Knows
+
+Your body carries millions of years of survival intelligence.
+
+It knows threat before your mind does. It knows safety before your mind does. It knows desire before your mind does.
+
+When the body says no, it's protecting you. When the body says yes, it's opening to life. When the body says maybe, it's asking for more information. When the body says later, it's managing pacing.
+
+**The practice is listening.** Not overriding. Not rationalizing. Listening.
+
+---
+
+### The Speed of Signals
+
+Body signals are fast. Faster than thought.
+
+By the time you're thinking "I should want this," your body has already responded.
+
+**Pay attention to first reactions:**
+- The slight recoil
+- The micro-expansion
+- The held breath
+- The softening
+
+These are data. Trust them.
+
+---
+
+### When Signals Were Ignored
+
+If your signals were ignored early in life—by caregivers, partners, or by yourself—they may have quieted.
+
+This doesn't mean they're gone. It means they've been trained into silence.
+
+The work is retraining. Showing your body that its signals matter again. That you'll listen. That it's safe to speak.
+
+**This takes time.** Be patient. The body is learning to trust you again.
+
+---
+
+## Summary Table
+
+| State | Body Signal | Internal Experience | Action |
+|-------|-------------|---------------------|--------|
+| YES | Open, toward, expansive | Clear desire, wanting | Proceed |
+| MAYBE | Mixed, uncertain | Part yes, part unsure | Slow down, check in |
+| NO | Closed, away, contracted | Resistance, don't want | Stop |
+| LATER | Interest, wrong timing | Not yet, not now | Wait, revisit |
+
+---
+
+## Daily Practice
+
+Each day, practice using the ladder in low-stakes situations:
+
+**Morning:** What is my body's yes/no about the day ahead?
+
+**Meals:** Do I actually want to eat this? Is it a yes or a should?
+
+**Invitations:** Before responding, check: What does my body say?
+
+**Conversations:** Am I at a yes for this depth of sharing?
+
+**Evening:** Did I honor my signals today? Where did I override?
+
+The more you practice in small moments, the easier it becomes in high-stakes ones.
+
+---
+
+## The Core Truth
+
+**Your body speaks before your mind.** Your job is to listen.
+
+The consent ladder is not about giving permission—it's about receiving information.
+
+Your body knows what you want, what you don't want, what you need to think about, and what needs to wait.
+
+The practice is trusting what it tells you.
 
 ---
 

--- a/book/vol-4-embodied-leadership/appendices/appendix-c-scripts.md
+++ b/book/vol-4-embodied-leadership/appendices/appendix-c-scripts.md
@@ -4,49 +4,154 @@
 
 These scripts are templates. Adapt them to your voice and context.
 
+The goal is not to sound scripted—it's to have words ready when you need them. Practice saying these out loud until they feel natural.
+
+---
+
+## How to Use These Scripts
+
+1. **Read them out loud.** Notice which feel natural and which feel awkward.
+2. **Adapt to your voice.** Change words while keeping the structure.
+3. **Practice before you need them.** Rehearse in low-stakes moments so they're available in high-stakes ones.
+4. **Start simple.** Use the shortest version that works.
+5. **No explanation required.** These are complete sentences. You don't need to add justification.
+6. **Pause after speaking.** Let the script land. Don't fill the silence.
+
 ---
 
 ## Boundary Scripts
 
 ### General Nos
 
+**Simple nos:**
 - "I'm not available for that."
 - "That doesn't work for me."
 - "I'll pass on this one."
 - "No, thank you."
 - "I can't do that."
+- "No."
+
+**Firmer nos:**
+- "That's not something I'm willing to do."
+- "I won't be doing that."
+- "The answer is no."
+- "I've decided not to."
+- "This isn't negotiable for me."
+
+**Compassionate nos:**
+- "I care about you, and the answer is still no."
+- "I wish I could help, but I can't."
+- "I understand this is disappointing. My answer is still no."
+- "I know this isn't what you want to hear."
+
+---
 
 ### Family Boundaries
 
+**Setting the boundary:**
 - "I love you, and I can't do that."
 - "I know this is hard to hear. My answer is still no."
 - "I'm not able to engage in this conversation right now."
 - "I'll let you know when I'm available."
 - "I need to end this call now. I'll be in touch."
+- "I can love you and have limits at the same time."
+- "I'm not going to discuss that with you."
+- "This topic is off-limits for us."
+
+**Holding the boundary under pressure:**
+- "I understand you want me to change my mind. I'm not going to."
+- "We've been over this. My answer hasn't changed."
+- "I can see you're upset. My boundary is still in place."
+- "I'm going to need you to respect my decision."
+- "If this continues, I'll need to end the conversation."
+
+**After boundary violations:**
+- "That crossed a line for me."
+- "I told you I wasn't willing to discuss that."
+- "When you did [specific action], it violated my boundary."
+- "I'm going to take some space after that."
+- "We'll need to talk about what just happened."
+
+---
 
 ### Friend Boundaries
 
+**Declining invitations:**
 - "I'm going to sit this one out."
 - "I can't make it this time."
 - "I appreciate you thinking of me, but no."
-- "I'm not the right person for that."
+- "That's not for me, but I hope you have a great time."
+- "I'm not up for that right now."
+
+**Limiting contact:**
 - "I need some space right now."
+- "I'm going to be less available for a while."
+- "I can't be your go-to for this."
+- "I love you and I need some distance."
+- "I'm taking a step back from our regular contact."
+
+**Declining requests:**
+- "I'm not the right person for that."
+- "I don't have capacity for that right now."
+- "I can't be helpful with this."
+- "That's not something I can take on."
+
+---
 
 ### Work Boundaries
 
+**Declining projects:**
 - "I don't have capacity for this project."
 - "That timeline doesn't work for me."
 - "I need to decline this request."
 - "I'm focusing elsewhere right now."
-- "I'll need to get back to you on that."
+- "I'll need to say no to this one."
+
+**Protecting time:**
+- "I'm not available for meetings during that time."
+- "I'll need advance notice for requests like that."
+- "I can't respond to messages outside work hours."
+- "That's outside my role."
+- "I need to protect my focus time."
+
+**Pushing back on expectations:**
+- "I can do A or B, but not both by this deadline."
+- "For me to take this on, something else needs to come off my plate."
+- "I need to be realistic about what's possible."
+- "I'll need more time/resources to do this well."
+- "Let me get back to you after I assess my capacity."
+
+**Handling pushback:**
+- "I've thought about it. My answer is still no."
+- "I understand the urgency. I'm still not able to."
+- "I appreciate the opportunity. This isn't the right fit."
+- "My answer isn't going to change on this."
+
+---
 
 ### Partner Boundaries
 
+**In the moment:**
 - "I need space right now."
 - "I'm not ready for that conversation."
 - "I love you, and the answer is still no."
 - "Let's pause this and come back to it."
 - "I need to stop—I'm getting activated."
+- "I'm not available for this topic right now."
+
+**About patterns:**
+- "This isn't working for me anymore."
+- "I need something to change."
+- "I'm not willing to continue like this."
+- "We need to address this pattern."
+- "I won't accept that treatment."
+
+**Physical/intimate:**
+- "I want to slow down."
+- "I need to stop."
+- "Not tonight."
+- "I'm not in the space for that."
+- "My body isn't available for that right now."
 
 ---
 
@@ -54,25 +159,63 @@ These scripts are templates. Adapt them to your voice and context.
 
 ### When They Push
 
+**Holding firm:**
 - "I understand. The answer is still no."
 - "I've answered this question."
 - "I'm not going to keep answering this."
 - "My boundary hasn't changed."
 - "I hear you. I'm not changing my position."
+- "Asked and answered."
+
+**Naming the pushing:**
+- "I notice you're pushing against my boundary."
+- "I've said no several times now."
+- "It feels like you're trying to change my mind."
+- "My no isn't a starting point for negotiation."
+
+---
 
 ### When They Guilt
 
+**Staying steady:**
 - "I'm sorry you feel that way. My answer is still no."
 - "I understand you're disappointed."
 - "Your feelings are valid. My boundary is still in place."
 - "I can hold space for your reaction without changing my position."
+- "I can see this is hard for you. I'm still not available for that."
+
+**Naming the guilt:**
+- "I notice you're trying to make me feel guilty."
+- "Guilt isn't going to change my answer."
+- "I'm responsible for my choices, not for your feelings about them."
+
+---
 
 ### When They Rage
 
+**De-escalating:**
 - "I'm not willing to engage at this volume."
 - "I'm going to step away now."
 - "We can talk when things are calmer."
 - "I'm ending this conversation for now."
+- "I'll be available to talk when you're regulated."
+
+**Hard exits:**
+- "This is done for today."
+- "I'm leaving now."
+- "We're not going to continue this."
+- "I'll be in touch when I'm ready."
+
+---
+
+### When They Deny
+
+**Holding reality:**
+- "That's not how I experienced it."
+- "I trust my perception."
+- "We remember this differently. That doesn't change my boundary."
+- "I know what I felt/saw/heard."
+- "I'm not looking for you to agree. I'm telling you my boundary."
 
 ---
 
@@ -85,6 +228,11 @@ These scripts are templates. Adapt them to your voice and context.
 - "This feels good—I want to take our time."
 - "Let me catch up."
 - "I need a moment."
+- "Slower."
+- "Stay here with me."
+- "Not yet. This is good."
+
+---
 
 ### Changing Course
 
@@ -93,6 +241,10 @@ These scripts are templates. Adapt them to your voice and context.
 - "Let's do something different."
 - "My body wants something else."
 - "Can we try something else?"
+- "This isn't landing for me."
+- "I want to change what we're doing."
+
+---
 
 ### Stopping
 
@@ -101,14 +253,46 @@ These scripts are templates. Adapt them to your voice and context.
 - "I need space."
 - "I'm not available for more right now."
 - "Let's stop here."
+- "I want to stop."
+- "My body is saying no."
+- "I'm at a no."
 
-### Buying Time
+---
+
+### Buying Time / Later
 
 - "Can we wait?"
 - "I'm not ready for that yet."
 - "Maybe later—not tonight."
 - "I need to think about that."
 - "Not now. Maybe another time."
+- "I want to, just not yet."
+- "Ask me again another time."
+- "The timing isn't right for me."
+
+---
+
+### Redirecting
+
+- "What I actually want is..."
+- "I'd love it if we..."
+- "Can you [specific request]?"
+- "More of [this], less of [that]."
+- "What feels really good is..."
+- "I want to try..."
+- "Yes to this, no to that."
+
+---
+
+### Communicating During
+
+- "Green light. Keep going."
+- "I'm at a maybe. Let me check in."
+- "I shifted. Can we pause?"
+- "That's perfect."
+- "Not that. This."
+- "Stay with me here."
+- "I need connection, not intensity."
 
 ---
 
@@ -120,6 +304,11 @@ These scripts are templates. Adapt them to your voice and context.
 - "I was wrong about that. I'm sorry."
 - "I can see my part in this."
 - "I didn't show up the way I wanted to."
+- "I made a mistake. I see how that affected you."
+- "I own my part of what happened."
+- "Looking back, I wish I had [done differently]."
+
+---
 
 ### Expressing Without Attacking
 
@@ -127,6 +316,11 @@ These scripts are templates. Adapt them to your voice and context.
 - "I need to express something that's been on my mind."
 - "Can I share how I experienced that?"
 - "This is hard to say, and it's important."
+- "I want to tell you something that's been sitting with me."
+- "I'm not blaming you. I'm trying to share my experience."
+- "I felt [feeling] when [specific thing happened]."
+
+---
 
 ### Asking for What You Need
 
@@ -134,6 +328,11 @@ These scripts are templates. Adapt them to your voice and context.
 - "I need [specific thing] from you."
 - "Would you be willing to [specific request]?"
 - "Here's what would help..."
+- "What I'm looking for is [specific]."
+- "I'd like you to [specific behavior]."
+- "It would mean a lot if you could [specific thing]."
+
+---
 
 ### Holding Difference
 
@@ -141,6 +340,11 @@ These scripts are templates. Adapt them to your voice and context.
 - "We don't have to agree on this."
 - "Can we hold that we see this differently?"
 - "I can respect your view and still have mine."
+- "We're allowed to have different experiences of the same event."
+- "Your truth is yours. Mine is mine."
+- "I'm not trying to convince you. I'm sharing where I am."
+
+---
 
 ### Ending Without Collapsing
 
@@ -148,10 +352,24 @@ These scripts are templates. Adapt them to your voice and context.
 - "I'm getting flooded. Let's pause."
 - "I need a break before I can continue."
 - "Can we come back to this when I'm calmer?"
+- "I want to continue this, but not right now."
+- "I'm losing my grounding. I need to stop."
+- "Let's take a break and come back to this."
 
 ---
 
-## Group Redirect Scripts
+### Returning After Pause
+
+- "I'm ready to continue now."
+- "I've regulated. Can we talk?"
+- "I want to come back to what we were discussing."
+- "I've thought about what you said."
+- "Can we try that conversation again?"
+- "I want to repair what happened."
+
+---
+
+## Group & Leadership Scripts
 
 ### For Interruptions
 
@@ -159,6 +377,10 @@ These scripts are templates. Adapt them to your voice and context.
 - "Hold that—I'm not done yet."
 - "I'll come back to you."
 - "One moment—I want to complete this point."
+- "I'm going to finish my thought."
+- "Please let me finish."
+
+---
 
 ### For Derailment
 
@@ -166,6 +388,11 @@ These scripts are templates. Adapt them to your voice and context.
 - "Interesting—and the agenda says..."
 - "We're off track. Let's refocus."
 - "Can we come back to the main topic?"
+- "Let's park that for later."
+- "I want to stay on this thread."
+- "We'll circle back to that."
+
+---
 
 ### For Monopolizing
 
@@ -173,6 +400,11 @@ These scripts are templates. Adapt them to your voice and context.
 - "Thanks—let's rotate."
 - "What do others think?"
 - "Let's make sure everyone has a chance."
+- "I'm going to open this up to the group."
+- "Who else wants to weigh in?"
+- "Let's get some other perspectives."
+
+---
 
 ### For Escalation
 
@@ -180,24 +412,70 @@ These scripts are templates. Adapt them to your voice and context.
 - "I notice the temperature rising. Can we pause?"
 - "I'm not willing to engage at this volume."
 - "Let's take a breath before continuing."
+- "I want to continue this conversation at a different pace."
+- "We need to de-escalate before we continue."
+
+---
+
+### For Taking Leadership
+
+- "I'm going to step in here."
+- "Let me take the lead on this."
+- "Here's what I'm proposing."
+- "I'm going to make a call on this."
+- "I see it this way..."
+- "My read is..."
+- "I'm going to ask us to..."
+
+---
+
+### For Following
+
+- "I'm going to follow your lead here."
+- "What do you suggest?"
+- "I trust your judgment on this."
+- "I'm deferring to you."
+- "You're the expert on this."
+- "I'll support whatever you decide."
 
 ---
 
 ## Identity Release Scripts
 
-### The Release
+### The Release Statement
 
 - "I am no longer available for being the one who fixes everyone."
 - "I am no longer available for shrinking to make others comfortable."
 - "I am no longer available for performing my value."
 - "I am no longer available for carrying what isn't mine."
+- "I am no longer available for rescuing."
+- "I am no longer available for accommodation at my expense."
+- "I am no longer available for invisibility."
+- "I am no longer available for that version of me."
 
-### The Availability
+---
+
+### The Availability Statement
 
 - "I am available for relationships that don't require me to rescue."
 - "I am available for my own needs."
 - "I am available for being seen as I am."
 - "I am available for receiving without owing."
+- "I am available for taking up space."
+- "I am available for being ordinary."
+- "I am available for rest."
+- "I am available for desire without urgency."
+- "I am available for my own life."
+
+---
+
+### When the Old Identity Returns
+
+- "I see you, old pattern. You're not needed right now."
+- "That's the rescuer again. I'm not going there."
+- "Hello, good girl. I'm choosing differently now."
+- "I notice the performer trying to run. I'm staying present instead."
+- "The invisible one wants to shrink. I'm going to stay visible."
 
 ---
 
@@ -208,34 +486,166 @@ These scripts are templates. Adapt them to your voice and context.
 - "I can feel the room without becoming the room."
 - "I don't need protection. I need to remember to clean."
 - "My body knows. My job is to honor what it tells me."
+- "I can perceive without absorbing."
+- "My field is mine."
+- "What I absorb, I can release."
+- "Boundaries don't mean less love. They mean more me."
 
-### Sexuality
+---
+
+### Sexuality & Desire
 
 - "Sexuality heals when it no longer has to regulate fear."
 - "My desire belongs to me—not my survival."
 - "My body speaks before my mind. My job is to listen."
+- "I can be present during intimacy."
+- "My no is complete. My yes is spacious."
+- "I'm allowed to want what I want."
+- "My pleasure is not a performance."
 
-### Leadership
+---
+
+### Leadership & Presence
 
 - "True magnetism comes from coherence, not tactics."
 - "The most consistent nervous system leads."
 - "I can be wise without needing to be the wise one."
+- "I don't need to be loud—I need to be grounded."
+- "My presence is my leadership."
+- "I can hold space without taking over."
+- "Authority doesn't require armor."
 
-### Identity
+---
+
+### Identity & Being
 
 - "I don't heal a pattern. I graduate from an identity."
 - "I am not seeking anymore. I am living what I know."
 - "I may be wrong. I'm still choosing."
+- "I am not who I was trained to be."
+- "The role is not who I am. It's who I learned to be."
+- "I can let go of who I was without knowing who I'm becoming."
+- "I am enough without performing."
 
 ---
 
-## How to Use These Scripts
+### Regulation & State
 
-1. **Read them out loud.** Notice which feel natural.
-2. **Adapt to your voice.** Change words while keeping the structure.
-3. **Practice before you need them.** Rehearse in low-stakes moments.
-4. **Start simple.** Use the shortest version that works.
-5. **No explanation required.** These are complete sentences.
+- "I can return to myself."
+- "My nervous system is my instrument. I can tune it."
+- "Activation is information, not identity."
+- "I can feel without drowning."
+- "I can stay present when things get hard."
+- "Regulate first. Think later."
+- "My ground is always available."
+
+---
+
+## Self-Talk Scripts
+
+### When Activated
+
+- "I notice I'm activated. This is information."
+- "I'm going to regulate before I respond."
+- "My nervous system is doing its job. I can work with it."
+- "This will pass. Feelings are temporary."
+- "I don't have to act on this."
+
+---
+
+### When Overwhelmed
+
+- "Right now, all I have to do is breathe."
+- "One thing at a time."
+- "I can ask for help."
+- "This is a lot. I don't have to solve it all today."
+- "I'm going to take a break."
+
+---
+
+### When Self-Critical
+
+- "I'm learning. This is part of the process."
+- "I can be imperfect and still be okay."
+- "I would be kinder to a friend in this situation."
+- "One moment doesn't define me."
+- "I did the best I could with what I knew."
+
+---
+
+### When Making Progress
+
+- "I noticed that pattern faster this time."
+- "That was growth."
+- "I'm getting better at this."
+- "The work is working."
+- "That's evidence of change."
+
+---
+
+## Scripts for Specific Situations
+
+### Leaving a Toxic Relationship
+
+- "This relationship isn't healthy for me, and I'm ending it."
+- "I care about you. I can't continue this."
+- "I've made my decision. It's not up for discussion."
+- "I'm choosing myself now."
+- "I'm not going to explain or justify this further."
+
+---
+
+### Setting Boundaries with Parents
+
+- "I love you, and this is my decision to make."
+- "I'm not asking for permission. I'm informing you."
+- "I know you disagree. This is still what I'm choosing."
+- "I can love you and live my own life."
+- "Your approval isn't required for my choices."
+
+---
+
+### Ending a Friendship
+
+- "Our friendship has run its course."
+- "I'm stepping back from this relationship."
+- "I've realized this friendship doesn't serve me."
+- "I wish you well, and I'm moving on."
+- "We've grown in different directions."
+
+---
+
+### Declining to Explain
+
+- "I don't owe you an explanation."
+- "My reasons are my own."
+- "No is a complete sentence."
+- "I've said what I'm going to say."
+- "I'm not going to justify my decision."
+
+---
+
+### Responding to Manipulation
+
+- "That feels manipulative."
+- "I notice what you're doing."
+- "I'm not available for this tactic."
+- "My answer isn't going to change because you're pressuring me."
+- "This conversation is over."
+
+---
+
+## Closing Notes
+
+These scripts are training wheels. Use them until you don't need them.
+
+The goal is embodied language—words that arise naturally from your grounded state. Until that's reliable, scripts help bridge the gap.
+
+**Remember:**
+- You don't need to be perfect
+- You can stumble and still hold your boundary
+- Saying it imperfectly is better than not saying it
+- The other person's reaction is theirs to manage
 
 ---
 

--- a/book/vol-4-embodied-leadership/appendices/appendix-d-decoder-cards.md
+++ b/book/vol-4-embodied-leadership/appendices/appendix-d-decoder-cards.md
@@ -2,7 +2,17 @@
 
 ## Quick-Reference Cards for Sovereign Living
 
-Print these or save them for quick reference.
+Print these or save them for quick reference. Each card distills a chapter's essence into actionable reminders.
+
+---
+
+## How to Use These Cards
+
+- **Print and post** where you'll see them daily
+- **Review one card** when facing a related situation
+- **Use the integration lines** as daily mantras
+- **Reference during activated moments** to guide your response
+- **Share with partners or trusted others** to create shared language
 
 ---
 
@@ -10,7 +20,7 @@ Print these or save them for quick reference.
 
 ### What to Remember
 
-Your field is the energetic extension of your nervous system state. It's physiological first, not mystical.
+Your field is the energetic extension of your nervous system state. It's physiological first, not mystical. What you feel in a room is real—it's your nervous system reading other nervous systems.
 
 ### Quick Distinctions
 
@@ -19,16 +29,21 @@ Your field is the energetic extension of your nervous system state. It's physiol
 | "I'm just empathic" | I absorb without filtering |
 | "I feel everything" | I don't differentiate self from other |
 | "Love means feeling what they feel" | I confuse empathy with merger |
+| "Sensitivity is who I am" | Sensitivity without boundaries is leaking |
 
 ### Core Principle
 
 **Sensitivity ≠ Boundarylessness**
 
-You can perceive without absorbing.
+You can perceive without absorbing. You can feel what's happening without becoming it.
 
 ### Practice
 
-60-Second Field Scan: Front, back, left, right, above, below. Notice without changing.
+**60-Second Field Scan:** Stand or sit. Close eyes. Scan your field—front, back, left, right, above, below. Notice without changing. What's cluttered? What's clear? Three breaths. Return.
+
+### Body Cue
+
+The feeling of carrying energy that isn't yours—heaviness, confusion, emotional states that don't match your experience
 
 ### Integration Line
 
@@ -40,19 +55,27 @@ You can perceive without absorbing.
 
 ### What to Remember
 
-Most exhaustion isn't physical—it's energetic clutter you haven't cleared.
+Most exhaustion isn't physical—it's energetic clutter you haven't cleared. Your field collects residue from every interaction. Without hygiene, it accumulates.
 
-### Daily Practice
+### Daily Practice Stack
 
-- Morning: Pre-day seal
-- During: Return to sender as needed
-- Evening: Post-day clearing
+- **Morning:** Pre-day seal (1 min)
+- **During:** Return to sender as needed
+- **Evening:** Post-day clearing (5 min)
 
 ### Quick Check
 
-Am I carrying something that doesn't belong to me?
+**Am I carrying something that doesn't belong to me?**
 
-**If yes:** "This is not mine. I release it with compassion. Return to sender."
+**If yes:** Hand on chest. "This is not mine. I release it with compassion. Return to sender." Breathe. Feel it lift.
+
+### Signs You Need to Clean
+
+- Unexplained exhaustion
+- Carrying someone's mood
+- Can't stop thinking about someone
+- Feeling "off" without clear cause
+- Emotional reactivity that doesn't match the situation
 
 ### Integration Line
 
@@ -64,21 +87,26 @@ Am I carrying something that doesn't belong to me?
 
 ### The Three States
 
-| State | Signs | Field Quality |
-|-------|-------|---------------|
-| Ventral (Safe) | Relaxed, open, present | Coherent, inviting |
-| Sympathetic (Activated) | Tense, rapid, scanning | Activating, edgy |
-| Dorsal (Shutdown) | Slumped, flat, numb | Draining, heavy |
+| State | Signs | Field Quality | What Helps |
+|-------|-------|---------------|------------|
+| **Ventral (Safe)** | Relaxed, open, present, curious | Coherent, inviting, warm | Maintain |
+| **Sympathetic (Activated)** | Tense, rapid, scanning, reactive | Activating, edgy, sharp | Ground, slow breath |
+| **Dorsal (Shutdown)** | Slumped, flat, numb, distant | Draining, heavy, collapsed | Gentle movement, orienting |
 
 ### Key Insight
 
-Your state = Your field. Regulate inside to radiate outside.
+**Your state = Your field.** Regulate inside to radiate outside. You can't fake a regulated field.
 
 ### Quick Reset (90 Seconds)
 
-1. Orient (look around slowly)
-2. Breathe (inhale 4, exhale 6-8)
-3. Ground (feet on floor)
+1. **Orient:** Look around slowly (tells brainstem "safe")
+2. **Breathe:** Inhale 4, exhale 6-8 (activates parasympathetic)
+3. **Ground:** Feet on floor, weight of body, hands on surface
+4. **Check:** Has your state shifted?
+
+### Body Cue
+
+Jaw tension, shallow breath, scanning = sympathetic. Slumped, heavy, foggy = dorsal. Open chest, full breath, present = ventral.
 
 ### Integration Line
 
@@ -96,14 +124,23 @@ Your state = Your field. Regulate inside to radiate outside.
 | Breath deepens | Breath shallows |
 | Energy rises | Energy drops |
 | Body moves toward | Body pulls away |
+| Warmth spreading | Contraction, bracing |
+| Presence increases | Urge to escape |
 
 ### The Two-Breath No
 
 1. Receive request
-2. Breath one: Feel body's signal
-3. Breath two: Ground in answer
+2. **Breath one:** Feel body's signal
+3. **Breath two:** Ground in answer
 4. Speak: "I can't do that." (No explanation)
-5. Stop talking
+5. **Stop talking.** Don't fill the silence.
+
+### When It's Hard to Say No
+
+- The guilt means the pattern is activating, not that you're wrong
+- No is a complete sentence
+- Their disappointment is theirs to manage
+- A resentful yes is worse than a compassionate no
 
 ### Integration Line
 
@@ -115,11 +152,11 @@ Your state = Your field. Regulate inside to radiate outside.
 
 ### The Decision Filter
 
-1. What do I want? (Not should—want)
-2. What am I afraid of?
-3. Whose voice is loudest?
-4. What would I choose if I trusted myself?
-5. What decision would I respect in six months?
+1. **What do I want?** (Not should—want)
+2. **What am I afraid of?**
+3. **Whose voice is loudest?** (Mine, or someone else's?)
+4. **What would I choose if I trusted myself?**
+5. **What decision would I respect in six months?**
 
 ### Key Distinction
 
@@ -128,6 +165,11 @@ Your state = Your field. Regulate inside to radiate outside.
 | "What should I do?" | "What do I want?" |
 | "What will they think?" | "What matters to me?" |
 | "What's the right answer?" | "What feels true?" |
+| "What's expected of me?" | "What's aligned for me?" |
+
+### The Core Question
+
+**Am I choosing, or am I obeying?**
 
 ### Integration Line
 
@@ -141,19 +183,24 @@ Your state = Your field. Regulate inside to radiate outside.
 
 | Caring | Carrying |
 |--------|----------|
-| Compassion | Taking their crisis into your body |
-| Available | Thinking about them constantly |
-| Supporting | Rearranging life around their struggle |
+| Compassion present | Taking their crisis into your body |
+| Available when present | Thinking about them constantly |
+| Supporting without over-functioning | Rearranging life around their struggle |
 | Present when present | Unable to be at peace while they suffer |
+| Empathy with boundary | Merger without separation |
 
 ### Detachment vs. Dissociation
 
-- Detachment: Feeling without fusing. Staying present.
-- Dissociation: Numbing out. Leaving.
+- **Detachment:** Feeling without fusing. Staying present. Connected but separate.
+- **Dissociation:** Numbing out. Leaving. Not feeling anything.
 
 ### Practice: Bless and Release
 
 *"I love you. I bless your journey. Your path is yours. Mine is mine. I release this weight with compassion."*
+
+### The Key Question
+
+**Am I carrying this because I care, or because I'm afraid not to?**
 
 ### Integration Line
 
@@ -165,14 +212,16 @@ Your state = Your field. Regulate inside to radiate outside.
 
 ### What to Remember
 
-Sexuality heals when it no longer has to regulate fear.
+Sexuality heals when it no longer has to regulate fear. When sex is no longer a survival strategy, it becomes life force.
 
 ### Signs of Trauma-Wired Sexuality
 
-- Arousal after conflict
-- Attraction to intensity
-- Relief sex
+- Arousal after conflict or intensity
+- Attraction to chaos or danger
+- Relief sex (using sex to discharge tension)
 - Confusion between chemistry and threat
+- Dissociation or performance during intimacy
+- Desire wired to approval-seeking
 
 ### Signs of Sovereign Sexuality
 
@@ -180,10 +229,12 @@ Sexuality heals when it no longer has to regulate fear.
 - Arousal without collapse
 - Attraction without self-loss
 - Presence over intensity
+- Choice without obligation
+- Pleasure without performance
 
 ### The Neutral Phase
 
-Between trauma-wired and sovereign sexuality, there's often quiet. Desire muted. Fantasy soft. **This is reorganization, not dysfunction.**
+Between trauma-wired and sovereign sexuality, there's often quiet. Desire muted. Fantasy soft. **This is reorganization, not dysfunction.** Your system is rewiring. Be patient.
 
 ### Integration Line
 
@@ -197,22 +248,28 @@ Between trauma-wired and sovereign sexuality, there's often quiet. Desire muted.
 
 | State | Signal | Action |
 |-------|--------|--------|
-| YES | Open, toward | Proceed |
-| MAYBE | Mixed | Slow down, check in |
-| NO | Closed, away | Stop |
-| LATER | Interest, wrong timing | Wait |
+| **YES** | Open, toward, warm | Proceed |
+| **MAYBE** | Mixed, uncertain | Slow down, check in |
+| **NO** | Closed, away, tight | Stop |
+| **LATER** | Interest, wrong timing | Wait |
 
 ### Quick Scripts
 
-- Slowing: "I want to slow down."
-- Stopping: "I need to stop."
-- Changing: "Let's do something different."
+- **Slowing:** "I want to slow down."
+- **Stopping:** "I need to stop."
+- **Changing:** "Let's do something different."
+- **Buying time:** "Not tonight. Maybe another time."
+- **Checking in:** "Where are you right now?"
 
 ### Red/Yellow/Green
 
-- 🟢 Green: Proceed
-- 🟡 Yellow: Pause and check
-- 🔴 Red: Stop immediately
+- 🟢 **Green:** Proceed
+- 🟡 **Yellow:** Pause and check
+- 🔴 **Red:** Stop immediately
+
+### The Core Truth
+
+Your signals can change. That's allowed. Consent is ongoing, not a one-time question.
 
 ### Integration Line
 
@@ -224,10 +281,11 @@ Between trauma-wired and sovereign sexuality, there's often quiet. Desire muted.
 
 ### What Builds Intimacy
 
-- Pacing (not rushing to merge)
-- Repair (addressing ruptures)
-- Curiosity (genuine interest)
-- Accountability (owning your part)
+- **Pacing:** Not rushing to merge
+- **Repair:** Addressing ruptures, not ignoring them
+- **Curiosity:** Genuine interest in the other
+- **Accountability:** Owning your part
+- **Presence:** Actually here, not performing here
 
 ### The Key Question
 
@@ -240,6 +298,15 @@ Between trauma-wired and sovereign sexuality, there's often quiet. Desire muted.
 | Appropriate sharing | Everything immediately |
 | Gradual trust | Oversharing for connection |
 | Choosing what to share | No gatekeeping |
+| Serves connection | Serves discharge or approval |
+
+### Signs of Clean Intimacy
+
+- You can be yourself without performance
+- Conflict leads to repair, not rupture
+- You can hold difference without distance
+- The relationship grows you, not shrinks you
+- You feel nourished, not drained
 
 ### Integration Line
 
@@ -253,22 +320,29 @@ Between trauma-wired and sovereign sexuality, there's often quiet. Desire muted.
 
 | Manipulation | Magnetism |
 |--------------|-----------|
-| Calculated | Natural |
-| Strategic | Settled |
-| Hooks | Holds |
+| Calculated, strategic | Natural, settled |
+| Hooks with tactics | Holds with presence |
 | Collapses under scrutiny | Deepens with exposure |
+| Exhausting to maintain | Effortless when embodied |
+| Seeking a response | Allowing a response |
 
 ### What Creates Magnetism
 
-- Coherence (inside matches outside)
-- Regulation (nervous system settled)
-- Presence (actually here)
-- Integrity (word means something)
-- Non-neediness (not seeking approval)
+- **Coherence:** Inside matches outside
+- **Regulation:** Nervous system settled
+- **Presence:** Actually here, not performing
+- **Integrity:** Word means something
+- **Non-neediness:** Not seeking approval
 
 ### The Coherence Loop
 
 Body → Breath → Truth → Action
+
+When these align, magnetism is natural. When they don't, you're efforting.
+
+### The Key Question
+
+**Am I being magnetic, or manufacturing magnetism?**
 
 ### Integration Line
 
@@ -282,17 +356,33 @@ Body → Breath → Truth → Action
 
 **Groups entrain to the most consistent nervous system, not the loudest.**
 
+You don't need volume. You need ground.
+
 ### The Neutral Presence Protocol
 
-**Before:** Check state. Ground. Set intention.
-**During:** Anchor in yourself. Observe without absorbing. Speak from ground.
-**After:** Clear field. Energy check. Adjust for next time.
+**Before:**
+- Check your state
+- Ground
+- Set intention
+
+**During:**
+- Anchor in yourself
+- Observe without absorbing
+- Speak from ground, not reactivity
+
+**After:**
+- Clear your field
+- Energy check: What did you absorb?
+- Adjust for next time
 
 ### Redirect Scripts
 
-- Interruptions: "Let me finish, then I'd love to hear your thought."
-- Derailment: "Let's table that for now."
-- Monopolizing: "I want to hear from others."
+| Situation | Script |
+|-----------|--------|
+| Interruptions | "Let me finish, then I'd love to hear your thought." |
+| Derailment | "Let's table that for now." |
+| Monopolizing | "I want to hear from others." |
+| Escalation | "Let's slow down." |
 
 ### Integration Line
 
@@ -308,13 +398,21 @@ Body → Breath → Truth → Action
 - Difficulty letting others lead
 - Deflating when not consulted
 - Using insight for positioning
+- Competing with other helpers
+- Spiritual bypassing feedback
 
 ### The Integrity Check
 
-1. Is this for service or status?
-2. Can I be wrong?
-3. Am I attached to the outcome?
-4. Would I share this if no one knew it came from me?
+Before sharing insight, guiding, or stepping into leadership:
+
+1. **Is this for service or status?**
+2. **Can I be wrong?**
+3. **Am I attached to the outcome?**
+4. **Would I share this if no one knew it came from me?**
+
+### The Path of Ordinary
+
+The deepest healers often become ordinary. Not less wise—less identified with wisdom. They can sit in a room and not need to guide it.
 
 ### Integration Line
 
@@ -326,15 +424,29 @@ Body → Breath → Truth → Action
 
 ### Common Identity Residues
 
-- The Rescuer: "I exist to help"
-- The Good One: "I exist to accommodate"
-- The Performer: "I exist to be seen"
-- The Invisible One: "I exist to not take up space"
+| Identity | Core Belief | Transition To |
+|----------|-------------|---------------|
+| **Rescuer** | "I exist to help" | Compassionate Witness |
+| **Good One** | "I exist to accommodate" | Honest One |
+| **Performer** | "I exist to be seen" | Present One |
+| **Invisible One** | "I exist to not take space" | Visible One |
+| **Scapegoat** | "Something is wrong with me" | Self-Owned |
+| **Caretaker** | "My attention belongs on others" | Self-Attendant |
 
 ### The Release Practice
 
-*"I am no longer available for [old role]."*
-*"I am available for [new possibility]."*
+1. Name the old identity
+2. *"I am no longer available for [old role]."*
+3. *"I am available for [new possibility]."*
+4. Feel it in your body
+5. Live it
+
+### When the Old Identity Returns
+
+- **Notice:** "There's the old identity."
+- **Name:** "That's the rescuer trying to run."
+- **Choose:** "I'm not available for that anymore."
+- **Return:** To present, to body, to who you actually are now.
 
 ### Integration Line
 
@@ -346,9 +458,20 @@ Body → Breath → Truth → Action
 
 ### Daily Maintenance
 
-- Morning: Field scan + seal
-- Throughout: State awareness + resets
-- Evening: Clearing + gratitude
+**Morning:**
+- Field scan
+- Pre-day seal
+- Intention
+
+**Throughout:**
+- State awareness
+- Resets as needed
+- Return to sender
+
+**Evening:**
+- Clearing
+- Energy audit
+- Gratitude
 
 ### Weekly Review Questions
 
@@ -357,7 +480,16 @@ Body → Breath → Truth → Action
 3. Where did old patterns run?
 4. What does next week need?
 
-### The Final Integration
+### The Dojo Is Everywhere
+
+- Family dinner
+- Work meetings
+- Difficult conversations
+- Morning commute
+- Intimate moments
+- Solitude
+
+### Integration Line
 
 *"I am not seeking anymore. I am living what I know."*
 
@@ -401,7 +533,7 @@ Body → Breath → Truth → Action
 
 ### What This IS
 
-Nervous system patterning shaped by exposure, fear, and lack of containment.
+Nervous system patterning shaped by exposure, fear, and lack of containment. The body adapted to the environment it was given.
 
 ### Reframe
 
@@ -419,11 +551,11 @@ Nervous system patterning shaped by exposure, fear, and lack of containment.
 
 | Pattern | What Happened | What the Body Learned |
 |---------|---------------|----------------------|
-| Compliance | Said yes to avoid conflict | "My body is negotiable" |
-| Dissociation | Left body during intimacy | "Absence is safer than presence" |
-| Intensity-seeking | Arousal only with conflict | "Danger = connection" |
-| Performance | Sex as role, not experience | "Being desired = worth" |
-| Shame | Unexplained guilt after intimacy | "Pleasure is wrong" |
+| **Compliance** | Said yes to avoid conflict | "My body is negotiable" |
+| **Dissociation** | Left body during intimacy | "Absence is safer than presence" |
+| **Intensity-seeking** | Arousal only with conflict | "Danger = connection" |
+| **Performance** | Sex as role, not experience | "Being desired = worth" |
+| **Shame** | Unexplained guilt after intimacy | "Pleasure is wrong" |
 
 ### Sexuality Returning to Self
 
@@ -460,14 +592,40 @@ Nervous system patterning shaped by exposure, fear, and lack of containment.
 
 ## Quick Reference: Core Integration Lines
 
-1. "I can feel the room without becoming the room."
-2. "I don't need protection. I need to remember to clean."
-3. "My body knows. My job is to honor what it tells me."
-4. "My desire belongs to me—not my survival."
-5. "Intimacy is safety + truth over time."
-6. "True magnetism comes from coherence, not tactics."
-7. "I don't heal a pattern. I graduate from an identity."
-8. "I am not seeking anymore. I am living what I know."
+Use these as daily mantras or touchstones:
+
+1. *"I can feel the room without becoming the room."*
+2. *"I don't need protection. I need to remember to clean."*
+3. *"My body knows. My job is to honor what it tells me."*
+4. *"My desire belongs to me—not my survival."*
+5. *"Intimacy is safety + truth over time."*
+6. *"True magnetism comes from coherence, not tactics."*
+7. *"I don't heal a pattern. I graduate from an identity."*
+8. *"I am not seeking anymore. I am living what I know."*
+
+---
+
+## Emergency Quick Reference
+
+### When Flooding
+
+1. Name: "I'm flooding."
+2. Ground: Feet on floor. 5 things you see.
+3. Breathe: Long exhales.
+4. Delay: "I'll decide when regulated."
+
+### When Absorbing
+
+1. Notice: "This isn't mine."
+2. Release: "Return to sender."
+3. Return: To your own body.
+
+### When Activated Before Speaking
+
+1. Pause. One breath.
+2. Ground. Feet. Breath.
+3. Check: "What state am I in?"
+4. Speak from regulation, not activation.
 
 ---
 

--- a/book/vol-4-embodied-leadership/appendices/appendix-e-sexuality-self-check.md
+++ b/book/vol-4-embodied-leadership/appendices/appendix-e-sexuality-self-check.md
@@ -6,85 +6,193 @@
 
 This is not a test. This is a mirror.
 
+There are no right answers. There are no scores. There is only reflection—seeing yourself more clearly so you can move forward with more awareness.
+
 Answer slowly. Skip anything that feels activating. Return when ready.
+
+If you find yourself rushing through, pause. This isn't meant to be completed in one sitting. Let yourself feel what comes up.
 
 ---
 
-## Early Learning & Environment
+## How to Use This Self-Check
+
+1. **Read each statement slowly.** Let it land in your body before checking.
+2. **Notice your body's response,** not just your thoughts.
+3. **Check only what genuinely resonates,** not what you think should or shouldn't apply.
+4. **Skip sections that feel overwhelming.** You can return later.
+5. **Be honest.** This is for you alone.
+6. **Don't shame yourself.** Everything here makes sense in context. These patterns developed for reasons.
+
+---
+
+## Section 1: Early Learning & Environment
+
+*These questions explore what your nervous system learned before you had language to describe it.*
 
 Check any that resonate:
 
 - ☐ I was exposed to adult sexuality without explanation or protection
 - ☐ Sexual jokes, material, or behavior made me uncomfortable growing up
 - ☐ I witnessed infidelity, humiliation, or desperation around relationships
-- ☐ I learned more by watching adults than by being taught
-- ☐ Boundaries around sexuality felt unclear or absent
+- ☐ I learned more about sexuality by watching adults than by being taught
+- ☐ Boundaries around sexuality felt unclear or absent in my household
+- ☐ Sexuality was shamed, hidden, or treated as something dirty
+- ☐ Sexuality was overly celebrated or performed in ways that felt uncomfortable
+- ☐ I saw adults using sex to get needs met (attention, security, control)
+- ☐ I was exposed to pornography or sexual content before I could understand it
+- ☐ I witnessed violence, rage, or chaos connected to romantic/sexual relationships
+- ☐ I felt responsible for a parent's emotional or romantic needs
+- ☐ Adults commented on my body or development in ways that felt uncomfortable
+- ☐ I learned that love and pain often go together
 
-**If several resonate:** Your body learned about sex before it learned about safety.
+**If several resonate:** Your body learned about sex before it learned about safety. This isn't your fault. The nervous system absorbs the environment it's given.
 
 ---
 
-## Consent & Choice
+## Section 2: Messages Received
+
+*These questions explore the explicit and implicit messages you absorbed.*
+
+Check any that resonate:
+
+- ☐ I was taught (explicitly or implicitly) that my body is for others' pleasure
+- ☐ I was taught that saying no to sex might cost me love or safety
+- ☐ I was taught that my worth is connected to being desirable
+- ☐ I was taught that "good" people don't express sexual desire
+- ☐ I was taught that my desires are shameful or wrong
+- ☐ I was taught to prioritize others' pleasure over my own
+- ☐ I was taught that my body belongs to me only secondarily
+- ☐ I was taught that sex is something you give, not something you share
+- ☐ I was taught that being "too much" sexually is dangerous
+- ☐ I was taught that being "not enough" sexually means being unlovable
+- ☐ I never received clear messages about consent or boundaries
+- ☐ I was taught that enduring discomfort during sex is normal
+- ☐ I was taught that talking about sex is inappropriate
+
+**If several resonate:** These messages became programming. They shaped how you relate to your own desire. Recognizing them is the first step to rewriting them.
+
+---
+
+## Section 3: Consent & Choice
+
+*These questions explore your relationship with saying yes and no.*
 
 - ☐ I've agreed to sexual situations to keep the peace
 - ☐ I've said "okay" when I felt frozen or unsure
 - ☐ I've felt relief after sex rather than connection
 - ☐ I've struggled to leave situations that felt uncomfortable
 - ☐ I've gone along with things I didn't want
+- ☐ I've had trouble knowing what I actually want during sex
+- ☐ I've said yes because I didn't know how to say no
+- ☐ I've said yes to avoid the person's reaction to no
+- ☐ I've said yes hoping it would make me feel closer to the person
+- ☐ I've said yes when my body was saying no
+- ☐ I've felt like my body wasn't really mine during intimacy
+- ☐ I've confused obligation with desire
+- ☐ I've had sex to prove I'm not "frigid" or "broken"
+- ☐ I've had sex to secure the relationship
+- ☐ My yes has often been a "yes to avoid worse"
 
-**If several resonate:** This reflects survival intelligence, not weak boundaries.
+**If several resonate:** This reflects survival intelligence, not weak boundaries. Your nervous system learned that going along was safer than resisting. This can be unlearned, slowly, with safety.
 
 ---
 
-## Arousal Patterns
+## Section 4: Arousal Patterns
+
+*These questions explore what activates desire and arousal.*
 
 - ☐ Desire increases during conflict or intensity
-- ☐ Calm or safety sometimes reduces libido
+- ☐ Calm or safety sometimes reduces my libido
 - ☐ I confuse chemistry with compatibility
 - ☐ I've been aroused without feeling emotionally present
 - ☐ Tenderness feels flat compared to intensity
+- ☐ I'm drawn to relationships that are unstable or dramatic
+- ☐ I find myself bored by partners who treat me well
+- ☐ Anger or fear can feel arousing
+- ☐ I've used sex to discharge tension from conflict
+- ☐ I've felt aroused in situations that I knew weren't safe
+- ☐ My fantasies often involve dynamics of power, danger, or being taken
+- ☐ Stability feels unsexy
+- ☐ I've mistaken adrenaline for attraction
 
-**If several resonate:** Arousal can be conditioned. Desire requires safety.
+**If several resonate:** Arousal can be conditioned. When the nervous system learned to associate sexuality with intensity or threat, it wires arousal to those signals. Desire can be rewired to safety—but the process takes time and patience.
 
 ---
 
-## During Intimacy
+## Section 5: During Intimacy
+
+*These questions explore your experience during sexual encounters.*
 
 - ☐ I dissociate or feel "not fully there" during sex
 - ☐ I perform instead of feel
 - ☐ I struggle to stay embodied
 - ☐ I feel pressure to give or please
 - ☐ I watch myself from the outside
+- ☐ I check out while still physically participating
+- ☐ I focus on the other person's experience more than my own
+- ☐ I have difficulty feeling pleasure even when I want to
+- ☐ I go through the motions without really being present
+- ☐ I feel numb or disconnected from my body
+- ☐ I can't seem to "get out of my head"
+- ☐ I monitor how I look or sound instead of feeling what's happening
+- ☐ I feel relief when it's over rather than satisfied
+- ☐ I've faked pleasure or orgasm to end the experience
+- ☐ I feel like I'm playing a role rather than being myself
 
-**If several resonate:** Dissociation is a protective reflex, not disinterest.
+**If several resonate:** Dissociation is a protective reflex, not disinterest. The body learned to leave when staying present was too overwhelming. Presence can be rebuilt—slowly, safely, at your own pace.
 
 ---
 
-## After Intimacy
+## Section 6: After Intimacy
+
+*These questions explore what happens after sexual experiences.*
 
 - ☐ I feel shame without knowing why
-- ☐ I replay interactions mentally
+- ☐ I replay interactions mentally, critiquing myself
 - ☐ I feel empty or depleted
 - ☐ I wonder what's "wrong" with me
 - ☐ Connection fades quickly after sex
+- ☐ I feel used even when the encounter was consensual
+- ☐ I feel anxious about whether I did it "right"
+- ☐ I feel guilty for having wanted sex
+- ☐ I feel guilty for not wanting sex enough
+- ☐ I want to be alone immediately after
+- ☐ I don't feel the closeness I expected
+- ☐ I feel like I gave something away
+- ☐ I feel disconnected from my partner afterward
+- ☐ I need reassurance that I'm still loved/wanted
 
-**If several resonate:** Shame often belongs to unmet safety needs, not to you.
+**If several resonate:** Shame often belongs to unmet safety needs, not to you. Post-sex shame usually signals that something in the experience didn't feel fully chosen, fully present, or fully safe—even if nothing technically went wrong.
 
 ---
 
-## Relational Themes
+## Section 7: Relational Themes
+
+*These questions explore how sexuality functions in your relationships.*
 
 - ☐ I fear disappointing partners sexually
 - ☐ I struggle to say no without guilt
 - ☐ I've used sex to repair conflict
 - ☐ I feel more desired than cherished
 - ☐ My partner has complained about disconnection
+- ☐ I avoid intimacy to avoid the pressure
+- ☐ Sex feels like a performance I have to deliver
+- ☐ I feel responsible for my partner's sexual satisfaction
+- ☐ I don't ask for what I want because I don't know how
+- ☐ I feel invisible during sex—like it's happening to me, not with me
+- ☐ I've hidden my true desires from partners
+- ☐ I've performed enthusiasm I didn't feel
+- ☐ I've used sex to feel valuable or wanted
+- ☐ I've used sex to keep a partner from leaving
+- ☐ Sex feels like currency in my relationships
 
-**If several resonate:** Sex can become a repair strategy when repair wasn't modeled.
+**If several resonate:** Sex can become a repair strategy, a performance, or a transaction when the nervous system learns that connection isn't freely given. This pattern can shift when safety is present.
 
 ---
 
-## Reclamation Signals
+## Section 8: Reclamation Signals
+
+*These questions explore signs that your sexuality is returning to you.*
 
 Check any that are emerging:
 
@@ -94,61 +202,133 @@ Check any that are emerging:
 - ☐ Desire is quieter—but feels more honest
 - ☐ I'm less willing to perform
 - ☐ I'm more interested in presence than intensity
+- ☐ I can say no without as much guilt
+- ☐ I'm curious about my own pleasure
+- ☐ I'm starting to ask for what I want
+- ☐ Intimacy feels less like an obligation
+- ☐ I can be present during sex more easily
+- ☐ I feel desire emerging naturally, without forcing it
+- ☐ I'm choosing partners based on safety, not chemistry alone
+- ☐ I'm allowing myself to be slower
+- ☐ I trust my body's signals more
 
-**If several resonate:** These are signs of recalibration, not loss.
+**If several resonate:** These are signs of recalibration, not loss. Your system is reorganizing. The quiet phase is part of the healing. Trust the process.
 
 ---
 
 ## Interpreting Your Checkmarks
 
-### Many checks in early sections (Early Learning, Consent):
+### Many checks in early sections (Early Learning, Messages, Consent):
 
-Your sexuality likely organized around survival. This is not your fault—your body adapted to what was available.
+Your sexuality likely organized around survival. This is not your fault—your body adapted to what was available. The environment shaped you before you had any choice.
 
-### Many checks in arousal & intimacy sections:
+**What this means for healing:**
+- Be patient. You're unwiring decades of conditioning.
+- Focus on safety before pleasure. The body needs to trust first.
+- Grief may arise. You may mourn what you didn't get.
+- Go slowly. Rushing reinforces the old pattern.
 
-Your nervous system may still associate intensity with connection. This is rewirable.
+---
+
+### Many checks in arousal and intimacy sections:
+
+Your nervous system may still associate intensity with connection. Arousal got wired to threat signals because that's what was available. This is rewirable.
+
+**What this means for healing:**
+- Notice when you're drawn to intensity. Pause.
+- Experiment with staying present during calm, safe intimacy.
+- Allow pleasure to be subtle at first. It may rebuild quietly.
+- Practice embodiment outside of sexual contexts first.
+
+---
+
+### Many checks in relational themes:
+
+Sex may have become a strategy in your relationships—for connection, security, approval, or repair. This isn't a character flaw. It's adaptation.
+
+**What this means for healing:**
+- Examine what function sex serves beyond pleasure.
+- Practice having needs met outside of sexual exchange.
+- Build intimacy through presence, not performance.
+- Have conversations with partners about what you're discovering.
+
+---
 
 ### Checks in reclamation section:
 
 Healing is already underway. Trust the process.
 
----
-
-## One-Line Reframe
-
-*My sexuality adapted to keep me safe. Now it is learning how to feel free.*
+**What this means going forward:**
+- Celebrate these shifts. They're evidence of change.
+- Keep going. The work is working.
+- Stay curious. More will reveal itself.
+- Be patient. Integration takes time.
 
 ---
 
 ## Optional Reflection Prompts
 
-Use these for journaling or quiet reflection:
+Use these for journaling or quiet reflection. Don't answer them all at once. Let them sit with you over time.
 
-1. **Where did I learn to override myself?**
-   What early experience taught me that my signals don't matter?
+### 1. Where did I learn to override myself?
 
-2. **What does my body need before desire can return?**
-   Safety? Time? Trust? Honesty? Something else?
+What early experience taught me that my signals don't matter? When did I first learn to say yes when I meant no?
 
-3. **What would safety feel like during intimacy?**
-   Not what it "should" look like—what would it actually feel like in your body?
+### 2. What does my body need before desire can return?
 
-4. **What happens if I don't rush myself?**
-   What fears arise when I consider taking more time?
+Safety? Time? Trust? Honesty? Tenderness? Something else? What conditions would allow my authentic desire to emerge?
 
-5. **What would sexuality feel like if it weren't managing anything?**
-   If it didn't have to regulate fear, secure attachment, or prove worth?
+### 3. What would safety feel like during intimacy?
+
+Not what it "should" look like—what would it actually feel like in your body? How would you know you were safe?
+
+### 4. What happens if I don't rush myself?
+
+What fears arise when I consider taking more time? What might be waiting on the other side of slower?
+
+### 5. What would sexuality feel like if it weren't managing anything?
+
+If it didn't have to regulate fear, secure attachment, or prove worth? If it was just... desire?
+
+### 6. What did I learn about sexuality from watching the adults around me?
+
+Not what they told me—what did I see? What did I absorb? What conclusions did I draw?
+
+### 7. What permission do I need to give myself?
+
+To want? To not want? To be slow? To change my mind? To ask for what I need? To say no?
+
+### 8. What would I want sexuality to be for me, now?
+
+Not what it was. Not what others expect. What do I want it to be?
 
 ---
 
-## Reader Note
+## After Completing This Self-Check
 
-If parts of this checklist stirred emotion, pause. Ground. Breathe.
+### If You're Activated
 
-Nothing here requires fixing today.
+If this self-check stirred emotion, pause. Ground. Breathe.
 
-Awareness is progress.
+- Put your hand on your chest or belly.
+- Feel your feet on the floor.
+- Take five slow breaths.
+- Name what you're feeling without judging it.
+- Remind yourself: "I'm safe right now. This is reflection, not re-experiencing."
+
+Nothing here requires fixing today. Awareness is progress.
+
+---
+
+### What to Do With What You've Discovered
+
+**Don't force change.** Understanding is the first step. Action comes when you're ready.
+
+**Be gentle.** These patterns developed to protect you. They don't need to be attacked—they need to be thanked and released.
+
+**Seek support if needed.** A trauma-informed therapist, somatic practitioner, or sex therapist can help if these patterns feel overwhelming.
+
+**Trust the process.** Sexuality can heal. It happens slowly, with safety, with patience.
 
 ---
 
@@ -160,6 +340,10 @@ They mean your body learned early—and is now learning again.
 
 **What was learned in chaos can be unlearned in safety—slowly, gently, and without force.**
 
+Your nervous system did what it was trained to do. It protected you the only way it knew how.
+
+Now, you're teaching it something new.
+
 ---
 
 ## Integration Statement
@@ -168,6 +352,42 @@ They mean your body learned early—and is now learning again.
 
 ---
 
-*Return to this self-check periodically. Notice what shifts.*
+## A Note on Patience
 
+Sexuality rewires slowly.
+
+The patterns you're recognizing took years—sometimes decades—to form. They became neural pathways. They became automatic.
+
+They won't change in a week. Or a month. Maybe not in a year.
+
+But they can change.
+
+Every time you pause instead of override—the pathway weakens.
+Every time you say no when you mean no—the pathway weakens.
+Every time you stay present when you used to dissociate—the pathway weakens.
+Every time you choose safety over intensity—the pathway weakens.
+
+And new pathways form. Slowly. With practice.
+
+This is the work.
+
+---
+
+## One-Line Reframe
+
+*My sexuality adapted to keep me safe. Now it is learning how to feel free.*
+
+---
+
+## Return to This Self-Check
+
+This isn't a one-time exercise.
+
+Return periodically. Notice what shifts. What you check today may be different in six months.
+
+Change is gradual. Visible only over time. The self-check helps you see the arc.
+
+---
+
+*"Your body speaks before your mind. Your job is to listen."*
 

--- a/book/vol-4-embodied-leadership/chapters/13-repatterning-identity.md
+++ b/book/vol-4-embodied-leadership/chapters/13-repatterning-identity.md
@@ -22,9 +22,15 @@ The one who accommodates. Who smooths things over. Who makes others comfortable.
 
 It's exhausting. But it's also... her.
 
-When she tries to set boundaries, she doesn't know who she is anymore.
+When she tries to set boundaries, she doesn't know who she is anymore. The guilt isn't just discomfort—it's a kind of vertigo. As if she's losing her footing on the only ground she's ever known.
 
 Who is she if she's not the good one?
+
+She's been this person for so long that she can't separate the role from herself. When someone says "you've changed," she doesn't hear it as observation. She hears it as accusation.
+
+The good one wouldn't change. The good one would stay. The good one would accommodate.
+
+But something in her is tired of the good one. Something in her wants permission to be... not.
 
 ---
 
@@ -34,11 +40,39 @@ She's still kind. Still caring. Still thoughtful.
 
 But she's no longer the good one.
 
-She can say no without losing herself. She can prioritize her needs without guilt.
+She can say no without losing herself. She can prioritize her needs without guilt. She can disappoint someone and remain whole.
 
 She hasn't become someone else. She's become more herself.
 
 The good one was a role. This is who she actually is.
+
+She notices now when the old identity tries to return—when someone's disappointment pulls at her, when an expectation lands in her chest. She feels the tug. She no longer follows it.
+
+It took time. There was grief. There were moments she wasn't sure she'd survive the transition.
+
+But here she is. On the other side. Still herself—more herself than ever.
+
+---
+
+## Understanding Identity as a Survival Adaptation
+
+Before we name the residues, let's understand why identity forms the way it does.
+
+You weren't born the rescuer, the good one, the performer. These weren't personality traits that emerged naturally. They were **survival adaptations**—ways of being that kept you safe in environments where being yourself wasn't an option.
+
+**The child who becomes the good one** learned that accommodation prevents abandonment.
+
+**The child who becomes the rescuer** learned that being useful ensures belonging.
+
+**The child who becomes the performer** learned that being impressive deflects criticism.
+
+**The child who becomes the scapegoat** learned that carrying blame protects the system.
+
+**The child who becomes the invisible one** learned that disappearing prevents attack.
+
+These identities saved you. They worked. They got you through.
+
+The problem is: **you're not in that environment anymore.** And the identity that kept you safe is now keeping you small.
 
 ---
 
@@ -51,6 +85,7 @@ These are the old roles that:
 - Activate under stress
 - Run automatically in familiar contexts
 - Feel like "who you are"
+- Carry a strange comfort, even when they cost you
 
 **Common identity residues:**
 
@@ -58,31 +93,71 @@ These are the old roles that:
 
 "I exist to help. Without someone to save, I don't know who I am."
 
-**Shows up as:** Needing to be needed. Can't rest when others are struggling. Over-functioning.
+**Shows up as:** Needing to be needed. Can't rest when others are struggling. Over-functioning. Feeling empty when no one requires your help. Scanning for problems to solve. Difficulty receiving.
+
+**The deeper truth:** The rescuer identity often forms when the child had to parent the parent—when being the one who fixes felt like the only way to secure love. The rescuer isn't just helping. The rescuer is trying to earn belonging.
+
+**The transition:** From rescuer to *compassionate witness*. You learn that you can care without carrying. That you can be present without over-functioning. That your value exists independent of your usefulness.
 
 ### The Good Girl/Boy
 
 "I exist to accommodate. My value is in making others comfortable."
 
-**Shows up as:** Difficulty with conflict. Over-explaining. Guilt after boundaries.
+**Shows up as:** Difficulty with conflict. Over-explaining. Guilt after boundaries. Need for approval. Fear of disappointing anyone. Softening truth to avoid reaction. Scanning for what others want.
+
+**The deeper truth:** The good one learned that their authentic self was too much, too wrong, or too disruptive. Accommodation became survival. Being good meant being tolerable.
+
+**The transition:** From good one to *honest one*. You learn that you can have needs without being needy. That conflict is survivable. That disappointing someone doesn't equal losing them—and even if it does, you don't lose yourself.
 
 ### The Performer
 
 "I exist to be seen. My value is in my output and image."
 
-**Shows up as:** Exhaustion from constant impression management. Difficulty being ordinary.
+**Shows up as:** Exhaustion from constant impression management. Difficulty being ordinary. Fear of being boring. Need for recognition. Emptiness when alone. Curating experience rather than having it.
+
+**The deeper truth:** The performer learned that attention was conditional—that being seen depended on being impressive. The authentic self wasn't enough. So they created a version that would be.
+
+**The transition:** From performer to *present one*. You learn that you can just be. That your worth is inherent. That ordinary is enough. That you don't need applause to exist.
 
 ### The Scapegoat
 
 "I exist to carry blame. Something is fundamentally wrong with me."
 
-**Shows up as:** Shame spirals. Expecting rejection. Difficulty receiving good.
+**Shows up as:** Shame spirals. Expecting rejection. Difficulty receiving good. Explaining yourself preemptively. Bracing for criticism. Feeling inherently defective.
+
+**The deeper truth:** The scapegoat took on the family's shadow. They became the container for what the system couldn't own. The shame they carry isn't theirs—but they've held it so long it feels like identity.
+
+**The transition:** From scapegoat to *self-owned*. You learn that the shame was assigned, not earned. That you can put down what was never yours. That you are not what you were called.
 
 ### The Invisible One
 
 "I exist to not take up space. My safety depends on not being noticed."
 
-**Shows up as:** Shrinking in groups. Difficulty voicing needs. Feeling unseen.
+**Shows up as:** Shrinking in groups. Difficulty voicing needs. Feeling unseen. Avoiding attention. Minimizing accomplishments. Surprise when others remember you.
+
+**The deeper truth:** The invisible one learned that visibility brought danger. That taking up space invited attack or abandonment. Disappearing was safety.
+
+**The transition:** From invisible to *visible*. You learn that you deserve space. That your needs are legitimate. That you can be seen and stay safe. That your presence matters.
+
+### The Mediator
+
+"I exist to keep the peace. Without conflict, I have value."
+
+**Shows up as:** Inserting yourself between others. Anxiety when people disagree. Over-responsibility for group harmony. Difficulty taking sides. Exhaustion from managing emotional climate.
+
+**The deeper truth:** The mediator grew up in a volatile system where conflict felt life-threatening. They learned to regulate others to regulate themselves.
+
+**The transition:** From mediator to *participant*. You learn to have your own position. To let others work out their own conflicts. To tolerate discord without intervening. To be in the room without managing the room.
+
+### The Caretaker
+
+"I exist to anticipate and meet needs. My attention is always on others."
+
+**Shows up as:** Hyper-awareness of others' states. Difficulty knowing your own needs. Guilt when focused on yourself. Exhaustion from constant attunement. Feeling resentful but unable to stop.
+
+**The deeper truth:** The caretaker learned that their feelings took a backseat. That focusing on self meant abandonment. That the only safe attention was outward attention.
+
+**The transition:** From caretaker to *self-attendant*. You learn to turn attention inward. To notice your own needs with the same care you give others. To let others caretake themselves.
 
 ---
 
@@ -102,7 +177,11 @@ Old identities are practiced. They run automatically. They don't require conscio
 
 **This is not failure. It's biology.**
 
+The amygdala doesn't know you've done three years of therapy. When it detects familiar threat patterns, it routes to familiar responses. This isn't weakness—it's survival architecture doing its job.
+
 The practice is noticing the default, interrupting it, and choosing differently—over and over—until the new identity becomes as practiced as the old one.
+
+**Timeline reality:** This takes time. Months. Sometimes years. The neural pathways of your old identity had decades to form. The new ones are still being built. Be patient with the construction.
 
 ---
 
@@ -115,16 +194,50 @@ These networks include:
 - Behavioral patterns associated with that identity
 - Emotional responses linked to that identity
 - Relational patterns that reinforce it
+- Body postures and sensations connected to it
+- Automatic scripts for social situations
 
 **Changing identity means building new networks.**
 
 This happens through:
-- Repetition (practice)
-- Emotional engagement (feeling the new way)
-- Consistent action (behavior that matches the new identity)
-- Environmental support (contexts that reinforce the change)
+- **Repetition** (practice): Each time you choose the new way, you strengthen the new pathway
+- **Emotional engagement** (feeling the new way): Emotion acts as a neural highlighter, marking experiences as significant
+- **Consistent action** (behavior that matches the new identity): The body teaches the brain
+- **Environmental support** (contexts that reinforce the change): New patterns need supportive conditions
 
-**Translation:** You become who you practice being.
+**The Hebb principle:** Neurons that fire together, wire together. Every time you choose the new response over the old, you're literally rewiring your brain.
+
+**The extinction principle:** Neural pathways that aren't used weaken over time. The old identity doesn't disappear—it becomes less accessible.
+
+**Translation:** You become who you practice being. Not who you wish you were. Not who you think you should be. Who you *practice* being.
+
+---
+
+## The Grief of Letting Go
+
+What we don't often discuss: **identity transition involves grief**.
+
+You're not just adopting new behaviors. You're letting go of who you've been. And that person—even if they were exhausted, even if they were suffering—was still *you*.
+
+**What you might grieve:**
+
+- The familiarity of the old role
+- The relationships built around the old identity
+- The sense of purpose the old identity provided
+- The ways people depended on the old you
+- The certainty of knowing how to be
+
+**Signs grief is present:**
+
+- Sadness that seems disproportionate to the change
+- Longing for old patterns even when you know they hurt
+- Resistance that feels like more than just habit
+- Fear that you're losing something essential
+- Moments of wondering if the work is worth it
+
+**This grief is valid.** It doesn't mean you're going backward. It means you're actually transitioning—actually letting go, not just adding new behaviors on top of old identity.
+
+Let yourself feel it. The new identity can't fully arrive until the old one is mourned.
 
 ---
 
@@ -134,7 +247,7 @@ A declarative practice for releasing old identities.
 
 **Step 1:** Identify the old identity. Name it clearly.
 
-*"The rescuer." "The good girl." "The one who shrinks."*
+*"The rescuer." "The good girl." "The one who shrinks." "The caretaker." "The performer."*
 
 **Step 2:** Speak the release.
 
@@ -144,7 +257,11 @@ A declarative practice for releasing old identities.
 
 *"I am no longer available for performing my value."*
 
-**Step 3:** Name what you are available for.
+*"I am no longer available for anticipating needs before they're expressed."*
+
+*"I am no longer available for carrying shame that isn't mine."*
+
+**Step 3:** Name what you ARE available for.
 
 *"I am available for relationships that don't require me to rescue."*
 
@@ -152,9 +269,17 @@ A declarative practice for releasing old identities.
 
 *"I am available for being seen as I am."*
 
-**Step 4:** Live it.
+*"I am available for letting others manage their own experience."*
 
-The declaration means nothing without action. Each time the old identity activates, choose differently.
+*"I am available for taking up space without apology."*
+
+**Step 4:** Feel it in your body.
+
+This isn't just cognitive. Let the declaration land somatically. Notice what shifts in your chest, your shoulders, your jaw. Let the body register the permission.
+
+**Step 5:** Live it.
+
+The declaration means nothing without action. Each time the old identity activates, choose differently. The living is the practice.
 
 ---
 
@@ -162,41 +287,103 @@ The declaration means nothing without action. Each time the old identity activat
 
 ### Old Self Script: The Rescuer
 
-"I need to help. If I'm not helping, I have no value. Their pain is my responsibility."
+"I need to help. If I'm not helping, I have no value. Their pain is my responsibility. I can't rest while someone is struggling. My attention belongs on their needs, not mine."
 
 ### New Self Script: The Compassionate Witness
 
-"I can witness without rescuing. My value exists independent of usefulness. Their pain is theirs to feel."
+"I can witness without rescuing. My value exists independent of usefulness. Their pain is theirs to feel. I can care deeply without over-functioning. My attention can include myself."
 
 ---
 
 ### Old Self Script: The Good One
 
-"I must accommodate. Conflict means I've failed. My boundaries hurt people."
+"I must accommodate. Conflict means I've failed. My boundaries hurt people. I need everyone to be okay with me. If someone is disappointed, I've done something wrong."
 
 ### New Self Script: The Honest One
 
-"I can have needs. Conflict is survivable. My boundaries protect connection."
+"I can have needs. Conflict is survivable. My boundaries protect connection. Some people won't be okay with me—and I will be okay. Disappointing someone doesn't make me wrong."
 
 ---
 
 ### Old Self Script: The Performer
 
-"I must impress. My worth is in my output. Being ordinary is failing."
+"I must impress. My worth is in my output. Being ordinary is failing. I need recognition to feel real. If I'm not achieving, I'm invisible."
 
 ### New Self Script: The Present One
 
-"I can just be. My worth is inherent. Ordinary is enough."
+"I can just be. My worth is inherent. Ordinary is enough. I don't need applause to exist. I can be here without earning my presence."
 
 ---
 
 ### Old Self Script: The Invisible One
 
-"I shouldn't take up space. My needs are too much. Safety means hiding."
+"I shouldn't take up space. My needs are too much. Safety means hiding. If I'm seen, something bad will happen. I am not meant to be noticed."
 
 ### New Self Script: The Visible One
 
-"I deserve space. My needs are legitimate. I can be seen and stay safe."
+"I deserve space. My needs are legitimate. I can be seen and stay safe. My presence matters. I am allowed to be here."
+
+---
+
+### Old Self Script: The Scapegoat
+
+"Something is wrong with me. I deserve blame. Everyone sees my defects. I need to explain and defend myself preemptively. The shame is mine to carry."
+
+### New Self Script: The Self-Owned
+
+"The shame was assigned, not earned. I can put down what isn't mine. I am not what I was called. I can make mistakes without being a mistake. I belong to myself."
+
+---
+
+### Old Self Script: The Caretaker
+
+"Their feelings are my responsibility. I must anticipate and prevent their distress. My needs come last—or not at all. Focusing on myself is selfish. I only feel safe when everyone else is settled."
+
+### New Self Script: The Self-Attendant
+
+"Their feelings are theirs to feel. I can notice without managing. My needs matter as much as anyone's. Self-attention is not selfishness. I can be settled while others are not."
+
+---
+
+## The Identity Transition Map
+
+Identity change doesn't happen all at once. It moves through stages:
+
+### Stage 1: Recognition
+
+You see the old identity clearly. You name it. You understand where it came from.
+
+*"Oh. I've been the rescuer. This is why I'm exhausted."*
+
+### Stage 2: Experimentation
+
+You try new responses. It feels awkward, performative, wrong. You don't know who you are.
+
+*"I said no. It felt terrible. I wanted to take it back immediately."*
+
+### Stage 3: Turbulence
+
+The old identity fights for survival. Others react to your change. You doubt the work.
+
+*"Everyone is upset with me. Maybe I was better before. Maybe I should go back."*
+
+### Stage 4: Grief
+
+You feel the loss of the old identity. You mourn who you were, even if they were suffering.
+
+*"I miss being the good one. At least I knew who I was."*
+
+### Stage 5: Integration
+
+The new identity becomes natural. The old one visits but doesn't run the show. You are both—and neither.
+
+*"I'm still kind. But I'm not compulsively kind. There's a difference."*
+
+### Stage 6: Embodiment
+
+You forget you're practicing. The new identity is just who you are now. The old one feels like a past life.
+
+*"I can't imagine living the way I used to. That person is gone."*
 
 ---
 
@@ -204,12 +391,16 @@ The declaration means nothing without action. Each time the old identity activat
 
 Signs the shift is becoming embodied:
 
-- You notice the old pattern activating—and choose differently
+- You notice the old pattern activating—and choose differently without heroic effort
 - The old identity feels strange, like clothes that no longer fit
 - You can name the old role without being captured by it
 - Others respond to you differently—because you're different
 - Under stress, you recover to the new pattern faster
 - The new way requires less effort
+- You surprise yourself with responses you didn't plan
+- People who knew the old you seem confused
+- The guilt that used to accompany change has softened
+- You can remember being the old identity without longing for it
 
 ---
 
@@ -220,16 +411,53 @@ They will. Especially:
 - In old contexts (family, certain relationships)
 - When activated by familiar triggers
 - When you're depleted
+- During illness or exhaustion
+- In the presence of people from your past
+- When someone really needs you and you could slip into the old role
+- When someone criticizes the new you
 
 **The response:**
 
 **Notice:** "There's the old identity."
 
-**Name:** "That's the rescuer trying to run again."
+Don't shame yourself for noticing. The noticing IS the practice.
+
+**Name:** "That's the rescuer trying to run again." "That's the good one trying to accommodate." "That's the invisible one trying to shrink."
+
+Naming creates distance. You're observing the pattern, not being the pattern.
 
 **Choose:** "I'm not available for that anymore."
 
+This is an internal statement. You don't have to say it out loud. But you need to say it to yourself.
+
 **Return:** To the present. To the body. To who you actually are now.
+
+Feel your feet. Take a breath. Remember: You are not who you were trained to be. You are who you're becoming.
+
+---
+
+## Working with Relapse
+
+The old identity will win sometimes. You will find yourself rescuing when you said you wouldn't. Accommodating when you meant to hold the boundary. Performing when you wanted to just be.
+
+**This is not failure. This is the work.**
+
+**When you "relapse" into old identity:**
+
+**1. Don't catastrophize.**
+One slip doesn't undo the work. Neural pathways don't reset that easily. You haven't gone backward—you've had a moment.
+
+**2. Get curious, not critical.**
+What triggered it? What need was the old identity trying to meet? What was the situation asking for that the new identity doesn't yet know how to provide?
+
+**3. Make the repair internal.**
+*"I see that I slipped into rescuing. That's old wiring. I'm learning. I can choose differently next time."*
+
+**4. Notice the recovery time.**
+Progress isn't never slipping—it's recovering faster. How long did it take you to notice? How long did it take you to return to yourself?
+
+**5. Strengthen the new pathway.**
+What would the new identity have done in that situation? Rehearse it mentally. Let your brain practice the alternative, even after the fact.
 
 ---
 
@@ -239,13 +467,47 @@ Once a week, check in with the transition:
 
 **Question 1:** Where did the old identity activate this week?
 
+Be specific. Name the moment, the context, the trigger.
+
 **Question 2:** Did I notice it? What happened?
+
+Was I able to observe the activation? Did I get swept up, or could I choose?
 
 **Question 3:** Where did the new identity feel natural?
 
+Celebrate these moments. They're evidence that the work is working.
+
 **Question 4:** What does the new identity need to become stronger?
 
+Is there a skill it needs? A belief it needs to let go of? A practice it needs?
+
 **Question 5:** What support do I need from my environment?
+
+Are there contexts that make the old identity more likely to activate? Are there relationships that need adjustment? Are there structures that would help?
+
+---
+
+## The Role of Relationships in Identity Transition
+
+Here's the uncomfortable truth: **some relationships were built around your old identity.**
+
+People who knew you as the rescuer may not know how to relate to you when you stop rescuing. People who depended on your accommodation may feel abandoned when you start having needs.
+
+**What you might encounter:**
+
+- Confusion: "You've changed. What happened to you?"
+- Resistance: "This isn't the real you. The real you would help."
+- Accusation: "You've become selfish." "You're not the person I knew."
+- Grief: Others mourning the version of you they needed
+- Distance: Relationships that can't survive your growth
+
+**What to remember:**
+
+Not every relationship will survive your identity transition. That's not your failure. That's information about what the relationship was actually based on.
+
+The relationships that can grow with you will. The ones that depended on your dysfunction won't.
+
+**This is painful.** And it's also clarifying.
 
 ---
 
@@ -255,8 +517,11 @@ Once a week, check in with the transition:
 - Where does it activate most strongly?
 - What new identity am I stepping into?
 - What would I be available for if I let the old identity go?
+- What might I lose if I change? What might I gain?
+- Who in my life is attached to my old identity?
+- What does my body feel when I imagine the new identity being fully mine?
 
-**Body cue to notice:** The familiar pull of old patterns, the strangeness of new ones
+**Body cue to notice:** The familiar pull of old patterns, the strangeness of new ones, the grief that accompanies growth
 
 **Practice:** "I am no longer available for..." (daily as needed)
 
@@ -272,17 +537,23 @@ Once a week, check in with the transition:
 
 You are not your patterns.
 
-You're not the rescuer, the good one, the performer, the scapegoat, the invisible one.
+You're not the rescuer, the good one, the performer, the scapegoat, the invisible one, the caretaker.
 
-These were roles you took on to survive. They served a purpose. They kept you safe.
+These were roles you took on to survive. They served a purpose. They kept you safe. They got you through environments that weren't designed for your flourishing.
 
 But you're not in that environment anymore. And you don't need those roles now.
 
 The invitation is not to become someone new. It's to stop being someone you never were.
 
-Underneath the roles is you. The actual you. The one who was there before the adaptations.
+Underneath the roles is you. The actual you. The one who was there before the adaptations, before the survival strategies, before the identities formed.
 
 That person gets to live now.
+
+They've been waiting.
+
+They're ready.
+
+And so are you.
 
 ---
 

--- a/book/vol-4-embodied-leadership/chapters/14-embodied-leadership-life.md
+++ b/book/vol-4-embodied-leadership/chapters/14-embodied-leadership-life.md
@@ -20,9 +20,11 @@ She's been learning for years.
 
 Books. Workshops. Retreats. Therapy. Coaches.
 
-Each time she thinks she's arrived, another layer appears.
+Each time she thinks she's arrived, another layer appears. Another wound to heal. Another pattern to address. Another level of consciousness to attain.
 
 She wonders when she'll finally be done. When she'll have learned enough. When she'll feel ready.
+
+She keeps waiting for the moment when she'll finally feel solid enough to live without a teacher, a book, a guide telling her what to do next.
 
 ---
 
@@ -34,9 +36,31 @@ But she's stopped seeking completion.
 
 The work is no longer preparation for life. It is life.
 
-Family dinner is the practice. The morning commute is the practice. The difficult conversation is the practice.
+Family dinner is the practice. The morning commute is the practice. The difficult conversation is the practice. The quiet moment before sleep is the practice.
 
 She's not waiting to become who she'll be. She's being who she is.
+
+When books appear, she reads them—not to fix herself, but for the pleasure of learning. When teachers appear, she learns—not because she's broken, but because she's curious.
+
+The seeking is over. The living has begun.
+
+---
+
+## The End of Seeking
+
+There is a particular exhaustion that comes from perpetual self-improvement.
+
+The belief that there's always one more layer. One more wound. One more level. That you're never quite ready for actual life because the preparation isn't complete.
+
+**This seeking can become its own trap.**
+
+The eternal student never becomes the practitioner. The always-healing person never becomes the healed one. The perpetually growing self never simply exists.
+
+**At some point, the seeking must end.** Not because you're done growing—you never will be. But because the seeking itself can become a way of avoiding life.
+
+You're ready. You've been ready. The preparation is over.
+
+What remains is living.
 
 ---
 
@@ -48,28 +72,95 @@ The dojo is everywhere:
 - Holding boundaries with those who taught you to have none
 - Staying regulated when old patterns activate
 - Loving without losing yourself
+- Returning to your own ground after absorbing their chaos
+- Speaking truth without requiring them to change
+- Letting them have their reactions without managing them
+- Visiting without collapsing, leaving without guilt
 
 **In work:**
 - Leading without performing
 - Staying grounded in group dynamics
 - Speaking truth without requiring agreement
+- Holding authority without needing compliance
+- Receiving criticism without collapsing
+- Offering feedback without attacking
+- Being present in meetings instead of managing impression
+- Trusting your competence instead of proving it
 
 **In partnership:**
 - Intimacy without collapse
 - Conflict without abandonment
 - Closeness without fusion
+- Desire without urgency
+- Repair without over-apologizing
+- Receiving without owing
+- Speaking needs without demanding
+- Holding difference without distance
 
 **In community:**
 - Showing up without shrinking
 - Contributing without performing
 - Holding space without rescuing
+- Belonging without merging
+- Being seen without curating
+- Disagreeing without leaving
+- Leading when needed, following when not
 
 **In solitude:**
 - Sitting with yourself without distraction
 - Feeling without numbing
 - Being without doing
+- Resting without guilt
+- Enjoying your own company
+- Trusting your own mind
+- Being quiet without anxiety
 
-Every context is practice. Every interaction is teaching you something.
+Every context is practice. Every interaction is teaching you something. Every moment is an opportunity to live what you've learned.
+
+---
+
+## What Living From Sovereignty Actually Looks Like
+
+Living from sovereignty is not about being unbothered. It's about being unhooked.
+
+**You may notice:**
+
+- You still feel triggered—but you don't follow the trigger into reaction
+- You still care what people think—but you don't rearrange yourself because of it
+- You still feel the pull of old patterns—but you don't let them drive
+- Conflict still hurts—but it doesn't annihilate you
+- Rejection still stings—but it doesn't define you
+- Intimacy still involves vulnerability—but not self-loss
+
+**The shift isn't from feeling to not feeling.** The shift is from being controlled by feeling to being informed by it.
+
+You're still human. Still sensitive. Still affected by the world.
+
+You're just not lost in it anymore.
+
+---
+
+## The Ordinary Day
+
+Nothing dramatic happens.
+
+She wakes. She feels her body. She scans: where am I starting today?
+
+There's a meeting later that used to activate her. She notices a small contraction when she thinks of it. She breathes. Doesn't fight it. Doesn't amplify it.
+
+She moves through the morning. Present. Not performing presence—just present.
+
+At the meeting, someone challenges her. Old pattern flickers: defend. Explain. Convince. She notices. Breathes. Speaks from ground instead.
+
+"I see it differently. Here's why."
+
+No drama. No collapse. No victory lap. Just clarity.
+
+Evening comes. She's tired but not depleted. The day took energy but didn't take her.
+
+She rests. Actually rests. Not scrolling, not processing, not preparing for tomorrow. Just resting.
+
+This is what it looks like. Not the dramatic transformation. The ordinary living.
 
 ---
 
@@ -77,36 +168,53 @@ Every context is practice. Every interaction is teaching you something.
 
 Sustainability requires maintenance—especially in high-contact systems.
 
-### Daily Practices
+You wouldn't expect your car to run indefinitely without oil changes. You wouldn't expect your home to stay clean without attention. Your field works the same way.
+
+### Daily Practices (10-15 minutes total)
 
 **Morning:**
-- 60-second field scan
-- Pre-day seal
-- State check: Where am I starting?
+- 60-second field scan: Where am I starting?
+- Pre-day seal: I can perceive without absorbing
+- State check: What does today need from me?
+- Intention: One word or phrase to anchor the day
 
 **Throughout:**
-- State awareness (continuous)
+- State awareness (continuous—build the habit of checking in)
 - Regulated breathing before high-stakes moments
 - Return to sender (as needed)
+- Micro-resets: 30 seconds of grounding when activated
 
 **Evening:**
-- Post-day clearing
-- Energy audit: What did I absorb?
+- Post-day clearing: What did I absorb that isn't mine?
+- Energy audit: What took more than it should?
 - Gratitude for one sovereign moment
+- Release: I put down what is not mine to carry overnight
 
-### Weekly Practices
+### Weekly Practices (1-2 hours total)
 
-- Cord check
-- Longer regulation practice (yoga, meditation, nature)
-- Digital audit
-- Relationship review: Where did I lose myself?
+- Cord check: Who am I thinking about without choosing to?
+- Longer regulation practice: yoga, meditation, nature, movement
+- Digital audit: What am I consuming that leaves me worse?
+- Relationship review: Where did I lose myself this week?
+- Celebration: Where did I stay grounded?
+- Adjustment: What needs attention next week?
 
-### Monthly Practices
+### Monthly Practices (2-4 hours)
 
-- Full hygiene reset
-- Relationship audit template
-- Identity check: What patterns returned?
-- Environment clearing
+- Full hygiene reset: Physical, digital, energetic
+- Relationship audit template: Review key relationships
+- Identity check: What old patterns returned?
+- Environment clearing: Physical space, digital space
+- Goal review: Am I living aligned with what matters?
+- Body check: What is my body trying to tell me?
+
+### Quarterly Practices (Half day)
+
+- Deeper retreat: Extended silence, nature, or solitude
+- Life audit: Am I becoming who I want to be?
+- Relationship inventory: What relationships need adjustment?
+- Purpose check: Am I on track?
+- Celebration: How far have I come?
 
 ---
 
@@ -116,47 +224,57 @@ Use this every week to track how you're living the work.
 
 **Question 1: Where did I stay sovereign this week?**
 
-Name specific moments. Celebrate them.
+Name specific moments. Don't skip this. It's easy to focus on failures and miss successes. Naming what worked reinforces the neural pathways of what worked.
 
 **Question 2: Where did I lose myself?**
 
-Not to shame—to learn. What triggered it? What would you do differently?
+Not to shame—to learn. What triggered it? What would you do differently? What need was unmet that made you vulnerable?
 
 **Question 3: Where did old patterns run?**
 
-Did you notice? How quickly did you return?
+Did you notice? How quickly did you return? Progress isn't avoiding the patterns—it's noticing them faster and returning sooner.
 
 **Question 4: What boundaries held? What boundaries softened?**
 
-Track both successes and slips.
+Track both successes and slips. Look for patterns. Are certain relationships consistently difficult? Are certain contexts always depleting?
 
 **Question 5: What does next week need from me?**
 
-Set one intention. Keep it simple.
+Set one intention. Keep it simple. One thing to practice, one thing to be aware of, one thing to protect.
 
 ---
 
 ## The Relationship Audit Template
 
-Review your key relationships quarterly.
+Review your key relationships quarterly. This isn't about judging people—it's about being honest about what relationships are doing to your nervous system.
 
 **For each significant relationship:**
 
 **1. Do I feel more me around this person, or less?**
 
+This is the core question. Does this relationship enhance or diminish your sense of self?
+
 **2. Is the energy mutual, or draining?**
+
+Some relationships are reciprocal—you give, they give. Some are consistently one-directional. Neither is necessarily wrong, but you should know what you're choosing.
 
 **3. Are my boundaries respected?**
 
+When you set boundaries, do they honor them? Do they push back? Do they guilt you? Do they pretend to agree and then ignore?
+
 **4. Can we hold difference without distance?**
+
+Can you disagree and stay connected? Or does conflict create rupture that never fully repairs?
 
 **5. Is this relationship asking me to abandon myself to maintain it?**
 
+The hardest question. Some relationships only survive if you remain small, accommodating, or performing. That's information.
+
 **Decision:**
-- Continue as is
-- Adjust (with conversation)
-- Reduce contact
-- End
+- Continue as is: The relationship is healthy, or healthy enough
+- Adjust (with conversation): Something needs to change, and I'm willing to ask for it
+- Reduce contact: The relationship is more depleting than nourishing; I need distance
+- End: The relationship is fundamentally incompatible with who I'm becoming
 
 ---
 
@@ -168,19 +286,24 @@ Old patterns will run. Boundaries will soften. Sovereignty will waver.
 
 **This is not failure. It's practice.**
 
+The question isn't whether you'll slip—you will. The question is how you respond when you do.
+
 **When you slip:**
 
 **1. Notice without shame.**
-"There I went again." Not "I'm terrible."
+"There I went again." Not "I'm terrible." Not "I'll never change." Just simple noticing. The slip already happened. Shame won't undo it.
 
 **2. Investigate with curiosity.**
-What triggered it? What did I need that I didn't have? What was I avoiding?
+What triggered it? What did I need that I didn't have? What was I avoiding? What was the situation asking for that I couldn't provide from sovereignty?
 
 **3. Reset without drama.**
-Return to your practices. Begin again. Today.
+Return to your practices. Begin again. Today. Not Monday. Not after you've processed enough. Today.
 
 **4. Learn for next time.**
-What can I do differently when this arises again?
+What can I do differently when this arises again? What support do I need? What preparation would help?
+
+**5. Celebrate the noticing.**
+Every time you notice a slip, you're practicing awareness. That awareness is the foundation of change. You can't change what you can't see.
 
 ---
 
@@ -192,18 +315,26 @@ Change happens slowly. Then suddenly.
 - The practices feel effortful
 - The old patterns are strong
 - Sovereignty requires constant attention
+- Every choice feels like a battle
+- You wonder if you're making progress at all
 
 **Over time:**
 - The practices become natural
 - The old patterns weaken
-- Sovereignty becomes default
+- Sovereignty becomes easier to access
+- More choices feel automatic
+- Others start noticing the change before you do
 
 **Eventually:**
 - You forget you're practicing
 - The new patterns are who you are
 - Sovereignty is just how you move
+- The old patterns feel foreign
+- You can't imagine living the way you used to
 
 **Trust the arc.** You're further along than you realize.
+
+Progress isn't always visible in the moment. It's visible over months. Over years. You're playing a long game.
 
 ---
 
@@ -215,6 +346,8 @@ Not everyone around you is on this path.
 - Some people will activate you
 - Some relationships have limits
 - Some contexts require extra regulation
+- Some people will not understand what you're doing
+- Some people will resist your change
 
 **Your sovereignty doesn't depend on theirs.**
 
@@ -223,6 +356,33 @@ You can:
 - Hold boundaries without explanations
 - Limit exposure when needed
 - Love from a distance when close contact costs too much
+- Release expectations that they will change
+
+**Important:** You are not responsible for their growth. You can invite. You can model. You can share. But you cannot do their work for them.
+
+And they are not responsible for adjusting to your growth. Some will resent it. Some will celebrate it. Most will be confused by it.
+
+Let them have their response. It's theirs.
+
+---
+
+## The Paradox of Less Effort
+
+Here's what no one tells you: **the further you go, the easier it gets.**
+
+In the beginning, sovereignty feels like constant work. Vigilance. Effort. Attention.
+
+But over time, something shifts. The new patterns become automatic. The old patterns require effort to maintain.
+
+You stop trying to be sovereign. You just are.
+
+You stop practicing presence. You're just present.
+
+You stop working on your field. It's just clean.
+
+**This isn't complacency. It's integration.**
+
+The practices aren't abandoned—they're absorbed. They've become who you are rather than what you do.
 
 ---
 
@@ -234,21 +394,58 @@ You've done the work. What becomes possible?
 - Intimacy without collapse
 - Closeness without fusion
 - Love without self-abandonment
+- Conflict without annihilation
+- Trust without naivety
+- Receiving without owing
 
 **Work:**
 - Leadership without performance
 - Influence without manipulation
 - Authority without armor
+- Excellence without perfectionism
+- Contribution without exhaustion
+- Visibility without curating
 
 **Community:**
 - Presence without shrinking
 - Contribution without exhaustion
 - Belonging without losing yourself
+- Leadership without needing to lead
+- Following without losing voice
+- Connection without merger
 
 **Life:**
 - Desire without urgency
 - Choice without fear
 - Being without performing
+- Feeling without drowning
+- Solitude without loneliness
+- Joy without waiting for the other shoe
+
+---
+
+## The Integration of Sexuality
+
+Something specific becomes possible with your sexuality:
+
+**Your desire belongs to you now.**
+
+It's no longer:
+- A negotiation tool
+- A survival strategy
+- A way to secure attachment
+- A performance for approval
+- An escape from feeling
+
+It's simply: desire. Yours. To feel, to follow, or to let pass—all by choice.
+
+**Your body is your home now.**
+
+Not something you escape during intimacy. Not something you trade for connection. Not something that belongs to others more than to you.
+
+You can be present during sex. You can feel pleasure without dissociating. You can say no without guilt and yes without obligation.
+
+**This is no small thing.** For many, this is the deepest reclamation of all.
 
 ---
 
@@ -267,6 +464,10 @@ Whatever brought you to this path—the relationship that broke you, the family 
 To this moment. To this version of yourself.
 
 **You are no longer who you were. And you are more yourself than ever.**
+
+The pain was not wasted. The years of struggle were not wasted. Every difficult moment was teaching you something you needed to know.
+
+And here you are. On the other side. Changed.
 
 ---
 
@@ -294,9 +495,35 @@ If you wish, make this commitment to yourself:
 
 *I commit to living as the embodiment of what I now know.*
 
+*I commit to being who I am, not who I was trained to be.*
+
+*I commit to letting the work become my life.*
+
 *This is my life now.*
 
 *And I am ready.*
+
+---
+
+## The Daily Anchor
+
+Use this each morning, if you need a touchstone:
+
+*Today, I move from my own center.*
+
+*I can feel the room without becoming the room.*
+
+*I can care without carrying.*
+
+*I can be seen without performing.*
+
+*I am not my patterns.*
+
+*I am who I am becoming.*
+
+*Today, the dojo is everywhere.*
+
+*And I am the practice.*
 
 ---
 
@@ -306,6 +533,8 @@ If you wish, make this commitment to yourself:
 - What do you carry forward from here?
 - What commitment will you make?
 - What practice will you maintain?
+- What has become possible that wasn't before?
+- Who are you now that you weren't when you started?
 
 ---
 
@@ -331,17 +560,27 @@ In the morning. At the meeting. In the argument. In the silence. In the intimacy
 
 Not in the reading. In the being.
 
+Not in the understanding. In the doing.
+
+Not in the knowing. In the living.
+
 Thank you for walking this far. Thank you for doing the work.
 
 Now go live it.
 
 ---
 
+## The Final Words
+
 *"My presence is erotic when it belongs to me."*
 
 *"My power is clean when I'm not seeking."*
 
 *"My life is mine—to inhabit, to feel, to choose."*
+
+*"I am not who I was trained to be. I am who I actually am."*
+
+*"The seeking is over. The living has begun."*
 
 ---
 


### PR DESCRIPTION
- Chapter 13: Added identity residues section with 7 identity types, neuroscience of identity transition, grief of letting go, identity transition map, and working with relapse
- Chapter 14: Expanded daily life as dojo, maintenance plan with daily/weekly/monthly/quarterly practices, relationship audit template, and integration of sexuality section
- Appendix A: Comprehensive field hygiene menu with emergency, daily, extended, weekly, and monthly practices
- Appendix B: Detailed consent ladder with body signals, color system, partner communication scripts, and signal reclamation
- Appendix C: Complete scripts collection for boundaries, intimacy, repair, group dynamics, identity release, and daily mantras
- Appendix D: 16 decoder cards covering all major concepts with quick reference tables and integration lines
- Appendix E: Comprehensive sexuality self-check with 8 sections, interpretation guide, and reflection prompts