### PR TITLE
📚 Expand and deepen Volume 3 chapters 1-4

### DIFF
--- a/book/vol-3-sovereignty/chapters/01-opening-manifesto.md
+++ b/book/vol-3-sovereignty/chapters/01-opening-manifesto.md
@@ -36,6 +36,29 @@ Not because they lacked capacity — but because capacity without safety is not 
 
 ---
 
+## The Hidden Architecture of Hyper-Vigilance
+
+What looks like indecision is often something else entirely.
+
+It is a nervous system running thousands of calculations per second:
+
+- *If I choose this, will they be disappointed?*
+- *If I speak first, will I be blamed?*
+- *If I want something, will I owe something?*
+- *If I'm wrong, will I be abandoned?*
+
+This is not overthinking. This is survival architecture.
+
+The child who learned that their preferences created conflict did not become weak. They became extraordinarily skilled at reading rooms, anticipating needs, and preemptively adjusting.
+
+These skills kept them safe. But safety is not sovereignty.
+
+Sovereignty asks: *What if I could choose without calculating the cost to everyone else first?*
+
+That question feels dangerous because it once was.
+
+---
+
 ## Field Note: The Question That Changed Everything
 
 The moment I understood sovereignty was not a moment of power.
@@ -59,6 +82,32 @@ The next morning, I woke up and asked myself a question I'd never asked before:
 *"What if the discomfort of choosing for myself is the price of becoming myself?"*
 
 That question started everything that follows.
+
+---
+
+## Field Note: The Dinner Invitation
+
+Let me share another moment—smaller, but just as revealing.
+
+A friend invited me to dinner. I wanted to say no. I was tired. I needed rest.
+
+Instead of answering, I noticed myself doing something strange: I began constructing reasons.
+
+*I could say I have a deadline.*
+*I could say I'm not feeling well.*
+*I could say I have other plans.*
+
+None of these were true. The truth was simpler: I wanted to stay home.
+
+But "I want to stay home" felt insufficient. It felt selfish. It felt like something that required justification.
+
+So I began building a case—not for her, but for myself. As if my own preference needed a defense attorney.
+
+That moment taught me something crucial:
+
+**When you cannot say "no" without a reason, you have outsourced your authority.**
+
+The work of sovereignty is reclaiming the right to choose without presenting evidence.
 
 ---
 
@@ -98,6 +147,28 @@ It is not about dominating a space. It is about **inhabiting your own**.
 
 ---
 
+## The Paradox of Arrival
+
+Here is something no one tells you about healing:
+
+When you finally arrive at safety, it doesn't feel safe.
+
+After years of chaos, intensity, and emotional labor, calm feels suspicious. Rest feels dangerous. Stillness feels like waiting for the other shoe to drop.
+
+This is not regression. This is the paradox of arrival.
+
+Your nervous system was calibrated for emergency. It learned to interpret adrenaline as normal and peace as precursor to threat. Now that the emergency has passed, the system doesn't know what to do.
+
+It asks: *Where is the danger? Why isn't anyone upset? What am I missing?*
+
+These questions are not failures of healing. They are evidence that healing is incomplete.
+
+The final stage is not surviving chaos—it is tolerating peace.
+
+Sovereignty is what emerges when peace finally feels safe.
+
+---
+
 ## Who This Book Is For
 
 I wrote this for those who:
@@ -109,6 +180,10 @@ I wrote this for those who:
 - Mistake neutrality for failure
 - Have done the healing work but don't know how to stand in the cleared space
 - Are ready to stop shrinking—without becoming someone they're not
+- Find themselves apologizing for preferences
+- Over-explain every decision
+- Feel relief when someone else takes charge
+- Wonder if they'll ever feel "ready"
 
 This is not a book that asks you to be bigger.
 
@@ -131,10 +206,38 @@ Sovereignty is **not**:
 - Independence disguised as protection
 - Spiritual bypass disguised as detachment
 - Dominance disguised as leadership
+- Rigidity disguised as strength
+- Isolation disguised as self-sufficiency
+- Certainty disguised as wisdom
 
 People who came from controlling environments often fear becoming what they escaped. This fear is valid. But sovereignty is not the opposite of enmeshment—it's the resolution of it.
 
+**The opposite of enmeshment is avoidance.**
+**The resolution of enmeshment is differentiation.**
+
+Avoidance says: "I can't be close to anyone because I'll lose myself."
+Differentiation says: "I can be close without disappearing."
+
 Sovereignty is not about not needing anyone. It's about needing without losing yourself.
+
+---
+
+## The Spectrum of Healing
+
+Most people imagine healing as a destination. It's more accurate to understand it as a spectrum with three stages:
+
+**Stage 1: Recognition**
+You name what happened. You understand the patterns. You recognize manipulation, emotional immaturity, and narcissism for what they are. This is cognitive work—the work of seeing clearly.
+
+**Stage 2: Regulation**
+You retrain your nervous system. You learn to tolerate safety, build secure attachment, and repair the neurological damage of chronic stress. This is somatic work—the work of feeling differently.
+
+**Stage 3: Sovereignty**
+You learn to live from the healed place. You make choices without fear of blame. You lead without performing. You rest without guilt. This is integration work—the work of being differently.
+
+This book lives in Stage 3.
+
+You've done the seeing. You've done the feeling. Now comes the being.
 
 ---
 
@@ -151,11 +254,36 @@ The **prefrontal cortex** (decision-making) and the **limbic system** (emotional
 - **Prefrontal:** "I'm allowed to choose for myself."
 - **Limbic:** "Choosing for yourself leads to rejection."
 
+This is called **neural incongruence**—when different parts of the brain hold contradictory beliefs.
+
+The prefrontal cortex can update quickly through insight. The limbic system updates slowly through experience. This is why you can understand sovereignty intellectually while your body still resists it.
+
 Sovereignty requires updating the limbic system through repeated experience—not through insight alone.
 
 **Key insight:** Your mind may be ready for sovereignty. Your body may still be catching up.
 
 **Translation:** Go slowly. Practice small sovereignty. Let your nervous system update through experience.
+
+---
+
+## The Neuroscience of Delayed Self-Trust
+
+Here's what happens in the brain when you've been conditioned to defer to others:
+
+**The anterior cingulate cortex (ACC)**, which monitors for conflict between what you want and what others expect, becomes hyperactive. It flags every personal preference as a potential threat.
+
+**The default mode network (DMN)**, which processes self-referential thinking, becomes dysregulated. Instead of helping you understand your own preferences, it runs simulations of how others will react.
+
+**The ventromedial prefrontal cortex (vmPFC)**, which integrates emotion and decision-making, struggles to complete decisions because it's constantly interrupted by social threat signals.
+
+This is why decision-making feels so exhausting for people who grew up managing others' emotions. Your brain is running three times as many calculations as necessary—not about the decision itself, but about its social implications.
+
+Sovereignty training helps these systems recalibrate:
+- The ACC learns that self-choice doesn't equal danger
+- The DMN returns to self-reference rather than other-reference
+- The vmPFC completes decision loops without threat interruption
+
+This takes time. It takes practice. And it takes patience with yourself.
 
 ---
 
@@ -169,17 +297,38 @@ You are the final word in your own life.
 
 This doesn't mean you ignore input or isolate from others. It means your decisions don't require external permission to be valid.
 
+Internal authority is the capacity to:
+- Trust your own judgment
+- Make decisions without excessive consultation
+- Hold positions without defending them
+- Change your mind without shame
+- Say "I don't know" without losing confidence
+
 ### 2. Aura Boundaries
 
 What is yours to carry, and what is not.
 
 Empathy without absorption. Presence without entanglement. Connection without collapse.
 
+Aura boundaries are the capacity to:
+- Feel others' emotions without taking them on
+- Stay present without becoming responsible
+- Witness pain without needing to fix it
+- Maintain clarity in emotional fields
+- Keep your center when others are dysregulated
+
 ### 3. Embodied Leadership
 
 Leadership as presence, not performance.
 
 Influence through steadiness, not force. Authority that comes from self-connection, not certainty.
+
+Embodied leadership is the capacity to:
+- Hold space without managing it
+- Influence without pushing
+- Speak without over-explaining
+- Remain grounded when challenged
+- Lead through example, not demand
 
 ---
 
@@ -197,6 +346,27 @@ And the ground beneath you is solid.
 
 ---
 
+## Common Misconceptions
+
+As you enter this work, you may encounter some beliefs that need updating:
+
+**Misconception 1: "Sovereignty means never needing help."**
+Truth: Sovereignty means knowing when to ask and asking without shame.
+
+**Misconception 2: "Boundaries mean keeping people out."**
+Truth: Boundaries mean knowing where you end and others begin.
+
+**Misconception 3: "Leadership requires certainty."**
+Truth: Leadership requires presence. Certainty is often a performance.
+
+**Misconception 4: "If I'm still struggling, I haven't healed enough."**
+Truth: Sovereignty is not the absence of struggle. It's how you meet struggle.
+
+**Misconception 5: "I should feel ready before I begin."**
+Truth: Readiness is a feeling that often arrives after you start.
+
+---
+
 ## The Promise
 
 By the end of this book, you will know:
@@ -207,6 +377,10 @@ By the end of this book, you will know:
 - How to care without carrying
 - How to separate without guilt
 - How to desire without fear
+- How to rest without earning it
+- How to hold your ground without force
+- How to influence without manipulation
+- How to be steady without being rigid
 
 Not because you became bigger.
 
@@ -223,6 +397,8 @@ Each chapter builds capacity, not just understanding. The exercises are not opti
 Some chapters will activate you. That's intentional. Sovereignty is built by staying present when discomfort arises—not by avoiding it.
 
 **Suggestion:** Read one chapter, then practice it for a few days before moving on. Let your body integrate what your mind understands.
+
+**Warning:** Your nervous system may resist this work. That resistance is not a sign you're doing it wrong—it's a sign you're doing it right. Go slowly. Honor your pace. Return when you're ready.
 
 ---
 
@@ -241,6 +417,36 @@ This structure is intentional. Sovereignty isn't learned through reading—it's 
 
 ---
 
+## A Practice Before You Begin: The Sovereignty Inventory
+
+Before moving forward, take stock of where you are.
+
+Answer honestly—not where you want to be, but where you actually are:
+
+**Decision-Making:**
+- Do I regularly ask others what I should do?
+- Do I feel anxious when I have to decide alone?
+- Do I over-research before simple choices?
+- Do I change my mind based on others' reactions?
+
+**Emotional Boundaries:**
+- Do I feel responsible for others' moods?
+- Do I feel drained after being with certain people?
+- Do I find it hard to know what I feel versus what others feel?
+- Do I absorb tension in a room?
+
+**Self-Authority:**
+- Do I apologize for my preferences?
+- Do I over-explain my choices?
+- Do I wait for permission before acting?
+- Do I doubt myself when someone disagrees?
+
+Notice your answers without judgment. This is your starting point.
+
+You'll revisit this inventory at the end of the book.
+
+---
+
 ## Reader Reflection
 
 Before you begin, take a moment to consider:
@@ -249,6 +455,8 @@ Before you begin, take a moment to consider:
 - What do you hope will be different when you finish?
 - Where do you feel you lack sovereignty—not in theory, but in daily life?
 - What would change if you trusted yourself completely?
+- What are you afraid might happen if you stopped deferring to others?
+- What would you choose if no one's feelings were at stake?
 
 You don't need to answer these now. Just hold them as you read.
 
@@ -274,7 +482,12 @@ You've done the hard work of recognition and healing.
 
 Now begins the quieter work: becoming who you already are.
 
+This work is not about transformation. It's about revelation—uncovering what was always there beneath the conditioning.
+
+You are not building sovereignty from scratch.
+
+You are removing what obscured it.
+
 ---
 
 **[Continue to Chapter 2: When No One Else Decides →](./02-installing-internal-authority.md)**
-

--- a/book/vol-3-sovereignty/chapters/02-installing-internal-authority.md
+++ b/book/vol-3-sovereignty/chapters/02-installing-internal-authority.md
@@ -59,23 +59,80 @@ Nothing bad happens.
 
 ---
 
+## Field Note: The Restaurant
+
+He sits across from his partner, staring at the menu.
+
+"What do you want?" she asks.
+
+He scans her face. What does she want? What would make her happy? What choice would create harmony?
+
+"I don't mind," he says. "You pick."
+
+She sighs. "You always do that."
+
+He doesn't know how to explain that the question "what do you want?" sends his nervous system into calculation mode. His preference is not available until he knows hers. His desire is conditional on whether it will create friction.
+
+Later that night, alone in the kitchen, he realizes he did have a preference. He wanted the salmon. He just couldn't access it in the moment.
+
+His preferences had become encrypted—only readable after the relational stakes had passed.
+
+---
+
 ## The Hidden Contract You Were Trained Under
 
 Many people were raised under an unspoken agreement:
 
 > *You may choose — as long as your choice does not inconvenience, upset, or destabilize anyone else.*
 
+This contract seems reasonable on the surface. It sounds like consideration, like kindness.
+
+But hidden inside it is a trap:
+
+Your choices are only valid when they don't cause discomfort.
+
 Over time, this teaches the nervous system that:
 
 - Responsibility leads to blame
 - Autonomy leads to guilt
 - Authority leads to punishment
+- Preferences lead to conflict
+- Wanting leads to owing
 
 So the system adapts.
 
 It learns to wait. To scan. To minimize impact. To choose safety over preference.
 
 Not because it lacks strength — but because it learned that staying small kept the peace.
+
+---
+
+## The Anatomy of the Hidden Contract
+
+Let's break down what this contract actually installs:
+
+**Clause 1: Your needs are negotiable.**
+Your preferences are suggestions, not rights. They can be overruled by anyone else's comfort.
+
+**Clause 2: Their feelings are your responsibility.**
+If they react negatively to your choice, you caused that. You must prevent it or fix it.
+
+**Clause 3: Harmony is more important than honesty.**
+Peace at any cost—including the cost of your own truth.
+
+**Clause 4: Good people don't make waves.**
+Wanting something that creates friction means you're selfish, difficult, or wrong.
+
+**Clause 5: Approval must be earned.**
+You don't get to exist freely. You must prove you deserve permission.
+
+This contract was never written down. It was absorbed through repeated experience:
+- The disappointed sigh when you made your own choice
+- The cold silence after you expressed a need
+- The explosion that followed your independence
+- The withdrawal of love when you failed to anticipate
+
+These experiences taught your nervous system: *Choice is dangerous. Authority is punished. Stay small to stay safe.*
 
 ---
 
@@ -103,6 +160,29 @@ That doesn't mean you're failing. It means you're early.
 
 ---
 
+## The Disorientation of Freedom
+
+There's a particular kind of vertigo that arrives when you realize:
+
+*No one is going to tell me what to do.*
+
+For most people, this sounds liberating. For those who learned to orient around others, it feels like standing at the edge of a cliff without a railing.
+
+The questions flood in:
+- *What if I choose wrong?*
+- *What if they're disappointed?*
+- *What if this is the wrong decision?*
+- *What if I regret it?*
+- *What if I'm being selfish?*
+
+These questions masquerade as wisdom. They feel like careful consideration.
+
+But they're actually something else: **seeking permission to exist**.
+
+When you need everyone's okay before you act, you've given everyone a vote in your life. And when everyone votes, you don't live your life—you live a compromise of everyone's preferences.
+
+---
+
 ## The Autonomy Gap
 
 There is a space between:
@@ -117,16 +197,43 @@ In this gap:
 - Neutrality feels suspicious
 - Guilt appears without cause
 - Desire feels unclear
+- Rest feels unearned
+- Preferences seem distant
 
 Many people mistake this gap for regression and rush to fill it:
 - By asking others
 - By over-explaining
 - By compensating
 - By choosing what feels safest
+- By avoiding decisions entirely
+- By creating false urgency to force resolution
 
 But the gap is not a problem.
 
 **It is the place where internal authority is installed.**
+
+---
+
+## Understanding the Gap
+
+The autonomy gap exists because your operating system is updating.
+
+For years—perhaps decades—your nervous system ran one program: *Reference external sources to determine correct behavior.*
+
+Now you're installing a new program: *Reference internal sources.*
+
+During this transition, there will be lag. There will be moments when neither program fully runs—when the old system has stopped and the new system hasn't yet booted.
+
+This feels like:
+- Confusion
+- Blankness
+- "I don't know what I want"
+- "I don't know who I am"
+- Floating without anchor
+
+These feelings are not signs of failure. They are signs that the old program is releasing.
+
+**The blank space is necessary. It's where the new operating system loads.**
 
 ---
 
@@ -136,9 +243,69 @@ In threat-conditioned brains, the **Reticular Activating System (RAS)** flags de
 
 The **prefrontal cortex (PFC)** — responsible for executive function — struggles to complete a decision loop when constantly interrupted by scanning, doubt, or external reference.
 
+Here's how this works neurologically:
+
+**Step 1:** A decision point arises.
+
+**Step 2:** The PFC begins processing options.
+
+**Step 3:** The amygdala scans for threat: *Is this choice dangerous?*
+
+**Step 4:** If past choices led to punishment, the amygdala sends alarm signals.
+
+**Step 5:** The PFC pauses, awaiting safety signals.
+
+**Step 6:** The brain seeks external reference—*What would they think? What's the "right" answer?*
+
+**Step 7:** External validation provides temporary safety signal.
+
+**Step 8:** The decision is completed—but routed through external authority.
+
+Over time, this loop becomes automatic. The brain learns: *I cannot complete a decision without external input.*
+
 **Key shift:** Pausing instead of asking others allows the PFC to complete a decision loop — installing self-trust.
 
 **Translation:** Calm isn't emptiness; it's the PFC doing its job without adrenaline.
+
+---
+
+## The Neuroplasticity of Self-Trust
+
+Here's the encouraging news: The brain is plastic. The pattern of external referencing can be rewired.
+
+Each time you:
+- Make a choice without consulting others
+- Sit with discomfort instead of seeking reassurance
+- Complete a decision loop on your own
+- Tolerate the anxiety of uncertainty
+
+You are literally rewiring neural pathways.
+
+The brain learns through repetition. Every time you complete a decision without outsourcing it, you strengthen the circuit that says: *I can do this.*
+
+This is not insight work. This is pattern work.
+
+You cannot think your way to self-trust. You can only practice your way there.
+
+---
+
+## The Neuroscience of the "Blank Moment"
+
+When you stop the reflex to ask others and instead pause, something happens neurologically:
+
+The habitual loop—*decision → threat scan → seek external input*—gets interrupted.
+
+In that interruption, the brain experiences what feels like a blank. This blankness is often interpreted as:
+- *I don't know what I want*
+- *I have no preferences*
+- *I'm broken*
+- *Something is wrong*
+
+But neurologically, this blankness is the brain searching for a new pathway. It's the moment between the old neural circuit deactivating and the new one activating.
+
+This blank moment is not emptiness. It is the brain reconfiguring.
+
+**The discomfort of the blank is the sensation of neural change.**
 
 ---
 
@@ -158,8 +325,57 @@ It looks like:
 - Tolerating uncertainty
 - Allowing mixed feelings
 - Completing a choice without reviewing alternatives
+- Holding a decision without defending it
+- Changing your mind without shame
 
 This is a skill. And skills are learned through repetition, not insight.
+
+---
+
+## The Difference Between Authority and Certainty
+
+Let's distinguish these clearly:
+
+**Certainty** says: "I know this is right."
+**Authority** says: "This is my choice, regardless of outcome."
+
+**Certainty** requires evidence.
+**Authority** requires presence.
+
+**Certainty** fears being wrong.
+**Authority** accepts the possibility of being wrong.
+
+**Certainty** is rigid.
+**Authority** is grounded.
+
+**Certainty** is often performative—a posture assumed to feel safe.
+**Authority** is embodied—a felt sense of self-possession.
+
+Many people wait for certainty before they act. They gather more information, seek more opinions, run more scenarios—all in search of the feeling of "rightness."
+
+But certainty rarely arrives. And when it does, it's often a construction—a story we tell ourselves to feel safe moving forward.
+
+**Authority doesn't require certainty. It requires willingness.**
+
+---
+
+## Why You Don't Need to Know
+
+Here's what changes everything:
+
+You don't need to know the right choice.
+
+You only need to know:
+- What you're drawn to
+- What you're willing to try
+- What feels true right now
+- What you can live with
+
+The right choice is not a destination. It's a direction.
+
+And the direction becomes clear only by moving—not by endless deliberation.
+
+**Moving generates clarity. Deliberating delays it.**
 
 ---
 
@@ -174,12 +390,55 @@ It is this:
 Staying with the body when guilt appears.
 Staying with the choice when anxiety follows.
 Staying without fixing, apologizing, or compensating.
+Staying when the urge to ask someone else is overwhelming.
+Staying when the blankness feels unbearable.
 
 Each time you do this, the nervous system learns:
 
 > *I can choose — and survive.*
 
 That is how authority relocates.
+
+---
+
+## The Relocation of Authority
+
+For years, authority lived outside you. It lived in:
+- Parents who determined what was acceptable
+- Partners whose moods dictated your behavior
+- Bosses whose opinions shaped your self-worth
+- Friends whose approval you needed
+- Social expectations you dared not violate
+
+Installing internal authority is a relocation project. You are moving authority from external sources to internal ground.
+
+This relocation doesn't happen through declaration. It happens through experience.
+
+Every time you:
+- Choose without asking
+- Hold your position without defending
+- Tolerate disagreement without collapsing
+- Complete a decision without needing validation
+
+You're telling your nervous system: *The authority lives here now.*
+
+---
+
+## The Panic of the First Self-Choice
+
+When you make a choice purely for yourself—without urgency, without obligation, without anyone else's input—something unexpected often happens:
+
+Panic.
+
+The nervous system sounds alarms. Guilt floods in. Anxiety spikes. A voice says: *Who do you think you are?*
+
+This panic is not evidence that you're doing something wrong.
+
+It's evidence that you're doing something new.
+
+The panic is the old system's final resistance. It's the conditioned belief that self-choice leads to punishment, finally confronting the reality that... nothing bad is happening.
+
+**The first few times you choose yourself, it will feel wrong. That wrongness is the sound of conditioning breaking.**
 
 ---
 
@@ -194,10 +453,16 @@ Say internally:
 
 That alone tells your nervous system: *we know what this is.*
 
+Naming the experience separates you from it. You're no longer drowning in the feeling—you're observing it.
+
 **Step 2: Orient**
 
 Look around and name 3 neutral things you see.
 (No meaning, no story.)
+
+*"I see a blue chair. I see a window. I see a plant."*
+
+Orienting to neutral objects pulls you out of the internal loop and reminds your nervous system that you're safe in present time.
 
 **Step 3: Complete**
 
@@ -206,7 +471,17 @@ Say internally:
 
 Completion is the signal your nervous system is waiting for.
 
-**Step 4: Redirect Gently**
+Many people loop endlessly because they never close the decision. They keep reviewing, reconsidering, second-guessing. The nervous system reads this as: *We're still in the decision. We're not safe yet.*
+
+Saying "this choice is complete" closes the loop.
+
+**Step 4: Ground**
+
+Feel your feet on the floor. Feel the weight of your body in the chair or on the ground.
+
+Ground through sensation, not thought.
+
+**Step 5: Redirect Gently**
 
 Do something sensory but neutral:
 - Walk
@@ -214,8 +489,56 @@ Do something sensory but neutral:
 - Shower
 - Feel sand/ground
 - Stretch
+- Breathe slowly
 
 This teaches the body: *life continues safely after choice.*
+
+---
+
+## A Practice: The 24-Hour Hold
+
+This practice builds tolerance for the autonomy gap.
+
+When faced with a decision that isn't urgent:
+
+**Step 1:** Notice the impulse to ask someone else.
+
+**Step 2:** Instead of reaching out, say internally: *"I'll sit with this for 24 hours."*
+
+**Step 3:** During that 24 hours, notice what arises:
+- Anxiety?
+- Guilt?
+- Urgency?
+- Blankness?
+- Surprising clarity?
+
+**Step 4:** After 24 hours, check: Do you know what you want?
+
+Often, you will. The knowledge was always there—it just needed space to surface.
+
+If you still don't know after 24 hours, that's information too. Sometimes decisions need more time. Sometimes you genuinely need input. But now you're asking from clarity, not compulsion.
+
+---
+
+## A Practice: The Body Vote
+
+When you can't access what you want, try this:
+
+**Step 1:** State the first option out loud.
+*"I'm going to the event."*
+
+**Step 2:** Notice your body. Does it contract or expand? Does your breath shorten or deepen? Does tension increase or decrease?
+
+**Step 3:** State the second option out loud.
+*"I'm staying home."*
+
+**Step 4:** Notice your body again. Same questions.
+
+**Step 5:** Pay attention to the option that created more expansion, deeper breath, less tension.
+
+Your body knows before your mind can articulate it. This practice helps you access that knowledge.
+
+Note: If both options create contraction, you may be approaching the decision from obligation rather than desire. Ask yourself: *What would I choose if no one's feelings were at stake?*
 
 ---
 
@@ -232,8 +555,50 @@ Only this:
 Stay with yourself when no one else decides.
 Stay when guilt does not make sense.
 Stay when freedom feels unfamiliar.
+Stay when the blankness is uncomfortable.
+Stay when the old patterns urge you to reach out.
+Stay when the answer isn't clear yet.
 
 This is how leadership begins — quietly, internally, without witnesses.
+
+---
+
+## The Graduation
+
+You will know internal authority is installing when:
+
+- You can sit with a decision without needing to resolve it immediately
+- You can tolerate not knowing without seeking reassurance
+- You can make a choice and not review it repeatedly
+- You can hold your position when someone disagrees
+- You can want something without apologizing for it
+- You can say no without a reason
+- You can change your mind without shame
+- You can feel guilt and not act on it
+
+These are not personality changes. They are capacity changes.
+
+And capacity grows through practice, not understanding.
+
+---
+
+## Common Questions
+
+**"What if I make the wrong choice?"**
+
+You will. Sometimes. And you'll survive it. Wrong choices are not catastrophes—they're data. The goal isn't perfect choices. The goal is choices you don't abandon yourself over.
+
+**"What if they're disappointed?"**
+
+They might be. Their disappointment is theirs to feel. Your job is to make your choice, not to prevent their feelings.
+
+**"How do I know if I should ask for input?"**
+
+Notice the energy behind the asking. Are you seeking information, or permission? Are you gathering perspectives, or avoiding responsibility? Input from a grounded place is useful. Input from a panicked place is outsourcing.
+
+**"What if I genuinely don't know what I want?"**
+
+Start smaller. What do you want for lunch? What do you want to wear? What do you want to do this evening? Desire is a muscle. It atrophies when unused. Begin with low-stakes choices and build from there.
 
 ---
 
@@ -242,8 +607,12 @@ This is how leadership begins — quietly, internally, without witnesses.
 - Where do I instinctively look outward for permission or confirmation?
 - What sensations arise when I don't decide immediately?
 - What happens if I let a question remain unanswered for 24 hours?
+- What am I afraid would happen if I chose wrong?
+- When was the last time I made a decision purely for myself?
+- What did I learn, growing up, about making waves?
+- Whose opinion do I automatically consider before my own?
 
-**Body cue to notice:** Tight chest, urgency, scanning
+**Body cue to notice:** Tight chest, urgency, scanning, reaching for phone
 
 **Practice:** Pause without asking
 
@@ -261,5 +630,26 @@ You are exactly where sovereignty begins.
 
 ---
 
-**[Continue to Chapter 3: What Is Mine — And What Is Not →](./03-aura-boundaries.md)**
+## Closing Note for This Chapter
 
+Internal authority is not about making better decisions.
+
+It is about knowing that your decisions are valid—regardless of outcome.
+
+This shift changes everything.
+
+When your choices don't require external validation, you're free to make them. When your authority doesn't depend on being right, you're free to risk being wrong.
+
+The heaviness you feel around decisions isn't because decisions are heavy.
+
+It's because you were carrying everyone else's reactions before you even chose.
+
+Put them down.
+
+The choice is yours.
+
+And that's not a burden—it's the first freedom.
+
+---
+
+**[Continue to Chapter 3: What Is Mine — And What Is Not →](./03-aura-boundaries.md)**

--- a/book/vol-3-sovereignty/chapters/03-aura-boundaries.md
+++ b/book/vol-3-sovereignty/chapters/03-aura-boundaries.md
@@ -54,6 +54,34 @@ Her trip remains hers.
 
 ---
 
+## Field Note: The Office
+
+He walks into the meeting and immediately senses it: his manager is upset.
+
+Before he can even sit down, his chest tightens. His mind starts calculating: *What did I do wrong? What can I fix? How do I smooth this?*
+
+Forty-five minutes later, the meeting ends. Nothing was wrong. The manager had received bad news that morning—completely unrelated to him.
+
+But he leaves exhausted. He's been regulating someone else's emotion for an hour without realizing it.
+
+He didn't absorb information. He absorbed a feeling.
+
+---
+
+## Field Note: The Party
+
+She enters the room and immediately scans. Who's tense? Who's unhappy? Who needs attention?
+
+Within minutes, she's positioned herself near the person who seems most uncomfortable. She's asking questions, filling silences, working to put them at ease.
+
+An hour later, she's depleted. She came to have fun. Instead, she worked.
+
+She doesn't even remember deciding to do this. Her body did it automatically—orienting toward distress like a magnet toward iron.
+
+On the drive home, she realizes: she never noticed what *she* felt at the party. She was too busy tracking everyone else.
+
+---
+
 ## Why You Learned to Carry What Wasn't Yours
 
 If you grew up in a system where:
@@ -64,6 +92,9 @@ If you grew up in a system where:
 - Silence felt dangerous
 - Someone else's distress became your problem
 - Peace required your intervention
+- You were punished for not anticipating needs
+- You were praised for fixing feelings
+- Emotional labor was invisible and expected
 
 your nervous system adapted by expanding outward.
 
@@ -72,6 +103,8 @@ You learned to:
 - Absorb tension before it could escalate
 - Anticipate reactions before they arrived
 - Regulate others indirectly through your own adjustment
+- Become a lightning rod for ambient distress
+- Preemptively smooth what might become rough
 
 This wasn't weakness.
 
@@ -85,8 +118,64 @@ But that intelligence came at a cost:
 - Guilt for separation
 - Exhaustion without cause
 - Difficulty knowing what you actually feel versus what you've absorbed
+- Resentment that builds without clear source
+- A sense that you don't fully belong to yourself
 
 **Aura boundaries repair this cost.**
+
+---
+
+## What Is an Aura Boundary?
+
+Let's be precise about what we mean.
+
+An **aura boundary** is not a wall you build.
+
+It is not distance you create.
+
+It is not coldness you perform.
+
+An aura boundary is **the nervous system's capacity to distinguish between what is yours and what is not.**
+
+This distinction exists at the level of felt sense—before words, before action.
+
+When aura boundaries are strong:
+- You can feel someone else's pain without taking it on
+- You can witness distress without becoming responsible
+- You can stay present in a room without becoming the room
+- You can care without carrying
+- You can be close without merging
+
+When aura boundaries are weak:
+- Others' emotions enter your body uninvited
+- You leave interactions feeling depleted
+- Guilt appears after neutral choices
+- You feel responsible for the emotional climate everywhere
+- You don't know where you end and others begin
+
+---
+
+## The Invisible Membrane
+
+Imagine there's an invisible membrane around you—like the membrane around a cell.
+
+In a healthy cell, the membrane is semi-permeable. It lets nutrients in and toxins out. It protects what's inside while still allowing exchange with the environment.
+
+Your aura boundary works the same way.
+
+When it functions well:
+- Information flows in (you can sense what others feel)
+- But ownership stays clear (you know it's not yours)
+- You can be present without being invaded
+- You can care without being consumed
+
+When it's been damaged or never properly formed:
+- Everything floods in
+- You can't distinguish your feelings from theirs
+- Proximity becomes merger
+- Connection becomes drowning
+
+The work of this chapter is repairing and strengthening that membrane.
 
 ---
 
@@ -100,9 +189,29 @@ Several brain mechanisms contribute to emotional absorption:
 
 **Neuroception** — your nervous system's unconscious scanning for safety — can tag other people's distress as a threat to you, even when it isn't. This makes their emotions feel urgent to address.
 
+**The anterior cingulate cortex (ACC)** monitors for social threat. In those trained to prioritize others' feelings, the ACC becomes hypervigilant—flagging any negative emotion in the field as something that requires your attention.
+
+**Limbic coupling** occurs when two nervous systems sync up. This is healthy in secure attachment. But in enmeshed systems, coupling becomes so automatic that you literally begin to feel what others feel in your own body.
+
 **Key insight:** Absorption isn't a personality trait—it's a trained neural pattern. What was trained can be retrained.
 
 **Translation:** Naming "this is not all mine" is not a cognitive trick. It's a neurological intervention that helps the insula recalibrate and reduces limbic coupling.
+
+---
+
+## The Neuroscience of Separation
+
+Here's what happens when you begin to distinguish what's yours from what's not:
+
+**The insula recalibrates.** Each time you name "this feeling isn't mine," you're training your insula to track origin, not just intensity. Over time, it becomes better at distinguishing self-generated sensations from absorbed ones.
+
+**The ACC calms.** When you stop treating others' emotions as your emergency, the ACC—which monitors for social threat—learns that their distress doesn't require your immediate intervention. Its alarm volume decreases.
+
+**Limbic coupling loosens.** When you consciously remain in your own body instead of merging with others, limbic coupling becomes a choice rather than an automatic default. You can still attune, but you're not hijacked.
+
+**The prefrontal cortex comes online.** Absorption is a limbic event—it happens fast, beneath conscious awareness. As you build boundaries, you create space for the prefrontal cortex to intervene: "Wait—is this mine?"
+
+This recalibration takes time and repetition. It's not a one-time insight. It's a gradual rewiring of automatic patterns.
 
 ---
 
@@ -117,6 +226,9 @@ This distinction changes everything.
 | You remain in your body | You leave your body to enter theirs |
 | Connection | Merger |
 | Choice remains | Choice disappears |
+| You can witness pain | You become the pain |
+| Compassion | Compulsion |
+| Sustainable | Depleting |
 
 **Empathy** is awareness without ownership.
 
@@ -128,8 +240,32 @@ When absorption is the default:
 - Guilt appears after neutral choices
 - Silence feels like something to fix
 - You feel responsible for the emotional climate of every room
+- You don't know what you actually feel—only what you've absorbed
 
 **Aura boundaries restore choice.**
+
+---
+
+## The Stages of Absorption
+
+Absorption isn't all-or-nothing. It unfolds in stages:
+
+**Stage 1: Sensing**
+You notice someone else's emotional state. This is normal empathy—healthy attunement.
+
+**Stage 2: Tracking**
+You begin monitoring their state, watching for changes. Your attention shifts from yourself to them.
+
+**Stage 3: Responsibility**
+You start feeling responsible for their state. A subtle sense that you should do something appears.
+
+**Stage 4: Absorption**
+Their emotion enters your body. It feels like yours. You can no longer distinguish origin.
+
+**Stage 5: Action**
+You act to relieve the feeling—but you're not relieving your feeling. You're relieving theirs, through yourself.
+
+Most people with weak aura boundaries move through all five stages in seconds, without awareness. The goal is to notice earlier—ideally at Stage 2 or 3—and make a different choice.
 
 ---
 
@@ -139,6 +275,7 @@ When you stop absorbing:
 - You stop regulating others
 - You stop smoothing the field
 - You stop compensating for their dysregulation
+- You stop being the emotional buffer
 
 The nervous system, used to absorption as a safety strategy, reacts.
 
@@ -148,9 +285,16 @@ Guilt appears not because you've done something wrong — but because an old job
 
 That guilt was trained into you. It's conditioning, not conscience.
 
+Here's how the training worked:
+- When you absorbed and smoothed, you were rewarded (or at least not punished)
+- When you didn't absorb, there were consequences (withdrawal, anger, criticism)
+- Your nervous system learned: *Absorbing = safe. Not absorbing = dangerous.*
+
 That signal fades when the system learns:
 
 > *I am still safe when I don't carry this.*
+
+This learning takes repetition. The guilt will arise many times before it stops. Each time you feel the guilt and still don't absorb, you're teaching your nervous system a new truth.
 
 ---
 
@@ -162,23 +306,36 @@ When you chronically absorb others' emotional states:
 - Exhaustion that rest doesn't fix
 - Feeling drained after social interactions
 - Needing excessive alone time to recover
+- A persistent sense of heaviness
+- Low-grade fatigue that becomes normal
 
 **Relationally:**
 - Resentment that builds without clear cause
 - Difficulty knowing what you actually feel
 - Tendency to avoid people or situations
+- Over-giving followed by withdrawal
+- Relationships that feel like work
+- Difficulty receiving (you're too busy giving)
 
 **Personally:**
 - Loss of self-definition
 - Difficulty making decisions
 - Chronic guilt when you choose yourself
+- Not knowing what you want
+- Feeling like an imposter in your own life
+- A sense of being everyone except yourself
 
 **Physically:**
 - Tension, headaches, digestive issues
 - Sleep disruption
 - Immune system suppression
+- Chronic inflammation
+- Stress-related illness
+- Accelerated aging
 
 Absorption is not generosity. It's a survival pattern that depletes you.
+
+**The most generous thing you can do is stay in your own body.**
 
 ---
 
@@ -196,8 +353,33 @@ How do you know if you're absorbing? Check these signs:
 - You feel anxious, heavy, or drained—even though nothing happened to you
 - You feel responsible for helping them feel better
 - You replay the conversation, looking for what you could have done differently
+- You carry their mood with you for hours
 
 **The pattern:** Their emotions became your homework.
+
+---
+
+## The Subtle Signs of Absorption
+
+Sometimes absorption is obvious. Other times it's subtle:
+
+**You leave interactions inexplicably tired.**
+Nothing happened. No conflict. Just presence. And yet you're drained.
+
+**You take on others' moods without realizing it.**
+Your partner comes home stressed; suddenly you're stressed. You didn't catch a virus—you caught an emotion.
+
+**You can't rest when someone nearby is upset.**
+Their dysregulation becomes your emergency. Even if they don't ask for help.
+
+**You feel guilty when you're happy and someone else isn't.**
+As if your wellbeing is somehow at their expense.
+
+**You know what everyone else is feeling but not what you're feeling.**
+The self-sensing circuit has been overridden by the other-sensing circuit.
+
+**You feel responsible for the "energy" of every room.**
+Not in a leadership way. In a compulsive way.
 
 ---
 
@@ -209,13 +391,44 @@ In fact, true leadership depends on **not doing that**.
 
 People regulate around steadiness, not effort. When you absorb the room, you become part of the chaos. When you hold your boundary, you become a reference point.
 
+This is counterintuitive. It feels like caring less. But it's actually caring more effectively.
+
+When you absorb:
+- You become dysregulated
+- Your capacity to help diminishes
+- You add to the chaos
+- You're part of the storm
+
 When you hold your aura:
 - Others locate themselves
 - Emotional contagion decreases
 - Urgency softens
 - Clarity increases
+- You become the eye of the storm
 
 This is influence without force.
+
+---
+
+## Why Staying Separate Helps Others
+
+Here's the paradox: **The best way to help others regulate is to not absorb their dysregulation.**
+
+When you absorb:
+- You validate that their emotion is an emergency
+- You remove their responsibility to regulate themselves
+- You model that distress should be passed to others
+- You deplete yourself, reducing your capacity to actually help
+
+When you stay separate:
+- You model that emotions are survivable
+- You leave them with their own experience (which they need to learn from)
+- You remain resourced enough to actually assist
+- You demonstrate that care doesn't require merger
+
+The most soothing presence is not the one that absorbs your pain.
+
+It's the one that witnesses it without being destroyed by it.
 
 ---
 
@@ -229,10 +442,36 @@ This sounds like:
 - *"This emotion belongs to someone else."*
 - *"Their anxiety is not my emergency."*
 - *"I can witness without carrying."*
+- *"This feeling entered my body, but it's not mine."*
+- *"I return what isn't mine."*
 
 **Aura boundaries are felt first, expressed second.**
 
 You don't announce a boundary. You embody it. Others feel the shift, even without words.
+
+When you're clear inside, you don't need to defend outside.
+
+---
+
+## The Silence That Changes Things
+
+One of the most powerful boundary practices is the simplest:
+
+**Not responding.**
+
+When someone sends anxiety your way—through a text, a look, a tone—the conditioned response is to soothe.
+
+But what if you simply... didn't?
+
+What if you let the silence stand?
+
+What if you let them feel what they feel, without you intervening?
+
+This silence is not cruelty. It is respect—for their capacity to handle their own experience.
+
+And it is self-protection—an honoring of your own energy.
+
+In that silence, you're saying: *I see you. I trust you to handle this. I'm not going to carry it for you.*
 
 ---
 
@@ -244,29 +483,81 @@ Use this when you feel pulled, guilty, anxious, or responsible for someone else'
 
 > *"This is not all mine."*
 
-This simple phrase begins the neurological separation.
+This simple phrase begins the neurological separation. You're cueing the insula to track origin.
 
 **Step 2: Notice where the sensation is in your body.**
 
-Where did you absorb it? Chest? Stomach? Shoulders?
+Where did you absorb it? Chest? Stomach? Shoulders? Jaw? Throat?
 
-**Step 3: Imagine your body gently containing only your sensation — not the whole room.**
+Just notice. Don't try to change it yet.
+
+**Step 3: Ask: "What was I feeling before I entered this field?"**
+
+Try to locate your own baseline state—before you absorbed.
+
+**Step 4: Imagine your body gently containing only your sensation — not the whole room.**
 
 You don't need to push anything out. Just notice what's actually yours.
 
-**Step 4: Exhale slowly and say:**
+**Step 5: Exhale slowly and say:**
 
 > *"I return what is not mine."*
 
 This doesn't have to be literal or visualized. It's simply an instruction to your nervous system.
 
-**Step 5: Ground into your feet.**
+**Step 6: Ground into your feet.**
 
 Feel the floor. Feel your weight. Return to your body.
 
 No visualization required. No effort required.
 
 Just distinction.
+
+---
+
+## A Practice: The Invisible Line
+
+Use this when you're about to enter a potentially absorbing situation.
+
+**Before entering:**
+
+Imagine a line on the floor—a threshold between you and the space you're about to enter.
+
+Say internally: *"I can enter this space and remain myself."*
+
+**Step across the line consciously.**
+
+As you enter, keep 5% of your awareness on your own body. Not vigilant—just present. A gentle thread of self-connection.
+
+**After exiting:**
+
+Check: Did I bring anything out that isn't mine?
+
+If yes, use the Separating the Field practice.
+
+This practice builds the habit of maintaining self-connection even in emotionally charged environments.
+
+---
+
+## A Practice: The Body Check
+
+Use this to reclaim awareness of your own emotional state.
+
+**Step 1:** Close your eyes. Take three breaths.
+
+**Step 2:** Scan your body from head to feet.
+
+**Step 3:** For each sensation you notice, ask: "Is this mine?"
+
+Don't analyze. Just listen for the first intuitive answer.
+
+**Step 4:** For anything that isn't yours, simply notice it without engaging.
+
+You don't need to push it out. Noticing is enough to begin differentiation.
+
+**Step 5:** Ask: "What do *I* feel right now—independent of anyone else?"
+
+This question may feel difficult at first. The answer may be "I don't know." That's okay. You're rebuilding a connection that's been overridden for years.
 
 ---
 
@@ -282,6 +573,9 @@ You may notice:
 - Less guilt
 - More energy after interactions
 - Cleaner relationships
+- Fewer compulsive helping behaviors
+- More space between stimulus and response
+- A sense of being at home in yourself
 
 This can feel unfamiliar at first.
 
@@ -289,9 +583,30 @@ This can feel unfamiliar at first.
 
 ---
 
+## The Discomfort of Not Absorbing
+
+When you stop absorbing, it will feel strange.
+
+You may feel:
+- Guilty (as discussed)
+- Cold ("I'm not caring enough")
+- Anxious ("Something bad will happen if I don't intervene")
+- Empty ("Who am I if I'm not helping?")
+- Selfish ("I should be doing more")
+
+These feelings are not evidence that you're doing something wrong.
+
+They are evidence that your nervous system is recalibrating.
+
+**The discomfort of not absorbing is the sensation of installing new patterns.**
+
+Stay with it. It fades. And what remains is sovereignty.
+
+---
+
 ## Why This Is Not Withdrawal
 
-**Withdrawal** is avoidance. It's leaving to protect yourself. It's numbing out or shutting down.
+**Withdrawal** is avoidance. It's leaving to protect yourself. It's numbing out or shutting down. It's creating distance because you can't handle proximity.
 
 **Aura boundaries** are presence without entanglement. You remain available. You remain caring. You're simply no longer absorbing.
 
@@ -301,8 +616,39 @@ This can feel unfamiliar at first.
 | Shutting down | Remaining open, but boundaried |
 | Protecting through distance | Protecting through clarity |
 | Avoidant | Sovereign |
+| Fear-based | Choice-based |
+| Reactive | Responsive |
+| "I can't be here" | "I can be here and still be me" |
 
 This is how sovereignty stabilizes.
+
+---
+
+## The Difference Between Care and Carrying
+
+Let's distinguish these clearly:
+
+**Care** is:
+- Witnessing
+- Holding space
+- Being present
+- Offering support
+- Choosing to help
+
+**Carrying** is:
+- Taking on
+- Absorbing
+- Becoming responsible
+- Compulsive helping
+- Losing yourself
+
+Care has boundaries. Carrying has none.
+
+Care is sustainable. Carrying leads to burnout.
+
+Care respects the other person's capacity. Carrying assumes they can't handle their own experience.
+
+Care is love. Carrying is enmeshment dressed as love.
 
 ---
 
@@ -321,6 +667,28 @@ People who respect you will adjust.
 
 This is not rejection. It's sorting.
 
+The relationships that depended on your absorption will struggle. They were built on an unsustainable foundation.
+
+The relationships that respect your wholeness will deepen. They have room for you to be you.
+
+This sorting can be painful. But it's necessary. You cannot have relationships that work for both people while one person is chronically absorbed.
+
+---
+
+## What Happens When You Hold Your Boundary
+
+When you stop absorbing and hold your aura, others have one of two responses:
+
+**Response 1: Adjustment**
+They feel the shift. They may initially be confused or uncomfortable. But they adjust. They begin to regulate themselves. The relationship recalibrates to a healthier dynamic.
+
+**Response 2: Escalation**
+They feel the shift and escalate—more intensity, more emotion, more demand. This is often unconscious: *"The old way isn't working, so I'll try harder."*
+
+Escalation is uncomfortable but informative. It tells you the relationship was built on your absorption. When you held the boundary, it exposed the dynamic.
+
+**How to handle escalation:** Stay calm. Stay boundaried. Don't match their intensity. Let the escalation pass. If they can adjust, the relationship may survive. If they can't, you have important information about compatibility.
+
 ---
 
 ## Reader Reflection
@@ -330,8 +698,11 @@ This is not rejection. It's sorting.
 - What changes when I do nothing instead of reassuring?
 - Who in my life relies on me to absorb their emotional state?
 - What would I have energy for if I wasn't carrying everyone?
+- When did I first learn to absorb others' feelings?
+- What did absorbing protect me from?
+- What does it cost me now?
 
-**Body cue to notice:** Stomach tension, shallow breath, sudden fatigue
+**Body cue to notice:** Stomach tension, shallow breath, sudden fatigue, chest heaviness
 
 **Practice:** "I return what is not mine."
 
@@ -347,6 +718,26 @@ That sentence ends enmeshment.
 
 ---
 
+## The Permission You May Need
+
+If you need permission to stop absorbing, here it is:
+
+**You are allowed to feel only your own feelings.**
+
+**You are allowed to witness pain without becoming it.**
+
+**You are allowed to remain in your body while someone else is distressed.**
+
+**You are allowed to leave an interaction without carrying it.**
+
+**You are allowed to let others feel what they feel.**
+
+**You are allowed to be well when others are not.**
+
+This is not abandonment. This is integrity.
+
+---
+
 ## Closing Note for This Chapter
 
 You do not need to protect your aura by becoming hard.
@@ -359,7 +750,10 @@ Influence without force is leadership.
 
 The most powerful thing you can do in any emotional field is stay in your own body.
 
+When you stay—present, grounded, contained—you offer others something far more valuable than your absorption.
+
+You offer them an example of what it looks like to belong to yourself.
+
 ---
 
 **[Continue to Chapter 4: Sovereignty Without Force →](./04-sovereignty-without-force.md)**
-

--- a/book/vol-3-sovereignty/chapters/04-sovereignty-without-force.md
+++ b/book/vol-3-sovereignty/chapters/04-sovereignty-without-force.md
@@ -1,5 +1,7 @@
 # Chapter 4: Sovereignty Without Force
 
+## Power Without Pressure, Stillness Without Collapse
+
 ---
 
 Most people misunderstand sovereignty.
@@ -15,10 +17,35 @@ Because force once meant:
 - Domination
 - Emotional withdrawal
 - Being "right" at someone else's expense
+- Anger that filled the room
+- Control disguised as care
+- Power used to diminish
 
 So when the idea of sovereignty arises, the body hesitates.
 
 Not because it lacks power — but because it remembers what power once did.
+
+---
+
+## The Fear Behind the Hesitation
+
+For many people, power and harm are wired together.
+
+They learned early:
+- When someone was powerful, someone else got hurt
+- When someone took charge, someone else got blamed
+- When someone was certain, someone else was wrong
+- When someone led, someone else had to follow or else
+
+This creates an unconscious equation: **Power = Danger.**
+
+So they learned to avoid power. To stay small. To defer. To let others lead.
+
+Not because they lacked capacity—but because capacity felt dangerous.
+
+The work of this chapter is unwiring that equation.
+
+**Sovereignty is not the power that harmed you. It is the power that protects you.**
 
 ---
 
@@ -30,9 +57,21 @@ Her heart races.
 
 She explains again. Adds context. Defends her logic.
 
+She can feel herself speeding up, words piling on words.
+
 The room grows tense.
 
+Someone else shifts uncomfortably.
+
+She explains more. Louder now. More examples.
+
 She leaves exhausted.
+
+Driving home, she replays it. Wonders what she could have said differently. What she missed. Why they didn't understand.
+
+She doesn't realize: she was never trying to convince them.
+
+She was trying to survive her own anxiety about disagreement.
 
 ---
 
@@ -40,13 +79,89 @@ She leaves exhausted.
 
 Someone disagrees with her.
 
-She states her position once — calmly — and stops.
+She feels her heart rate rise.
+
+She takes a breath. Notes the impulse to explain.
+
+Then she states her position once — calmly — and stops.
 
 The silence stretches.
+
+Her palms sweat. Her chest tightens.
+
+She doesn't fill the silence.
 
 Then someone else speaks.
 
 The room reorganizes.
+
+She remains still. Present. Grounded.
+
+Driving home, she doesn't replay anything.
+
+She already knows what she said. She meant it. It's done.
+
+---
+
+## Field Note: The Email
+
+He stares at the message for forty minutes.
+
+It's a request that crosses a boundary. Not aggressive—just presumptuous. Someone asking for more than he wants to give.
+
+His first draft is apologetic. *"I'm so sorry, but I really can't right now because..."* followed by three paragraphs of justification.
+
+He reads it back. Deletes.
+
+His second draft is curt. Almost rude. Overcompensating.
+
+He reads it back. Deletes.
+
+His third draft is simple: *"I won't be able to do this."*
+
+No explanation. No apology. No softening.
+
+His finger hovers over send. His chest is tight.
+
+He hits send.
+
+Nothing explodes.
+
+He realizes: all those explanations he usually adds are not for the other person.
+
+They're to manage his own anxiety about saying no.
+
+---
+
+## Field Note: The Conversation
+
+Her mother calls, anxious and critical.
+
+In the past, she would have soothed, explained, reassured. She would have rearranged herself to calm her mother's nervous system.
+
+Tonight, she does something different.
+
+She listens. She says "Mm-hmm." She doesn't argue.
+
+When her mother's monologue ends, she says: "It sounds like you're worried."
+
+Her mother waits for more. The reassurance. The fix.
+
+It doesn't come.
+
+"Well, yes," her mother says, uncertain now.
+
+"I understand."
+
+Silence.
+
+"Aren't you going to say anything?" her mother asks.
+
+"I just did."
+
+The call ends strangely. Incomplete feeling. But she notices: she has energy after. She didn't give anything away.
+
+She held her ground without fighting for it.
 
 ---
 
@@ -58,8 +173,13 @@ In systems shaped by emotional immaturity or narcissism, power is often expresse
 - Insistence
 - Superiority
 - Control of outcomes
+- Righteousness
+- Intimidation
+- Emotional intensity used as leverage
 
 Force moves quickly. Force demands agreement. Force overrides nuance.
+
+Force says: *"I will make you see it my way."*
 
 Many people learn to avoid force by avoiding power altogether.
 
@@ -68,8 +188,34 @@ They choose:
 - Accommodation over truth
 - Harmony over self
 - Silence over leadership
+- Collapse over confrontation
 
 This keeps the peace — but dissolves sovereignty.
+
+---
+
+## The False Binary
+
+Here's the trap:
+
+Many people believe there are only two options:
+
+**Option 1: Force**
+Aggressive, dominant, controlling. You get your way, but at someone else's expense. This is what you saw in the people who harmed you.
+
+**Option 2: Collapse**
+Yielding, accommodating, disappearing. You keep the peace, but at your own expense. This is what you learned to do to survive.
+
+Force or collapse. Dominate or disappear.
+
+**Sovereignty is the third option.**
+
+It is neither force nor collapse. It is presence.
+
+It is standing without pushing.
+It is holding without gripping.
+It is speaking without convincing.
+It is leading without dominating.
 
 ---
 
@@ -84,8 +230,40 @@ It looks like:
 - Holding decisions without defending
 - Allowing disagreement without collapse
 - Remaining grounded when others are activated
+- Speaking once, clearly, without repetition
+- Leaving space for others to respond
+- Tolerating not being understood
+- Accepting that some people won't like your answer
 
 **Sovereignty does not dominate the field. It stabilizes it.**
+
+---
+
+## The Physiology of Sovereignty vs. Force
+
+Let's understand what's happening in the body:
+
+**Force** is a stress response. When you push, explain, convince, defend:
+- Heart rate elevates
+- Breath shortens
+- Muscles tense
+- Voice raises
+- Tunnel vision narrows focus
+- The sympathetic nervous system activates
+
+You're not leading—you're fighting.
+
+**Sovereignty** is a regulated response. When you state your position and stay:
+- Heart rate remains stable (or returns to baseline quickly)
+- Breath deepens
+- Muscles stay relaxed
+- Voice stays level
+- Peripheral awareness remains
+- The ventral vagal system stays engaged
+
+You're not fighting—you're being.
+
+This is why sovereignty feels different. It's not just a different behavior—it's a different physiological state.
 
 ---
 
@@ -99,6 +277,8 @@ In that space:
 - Others may feel unsettled
 - Conversations may slow
 - Reactions may surface
+- Disagreement may linger
+- Resolution may not come immediately
 
 The nervous system, used to managing outcomes, may interpret this as danger.
 
@@ -106,17 +286,75 @@ It's not.
 
 It's reorganization.
 
+The discomfort you feel when you stop explaining, defending, or convincing is not evidence that you're failing.
+
+It's evidence that you're allowing a new dynamic to emerge.
+
+---
+
+## The Terror of Letting Things Be
+
+For people who grew up managing others' emotions, there's a particular terror in this:
+
+**Letting things be unresolved.**
+
+The itch to explain one more time.
+The urge to send that follow-up message.
+The compulsion to check if they understood.
+The anxiety that lives in ambiguity.
+
+This terror is not about the other person.
+
+It's about your nervous system's intolerance for uncertainty.
+
+When you learned that unresolved tension led to punishment, explosion, or withdrawal, your system learned: *Resolve at all costs.*
+
+Sovereignty asks you to tolerate unresolved.
+
+To let people disagree without chasing agreement.
+To let people be confused without correcting.
+To let conversations end without resolution.
+To let silence exist without filling.
+
+This tolerance is a skill. It takes practice.
+
 ---
 
 ## Neuroscience Lens: Power Without Threat
 
 Force (explaining, convincing) is often an **amygdala** response to perceived social risk.
 
-Calm assertion activates the **ventral vagal system** — signaling social safety that reduces escalation in others.
+When you feel misunderstood, disagreed with, or challenged, the amygdala can flag this as threat. The body enters a mild fight response. You push to resolve the threat.
+
+But pushing escalates. The other person's amygdala responds to your intensity. Now you have two activated nervous systems. The conversation becomes a battle.
+
+**Calm assertion activates the ventral vagal system** — signaling social safety that reduces escalation in others.
+
+When you stay calm:
+- Your tone signals safety
+- Your pace creates space
+- Your stillness invites others to settle
+- The emotional temperature drops
 
 **Key shift:** Saying less keeps vagal tone high — others regulate around steadiness.
 
 **Translation:** Influence increases when threat decreases.
+
+---
+
+## The Neuroscience of "Saying It Once"
+
+Here's what happens neurologically when you state your position once and stop:
+
+**The PFC stays online.** When you're not in explain-defend-convince mode, your prefrontal cortex—responsible for executive function and clear thinking—remains engaged. You're operating from your highest capacity.
+
+**The amygdala calms.** Without the escalation of force, the amygdala's threat response diminishes. You're not in fight mode.
+
+**Others' nervous systems respond.** When you stay regulated, others' mirror neurons pick up on your calm. Limbic coupling works in your favor. They regulate around your stillness.
+
+**The vagal brake engages.** The ventral vagal system—responsible for social engagement and felt safety—stays activated. You're signaling: *I'm not a threat. We can work this out.*
+
+This is why sovereignty is more influential than force. It works *with* the social nervous system rather than against it.
 
 ---
 
@@ -130,6 +368,12 @@ Calm assertion activates the **ventral vagal system** — signaling social safet
 
 **Pressure** escalates.
 **Power** stays.
+
+**Pressure** needs the other person to change.
+**Power** is complete regardless of their response.
+
+**Pressure** is about controlling outcome.
+**Power** is about embodying position.
 
 Most trauma-adapted people mistake pressure for power — because pressure once ended uncertainty.
 
@@ -153,8 +397,33 @@ When you are connected to yourself:
 - Your voice slows
 - Your words land
 - Your presence steadies others
+- You don't rush to fill silence
+- You can tolerate not knowing
+- You can say "I don't know" without losing authority
 
 This is leadership felt in the body, not argued in the mind.
+
+---
+
+## The Authority of "I Don't Know"
+
+Here's a paradox:
+
+**"I don't know" can be one of the most powerful things you say.**
+
+When said from collapse, it sounds like: *"I don't know... what do you think? Help me. Tell me what to do."*
+
+When said from sovereignty, it sounds like: *"I don't know."* Full stop. Grounded. Complete.
+
+The difference is internal. When you can tolerate not knowing—when your sense of authority doesn't depend on having answers—"I don't know" becomes a statement of presence, not helplessness.
+
+Leaders who can say "I don't know" from groundedness signal:
+- I'm not performing certainty
+- I'm honest about my limits
+- I trust the process
+- I don't need to be right to be here
+
+This is more powerful than false confidence.
 
 ---
 
@@ -165,19 +434,85 @@ Use this when you feel the urge to:
 - Explain
 - Justify
 - Hurry
+- Make sure they understand
+- Fix their perception
 
 **Step 1:** Pause and feel your feet on the ground.
 
-**Step 2:** Let your shoulders soften.
+Really feel them. The pressure. The temperature. The contact with floor or earth.
 
-**Step 3:** Ask internally:
+**Step 2:** Let your shoulders drop.
+
+Notice if they were creeping toward your ears. Let gravity take them down.
+
+**Step 3:** Slow your breath.
+
+Exhale longer than you inhale. This signals the vagus nerve to downregulate.
+
+**Step 4:** Ask internally:
 > *"Can I let this unfold without managing it?"*
 
-**Step 4:** Say only what is necessary — once.
+You don't need to answer yes. Just ask the question. Let it settle.
+
+**Step 5:** Say only what is necessary — once.
+
+Not twice. Not with extra explanation. Not with softening or hedging. Once.
 
 Then stop.
 
 **Stillness is not weakness. It is containment.**
+
+---
+
+## A Practice: The Pause Before Response
+
+Use this when you feel reactive—when your body wants to speak before your mind has caught up.
+
+**Step 1:** Notice the impulse to respond immediately.
+
+Don't judge it. Just notice: *I want to speak right now.*
+
+**Step 2:** Take one breath before speaking.
+
+Just one. In and out.
+
+**Step 3:** During that breath, ask: *"What do I actually want to say?"*
+
+Often, the impulse to speak is about discharging anxiety, not communicating.
+
+**Step 4:** Speak only if you have something to say.
+
+If the breath revealed that your impulse was just anxiety, stay silent.
+
+This practice builds the muscle of **response** instead of **reaction.**
+
+---
+
+## A Practice: Completing Without Convincing
+
+Use this after a conversation where you stated your position but didn't get agreement.
+
+**Step 1:** Notice if there's residual urge to follow up.
+
+*"I should text them."*
+*"Maybe I should clarify."*
+*"They might have misunderstood."*
+
+**Step 2:** Name the urge:
+
+> *"This is the urge to convince, not to communicate."*
+
+**Step 3:** Ask: *"Did I say what I meant?"*
+
+If yes, you're done.
+
+**Step 4:** Say internally:
+
+> *"This conversation is complete. Their understanding is not my responsibility."*
+
+**Step 5:** Ground.
+
+Feel your feet. Feel your weight. Let the conversation be over.
 
 ---
 
@@ -188,12 +523,23 @@ You may notice:
 - Clearer responses
 - Some people drifting away
 - Others leaning in more calmly
+- Shorter conversations
+- Less exhaustion after interactions
+- A sense of having more time
+- Relationships that feel cleaner
+- A strange new quiet
 
 This is not loss.
 
 This is sorting.
 
 **Systems reorganize around steadiness.**
+
+When you stop forcing, some people will miss the friction. They were used to the dynamic of push-pull. Without your push, they don't know how to relate.
+
+Others will be relieved. They always wanted you to be present, not performative.
+
+Both responses are information about who belongs in your life.
 
 ---
 
@@ -203,6 +549,23 @@ Here is a truth that frees many people:
 
 **You are responsible for your choices — not for others' reactions to them.**
 
+Let that land.
+
+You are responsible for:
+- What you say
+- How you say it
+- Whether you're honest
+- Whether you're kind
+- Whether you're clear
+
+You are NOT responsible for:
+- Whether they like it
+- Whether they agree
+- Whether they understand
+- Whether they feel comfortable
+- Whether they approve
+- Whether the relationship survives
+
 When this distinction lands somatically, force is no longer needed.
 
 You don't have to defend your authority.
@@ -211,13 +574,117 @@ You simply inhabit it.
 
 ---
 
+## The Paradox of Influence
+
+Here's what's counterintuitive:
+
+**The less you try to influence, the more influential you become.**
+
+When you push, convince, and explain:
+- Others feel pressured
+- They resist
+- They dig in
+- Your influence decreases
+
+When you state, pause, and stay:
+- Others feel respected
+- They consider
+- They have room to choose
+- Your influence increases
+
+Influence is not about making people do what you want.
+
+It's about being so grounded in yourself that others naturally orient toward you.
+
+This is not manipulation. It's presence.
+
+---
+
+## The Quiet Power
+
+There's a particular kind of power that doesn't announce itself.
+
+It doesn't need to be right.
+It doesn't need to be agreed with.
+It doesn't need to be validated.
+
+It simply... is.
+
+This power shows up as:
+- Speaking less
+- Waiting longer
+- Not filling silences
+- Not chasing understanding
+- Not softening hard truths
+- Not apologizing for clarity
+
+This is the power of sovereignty.
+
+It's quiet. It's steady. It doesn't fight.
+
+And precisely because it doesn't fight, it's very hard to oppose.
+
+---
+
+## What Sovereignty Looks Like in Practice
+
+Let's be concrete:
+
+**In a disagreement:**
+Force: "No, you don't understand—let me explain again..."
+Sovereignty: "I see it differently." [Pause. Wait.]
+
+**In a request you want to decline:**
+Force: "I really can't because... [lengthy explanation]..."
+Sovereignty: "I won't be able to do that." [Done.]
+
+**In a conflict:**
+Force: "That's not what I said—you're misunderstanding me—what I meant was..."
+Sovereignty: "That's not my intention. I'm sorry it landed that way." [Let them respond.]
+
+**When criticized:**
+Force: "That's not fair because... [defense]..."
+Sovereignty: "I hear that you see it that way." [Pause. Ground.]
+
+**When pressured:**
+Force: [Lengthy explanation of why you need time]
+Sovereignty: "I'll need some time to think about this."
+
+Notice the pattern: fewer words, no defense, no management of their response.
+
+---
+
+## The Courage of Sovereignty
+
+Let's be clear: this is not easy.
+
+Sovereignty requires courage because:
+
+- You will be misunderstood, and you won't fix it
+- You will be disagreed with, and you won't convince
+- You will be criticized, and you won't defend
+- You will be rejected, and you won't chase
+- You will be uncomfortable, and you won't escape
+
+This is courage not because it's dramatic—but because it's quiet.
+
+The courage to stay.
+The courage to be still.
+The courage to be yourself when that's not what someone wants.
+
+---
+
 ## Reader Reflection
 
 - Where do I over-explain, justify, or push to be understood?
 - What fear arises when I say less?
 - What changes when I state my position once and stop?
+- Whose understanding do I feel responsible for managing?
+- What would happen if I let a disagreement exist without resolving it?
+- Where did I learn that power was dangerous?
+- What would power look like if it weren't harmful?
 
-**Body cue to notice:** Jaw tension, rapid speech
+**Body cue to notice:** Jaw tension, rapid speech, leaning forward, rising pitch
 
 **Practice:** One clear sentence, then silence
 
@@ -233,6 +700,36 @@ That sentence retrains power without recreating harm.
 
 ---
 
+## The Spectrum of Response
+
+A useful frame: see your options as a spectrum.
+
+**Collapse ←---→ Sovereignty ←---→ Force**
+
+**Collapse** is:
+- Saying yes when you mean no
+- Agreeing to end the conversation
+- Disappearing to avoid conflict
+- Abandoning yourself
+
+**Force** is:
+- Pushing to be understood
+- Convincing to get agreement
+- Escalating to win
+- Abandoning connection
+
+**Sovereignty** is the middle:
+- Clear without pushing
+- Present without forcing
+- Boundaried without punishing
+- Firm without rigid
+
+Most people oscillate between collapse and force. They collapse until they can't anymore, then explode into force, then feel guilty and collapse again.
+
+Sovereignty is learning to stay in the middle.
+
+---
+
 ## Closing Note for This Chapter
 
 Sovereignty does not ask you to become harder.
@@ -243,7 +740,24 @@ That stillness is not passive. It is not compliant. It is not small.
 
 **It is leadership without violence.**
 
+The violence you knew—the force, the pressure, the domination—was not power.
+
+It was fear wearing power's clothing.
+
+True power doesn't need to push.
+
+It doesn't need to be loud.
+
+It doesn't need to win.
+
+It only needs to stay.
+
+And when you can stay—present, grounded, clear—you become something rare:
+
+A person who doesn't need to force anything.
+
+Because you already are what you were trying to prove.
+
 ---
 
 **[Continue to Chapter 5: Holding the Field Without Absorbing It →](./05-holding-the-field.md)**
-


### PR DESCRIPTION
Add substantial depth to the first four chapters of The Sovereignty Series
Volume 3 while preserving the original voice and essence:

- Chapter 1 (Opening Manifesto): Add new sections on hidden architecture
  of hyper-vigilance, paradox of arrival, spectrum of healing, delayed
  self-trust neuroscience, common misconceptions, and sovereignty inventory

- Chapter 2 (Installing Internal Authority): Add field notes on restaurant
  and encrypted preferences, anatomy of hidden contract, disorientation
  of freedom, neuroplasticity of self-trust, relocation of authority,
  24-hour hold and body vote practices, and common questions section

- Chapter 3 (Aura Boundaries): Add office and party field notes, invisible
  membrane metaphor, neuroscience of separation, stages of absorption,
  subtle signs, why staying separate helps others, invisible line and
  body check practices, care vs carrying distinction, and permission section

- Chapter 4 (Sovereignty Without Force): Add email and conversation field
  notes, false binary framework, physiology comparison, terror of letting
  things be, "I don't know" authority, pause before response practice,
  completing without convincing practice, paradox of influence, and
  spectrum of response model