### PR TITLE
📚 Expand and deepen Volume 3 chapters 14-18

### DIFF
--- a/book/vol-3-sovereignty/chapters/14-sovereignty-at-work.md
+++ b/book/vol-3-sovereignty/chapters/14-sovereignty-at-work.md
@@ -6,24 +6,32 @@
 
 Work is where many people first experienced authority—and where they learned what authority costs.
 
+The office. The factory floor. The classroom that became a conference room. These spaces carry the residue of every authority figure who came before.
+
 If your early experiences of authority were:
 - Critical
 - Volatile
 - Demanding
 - Unsafe
+- Conditional
+- Unpredictable
+- Emotionally immature
 
 then work environments can trigger old survival patterns without your awareness.
 
 You may find yourself:
-- Over-explaining decisions
-- Seeking validation before acting
-- Deferring to authority reflexively
-- Working to exhaustion to earn belonging
-- Avoiding visibility to stay safe
+- Over-explaining decisions long after they've been made
+- Seeking validation before acting on your own competence
+- Deferring to authority reflexively, even when you know better
+- Working to exhaustion to earn belonging that was never conditional
+- Avoiding visibility to stay safe from scrutiny
+- Apologizing for taking up space in meetings
+- Monitoring your boss's mood before the day even begins
+- Feeling like an imposter despite evidence of your competence
 
 Sovereignty at work means bringing the same internal authority to professional settings that you've developed everywhere else.
 
-**It means leading from self-trust, not from approval-seeking.**
+**It means leading from self-trust, not from approval-seeking. It means showing up as yourself, not as the version of you that keeps everyone comfortable.**
 
 ---
 
@@ -31,13 +39,17 @@ Sovereignty at work means bringing the same internal authority to professional s
 
 She's the first one in and the last to leave.
 
-She anticipates needs before they're expressed. She solves problems before they become problems.
+She anticipates needs before they're expressed. She solves problems before they become problems. She smooths tensions between team members who don't even realize tension exists.
 
-Her boss praises her. Her colleagues rely on her.
+Her boss praises her. Her colleagues rely on her. Human Resources calls her "indispensable."
 
-And she's exhausted. Not from the work—from the invisible labor of managing everyone's expectations.
+And she's exhausted. Not from the work—from the invisible labor of managing everyone's expectations, everyone's emotions, everyone's comfort.
 
-She doesn't know how to stop. Stopping feels like failure.
+She doesn't know how to stop. Stopping feels like failure. Stopping feels like the moment before abandonment.
+
+At night, she lies awake rehearsing tomorrow's meetings. On weekends, she checks email "just in case." On vacation, she's never truly gone.
+
+She tells herself this is just what success requires. But somewhere deeper, she knows: this is survival, not success.
 
 ---
 
@@ -47,64 +59,169 @@ She does excellent work.
 
 She also leaves on time. She says no to projects that aren't hers. She lets others solve problems she used to solve for them.
 
-Some colleagues are surprised. Her boss adjusts.
+The first time she left a problem unsolved, her chest tightened for hours. The second time, only for an hour. Now, it barely registers.
+
+Some colleagues are surprised. Her boss adjusts. Some relationships shift.
 
 She's still valued—but she's no longer depleted.
+
+For the first time, her career is sustainable. Not because the work changed, but because she stopped trying to earn belonging through exhaustion.
+
+---
+
+## Field Note: The Meeting
+
+He sits in the conference room, preparing to present his proposal.
+
+His manager enters. His body scans automatically: facial expression, energy, posture. Is she in a good mood? Bad? Neutral?
+
+He's done this scan a thousand times without realizing it. As a child, reading his father's mood meant survival. Now, thirty years later, he's reading his manager's mood with the same vigilance.
+
+His proposal is solid. He knows this. But when she asks a clarifying question, he hears criticism. His chest tightens. His voice speeds up. He over-explains, justifies, defends.
+
+Later, she approves the proposal without changes. The question was just a question.
+
+But his body didn't know that. His body was somewhere else entirely.
 
 ---
 
 ## Why Work Activates Old Patterns
 
-Work environments contain:
-- Authority figures (triggering father/mother imprints)
-- Social hierarchies (triggering family dynamics)
-- Performance evaluation (triggering conditional love patterns)
-- Competition (triggering sibling dynamics)
-- Visibility requirements (triggering exposure fears)
+Work environments contain nearly every element that can trigger unresolved attachment wounds:
 
-For trauma survivors, work can feel like a return to childhood dynamics—navigating power without safety.
+**Authority figures**
+Bosses, supervisors, and senior colleagues can trigger father/mother imprints. The nervous system doesn't distinguish between your current manager and the critical parent who shaped your relationship with authority thirty years ago.
+
+**Social hierarchies**
+Organizational structures can recreate family dynamics—who has power, who must defer, who speaks and who listens, who matters and who is invisible.
+
+**Performance evaluation**
+Reviews, feedback, and assessments can trigger conditional love patterns. If your worth was contingent on performance as a child, professional evaluation feels like an existential judgment, not a job function.
+
+**Competition**
+Colleagues competing for recognition, resources, or advancement can trigger sibling dynamics—rivalry, comparison, the fear of being less valued.
+
+**Visibility requirements**
+Presentations, leadership roles, and public recognition can trigger exposure fears. If attention meant scrutiny or punishment in childhood, professional visibility feels dangerous.
+
+**Financial dependency**
+The reality that your livelihood depends on these relationships raises the stakes, making workplace dynamics feel even more threatening than they might otherwise be.
+
+For trauma survivors, work can feel like a return to childhood dynamics—navigating power without safety, performing without ever truly belonging.
 
 ---
 
 ## Neuroscience Lens: Authority Imprints
 
-The brain's response to authority figures is shaped by early experiences with caregivers.
+The brain's response to authority figures is shaped by early experiences with caregivers. These responses are encoded in the **implicit memory system**—the part of memory that stores emotional and bodily responses without conscious recall.
+
+When you encounter an authority figure at work, your brain doesn't start fresh. It references every previous encounter with authority, searching for patterns that predict what comes next.
 
 If authority figures were:
-- **Critical** → You may feel anxious around feedback
-- **Volatile** → You may be hypervigilant to mood shifts
-- **Absent** → You may not trust guidance
-- **Conditional** → You may over-perform to earn approval
 
-These responses are **automatic**. The nervous system doesn't distinguish between your boss and your critical parent—it responds to patterns.
+**Critical** → You may feel anxious around feedback, scanning for disapproval before it arrives, bracing for judgment even when none is coming
 
-**Key insight:** Your relationship with work authority is often a repetition of early relationships with parental authority.
+**Volatile** → You may be hypervigilant to mood shifts, monitoring facial expressions and tone, adjusting your behavior based on microscopic cues others don't even notice
 
-**Translation:** Sovereignty at work requires recognizing these patterns and responding from adult capacity, not childhood survival.
+**Absent** → You may not trust guidance, assuming authorities will disappear when you need them most, relying only on yourself
+
+**Conditional** → You may over-perform to earn approval, believing that your worth is measured in output, that rest must be earned, that good enough is never quite enough
+
+**Invasive** → You may struggle with appropriate professional boundaries, unsure where your responsibilities end and others' begin
+
+**Unpredictable** → You may live in constant anticipation, never quite relaxing because the next shift could come at any moment
+
+These responses are **automatic**. The nervous system doesn't distinguish between your boss and your critical parent—it responds to patterns. A raised eyebrow in a meeting can trigger the same cascade of stress hormones that a parental outburst triggered decades ago.
+
+**Key insight:** Your relationship with work authority is often a repetition of early relationships with parental authority. The conference room becomes the kitchen table. The performance review becomes the report card. The request for feedback becomes the question that was never safe to answer honestly.
+
+**Translation:** Sovereignty at work requires recognizing these patterns and responding from adult capacity, not childhood survival. This doesn't mean the patterns disappear—it means you develop the awareness to choose differently.
 
 ---
 
 ## Common Work Patterns and Their Roots
 
 ### The Over-Functioner
-**Pattern:** Does more than their role requires. Anticipates needs. Cannot let things fail.
-**Root:** Parentified child who learned safety through usefulness.
-**Sovereign shift:** "I do my job excellently. I don't do everyone's job."
+
+**Pattern:** Does more than their role requires. Anticipates needs. Cannot let things fail. Carries responsibilities that belong to others. Is allergic to delegation.
+
+**How it appears:** Working late when others leave on time. Taking on projects that aren't yours. Fixing problems before anyone knows they exist. Feeling responsible for team morale. Unable to say no without elaborate justification.
+
+**Root:** Parentified child who learned safety through usefulness. Being indispensable was the only reliable strategy for belonging. If you were useful, you mattered. If you weren't useful, you were invisible—or worse.
+
+**The cost:** Burnout. Resentment. Colleagues who never develop capacity because you always rescue. A career built on unsustainable effort.
+
+**Sovereign shift:** "I do my job excellently. I don't do everyone's job. Their capacity is not my responsibility. I am allowed to do only what is mine."
+
+---
 
 ### The Approval-Seeker
-**Pattern:** Needs validation before acting. Checks in excessively. Cannot tolerate disapproval.
-**Root:** Conditional love—worth tied to performance.
-**Sovereign shift:** "I trust my work. I don't need constant reassurance."
+
+**Pattern:** Needs validation before acting. Checks in excessively. Cannot tolerate disapproval. Adjusts positions based on others' reactions rather than conviction.
+
+**How it appears:** Asking "does this make sense?" repeatedly. Watching for facial cues during presentations. Feeling deflated after neutral feedback. Changing opinions to match superiors. Unable to commit to decisions without consensus.
+
+**Root:** Conditional love—worth tied to performance and external approval. In childhood, approval meant safety. Disapproval meant rejection, withdrawal, or punishment. The lesson encoded: your worth is determined by others' reactions.
+
+**The cost:** Decision paralysis. Loss of authentic voice. Career shaped by others' expectations rather than your own values. The exhaustion of never knowing if you're enough.
+
+**Sovereign shift:** "I trust my work. I don't need constant reassurance. My competence exists regardless of whether it's noticed or praised in this moment."
+
+---
 
 ### The Invisible Worker
-**Pattern:** Avoids visibility. Doesn't speak up. Lets others take credit.
-**Root:** Safety through invisibility—attention was dangerous.
-**Sovereign shift:** "I can be seen without being targeted."
+
+**Pattern:** Avoids visibility. Doesn't speak up in meetings. Lets others take credit. Minimizes accomplishments. Prefers to work behind the scenes.
+
+**How it appears:** Staying quiet in meetings. Deflecting compliments. Not applying for promotions. Allowing ideas to be attributed to others. Preferring email to in-person interaction.
+
+**Root:** Safety through invisibility—attention was dangerous. In families where standing out meant criticism, attack, or jealousy, becoming invisible was adaptive. Being seen was associated with being targeted.
+
+**The cost:** Career stagnation. Ideas never heard. Recognition never received. The slow erosion of knowing you have value.
+
+**Sovereign shift:** "I can be seen without being targeted. Visibility is not danger. I am allowed to take credit for my work. Being known does not make me vulnerable."
+
+---
 
 ### The Conflict Avoider
-**Pattern:** Agrees to keep peace. Doesn't express disagreement. Builds resentment.
-**Root:** Conflict was dangerous in family—peace at any cost.
-**Sovereign shift:** "Professional disagreement is not personal attack."
+
+**Pattern:** Agrees to keep peace. Doesn't express disagreement. Builds resentment. Accommodates at personal cost. Avoids difficult conversations indefinitely.
+
+**How it appears:** Saying yes when you mean no. Agreeing in meetings, then questioning privately. Not advocating for yourself in negotiations. Letting boundary violations slide. Holding onto frustrations until they erupt.
+
+**Root:** Conflict was dangerous in family—peace at any cost. Disagreement led to punishment, withdrawal of love, or escalation into chaos. The lesson: your opinions are not worth the consequence of expressing them.
+
+**The cost:** Resentment. Loss of voice. Being overlooked because you never advocate. Decisions made without your input because you never offered it.
+
+**Sovereign shift:** "Professional disagreement is not personal attack. I can hold a different view and remain connected. My perspective has value even when others disagree. Conflict can be generative, not just destructive."
+
+---
+
+### The Perfectionist
+
+**Pattern:** Cannot finish until something is flawless. Procrastinates to avoid potential failure. Takes longer than necessary on tasks. Reviews work obsessively before submitting.
+
+**How it appears:** Missing deadlines due to over-revision. Unable to delegate because no one does it "right." Exhausted by projects that should be straightforward. Paralyzed by the first draft.
+
+**Root:** Excellence as protection. If you could be perfect, you could avoid criticism. Mistakes weren't learning opportunities—they were evidence of inadequacy. The bar was always just out of reach.
+
+**The cost:** Inefficiency. Missed opportunities. The inability to finish. Perfectionism as a prison that looks like ambition.
+
+**Sovereign shift:** "Done is better than perfect. Good enough is actually good enough. My value is not contingent on flawlessness. Mistakes are information, not indictments."
+
+---
+
+### The Chameleon
+
+**Pattern:** Changes personality based on context. Reads the room and becomes what's needed. Has no consistent professional identity. Exhausted from shapeshifting.
+
+**How it appears:** Different personas for different colleagues. Changing opinions to match the audience. Unable to answer "what do you really think?" Feeling unknown despite years at the same company.
+
+**Root:** Survival through adaptation. In unstable families, reading the room and becoming what was needed was essential for safety. Having a consistent self was a liability—flexibility was survival.
+
+**The cost:** Exhaustion. Loss of authentic self. Never being truly known. The loneliness of relationships built with versions of you that aren't real.
+
+**Sovereign shift:** "I can be myself in all contexts. I don't need to shapeshift to belong. My authentic self is enough for this environment. If it isn't, this may not be my environment."
 
 ---
 
@@ -114,40 +231,78 @@ These responses are **automatic**. The nervous system doesn't distinguish betwee
 - You trust your judgment without excessive consultation
 - You can make decisions without waiting for permission
 - You take responsibility for outcomes without collapsing
+- You can tolerate being wrong without it becoming an identity crisis
+- You know the difference between gathering input and seeking validation
 
 **In relationships:**
 - You can disagree with authority without panic
-- You can set boundaries with colleagues
+- You can set boundaries with colleagues without guilt
 - You can receive feedback without spiraling
+- You can have difficult conversations without catastrophizing
+- You can be liked without needing to be liked by everyone
 
 **In visibility:**
 - You can present your work without performing
 - You can be recognized without shame
 - You can lead without needing everyone to like you
+- You can take credit without diminishing
+- You can advocate for yourself without apology
 
 **In boundaries:**
-- You leave on time
-- You say no to what's not yours
+- You leave on time without elaborate justification
+- You say no to what's not yours without over-explaining
 - You don't absorb workplace stress as personal
+- You take vacation without checking email obsessively
+- You have a life outside of work that matters
 
 ---
 
 ## The Performance Trap
 
-Many high-achievers from difficult backgrounds learned:
+Many high-achievers from difficult backgrounds learned a foundational equation:
 
 **Excellence = Safety**
 
-If you were good enough, smart enough, accomplished enough—you could avoid criticism, rejection, or volatility.
+If you were good enough, smart enough, accomplished enough—you could avoid criticism, rejection, or volatility. Performance was protection. Achievement was armor.
 
-This pattern drives achievement but at a cost:
-- Burnout
-- Perfectionism
-- Inability to rest
-- Worth tied to output
-- Constant fear of exposure
+This equation drives success. It also drives destruction.
 
-**Sovereign shift:** "My worth is not my work. I do excellent work AND I am worthy regardless of outcome."
+The costs of the performance trap:
+- Burnout that looks like ambition
+- Perfectionism that looks like high standards
+- Inability to rest that looks like work ethic
+- Worth tied to output that looks like motivation
+- Constant fear of exposure that looks like attention to detail
+
+The performance trap convinces you that your worth must be earned every single day. That one failure negates a thousand successes. That rest is earned, not granted. That you are always one mistake away from being revealed.
+
+**What the performance trap fears most:** being ordinary. Being seen without achievement as a buffer. Being valued for existence, not production.
+
+**Sovereign shift:** "My worth is not my work. I do excellent work AND I am worthy regardless of outcome. My value exists even when I am unproductive. Rest is not earned—it is required."
+
+---
+
+## The Imposter Pattern
+
+Nearly everyone who grew up with inconsistent mirroring struggles with imposter syndrome. Here's why:
+
+When caregivers couldn't accurately reflect your qualities—your intelligence, your capability, your worth—you didn't develop a stable internal sense of competence. You learned to measure yourself through external validation.
+
+Now, no amount of evidence convinces you that you belong. Awards feel like flukes. Promotions feel like mistakes. Praise feels suspicious.
+
+**The imposter cycle:**
+1. Achieve something significant
+2. Wait for someone to notice it was a mistake
+3. Attribute success to luck, timing, or deception
+4. Work harder to avoid being "found out"
+5. Achieve something significant
+6. Repeat
+
+**What imposter syndrome protects against:** The vulnerability of believing in yourself. If you don't believe in yourself, you can't be devastated when others don't either. It's a preemptive rejection.
+
+**The truth underneath:** You're not an imposter. You were never adequately reflected. The problem isn't your competence—it's that competence never felt safe to claim.
+
+**Sovereign shift:** "I am qualified. Evidence supports this. The feeling of being an imposter is a pattern, not a prophecy. I can feel like a fraud and still be legitimate."
 
 ---
 
@@ -155,37 +310,79 @@ This pattern drives achievement but at a cost:
 
 Work boundaries are often harder than personal boundaries because:
 - Financial security is involved
-- Authority dynamics are formal
+- Authority dynamics are formal and enforced
 - Rejection has practical consequences
-- Cultural expectations vary
+- Cultural expectations vary by industry and company
+- Power imbalances are explicit
+
+Yet without boundaries, work consumes everything.
 
 **Principles for work boundaries:**
 
-1. **Start small.** Leave five minutes earlier. Say no to one thing.
-2. **Be matter-of-fact.** Boundaries don't require lengthy explanations.
-3. **Don't over-apologize.** "I can't take that on" is enough.
-4. **Accept that not everyone will approve.** Some colleagues will adjust; others won't.
-5. **Model consistency.** The boundary becomes normalized through repetition.
+**1. Start small.**
+Leave five minutes earlier than you think you should. Say no to one thing this week. Don't answer one email that can wait. Small experiments teach your nervous system that boundaries don't lead to catastrophe.
+
+**2. Be matter-of-fact.**
+Boundaries don't require lengthy explanations. "I'm not able to take that on" is complete. "I have a hard stop at 5" needs no justification. The more you explain, the more you invite negotiation.
+
+**3. Don't over-apologize.**
+"I can't take that on" is enough. "I'm so sorry, I really wish I could, but I just have so much going on right now, and I know this is important to you, and I feel terrible about it, but..." is too much. Every unnecessary apology undermines the boundary.
+
+**4. Accept that not everyone will approve.**
+Some colleagues will adjust without issue. Others will push back. Some relationships will shift. Not everyone needs to approve of your boundaries for your boundaries to be valid.
+
+**5. Model consistency.**
+The boundary becomes normalized through repetition. The first time you leave on time, it's noticed. The twentieth time, it's just who you are. Consistency is more powerful than any single declaration.
+
+**6. Expect internal discomfort.**
+Setting boundaries at work will feel uncomfortable—especially at first. Guilt, anxiety, and fear of consequences are normal. Feel them and hold the boundary anyway.
 
 ---
 
 ## A Practice: Before Difficult Work Interactions
 
-Use this before meetings, reviews, presentations, or conversations with authority figures:
+Use this before meetings, reviews, presentations, difficult conversations, or any interaction with authority figures:
 
-**Step 1:** Notice your body state.
-What's activated? Where do you feel tension?
+**Step 1: Notice your body state.**
+What's activated? Where do you feel tension? What's your breath doing? What posture are you holding?
+Don't try to change it—just notice.
 
-**Step 2:** Name the old pattern.
-"My nervous system thinks this is _________ (childhood authority figure)."
+**Step 2: Name the old pattern.**
+Say internally: "My nervous system thinks this is _________ (childhood authority figure)."
+This naming creates distance between the past and the present.
 
-**Step 3:** Ground in your adult self.
-"I am an adult professional. I have competence. I have choices."
+**Step 3: Ground in your adult self.**
+Say: "I am an adult professional. I have competence. I have choices. I can handle what happens here."
+Place your feet flat on the floor. Feel the solidity beneath you.
 
-**Step 4:** Set an intention.
-"In this interaction, I will _________ (speak once without over-explaining / stay regulated / not apologize for my position)."
+**Step 4: Set an intention.**
+"In this interaction, I will _________ (speak once without over-explaining / stay regulated even if challenged / not apologize for my position / take up space in the room)."
+Choose one specific intention, not five.
 
-**Step 5:** Breathe and enter.
+**Step 5: Breathe and enter.**
+Three slow breaths. Then move toward the interaction from choice, not reactivity.
+
+---
+
+## A Practice: After Difficult Work Interactions
+
+Use this when an interaction has activated you:
+
+**Step 1: Notice without judgment.**
+What's happening in your body? What thoughts are cycling? What emotions are present?
+
+**Step 2: Discharge the activation.**
+Walk. Shake your hands. Step outside. Get water. Move the energy through your body rather than letting it pool.
+
+**Step 3: Separate past from present.**
+Ask: "What part of my reaction was about right now, and what part was old material?"
+This isn't to dismiss your experience—it's to clarify it.
+
+**Step 4: Self-validate.**
+"That was hard, and I stayed present. Even if I didn't handle it perfectly, I was there. I didn't abandon myself."
+
+**Step 5: Decide on any follow-up.**
+Is there something to address? Something to let go? A conversation to have later? Decide from regulation, not reaction.
 
 ---
 
@@ -194,17 +391,24 @@ What's activated? Where do you feel tension?
 Some workplaces are genuinely toxic—not just triggering old patterns.
 
 Signs of a toxic workplace:
-- Chronic criticism without support
-- Moving goalposts
-- Gaslighting about agreements
-- Retaliation for boundaries
-- Leadership that cannot regulate
+- Chronic criticism without support or development
+- Moving goalposts that make success impossible
+- Gaslighting about agreements, expectations, or events
+- Retaliation for boundaries or reasonable requests
+- Leadership that cannot regulate and spills dysregulation onto staff
+- Consistent patterns of disrespect, dismissal, or devaluation
+- Requests that violate your ethics or wellbeing
+- An environment where you cannot succeed no matter what you do
 
 **Sovereignty doesn't mean staying in harm's way.**
 
-Sometimes the sovereign choice is to leave. Sometimes it's to document and protect yourself. Sometimes it's to minimize engagement while planning an exit.
+Sometimes the sovereign choice is to leave. Sometimes it's to document and protect yourself while planning an exit. Sometimes it's to minimize engagement while seeking other opportunities. Sometimes it's to name what's happening and risk the consequence.
 
-You're allowed to leave environments that cannot meet basic professional standards.
+You're allowed to leave environments that cannot meet basic professional standards. Your nervous system is not required to tolerate what is genuinely harmful.
+
+**The discernment question:** "Is this environment activating old wounds that I need to heal, or is this environment genuinely wounding me?"
+
+Both require response—but different responses. The first requires internal work. The second requires exit.
 
 ---
 
@@ -212,14 +416,44 @@ You're allowed to leave environments that cannot meet basic professional standar
 
 If you're in a leadership position—or moving toward one—sovereignty is essential.
 
-Sovereign leadership:
-- Doesn't need everyone's approval
-- Can make unpopular decisions
-- Stays regulated under pressure
-- Takes responsibility without collapsing
-- Models the behavior it expects
+Leadership without sovereignty becomes:
+- Performance pretending to be confidence
+- Control pretending to be organization
+- Approval-seeking pretending to be collaboration
+- Overwork pretending to be dedication
 
-The most influential leaders are often the most regulated. People follow steadiness, not performance.
+Sovereign leadership:
+- Doesn't need everyone's approval to make decisions
+- Can make unpopular decisions and tolerate the discomfort
+- Stays regulated under pressure so others can regulate
+- Takes responsibility without collapsing into shame
+- Models the behavior it expects from others
+- Can hold boundaries while remaining connected
+- Leads from steadiness, not from anxiety
+
+The most influential leaders are often the most regulated. People follow steadiness, not performance. People trust presence, not posturing.
+
+**The paradox of sovereign leadership:** The less you need approval, the more influence you have. The less you chase respect, the more it's given.
+
+---
+
+## When You're the Calming Presence
+
+As you develop workplace sovereignty, you may notice something shift:
+
+You become the regulating presence in dysregulated environments.
+
+When others escalate, your steadiness becomes a reference point. When conflict arises, people look to you. When uncertainty floods the room, your groundedness provides orientation.
+
+This is not a burden to take on. It's a natural consequence of the work you've done.
+
+**Boundaries for being the calming presence:**
+- You can offer regulation without being responsible for others' states
+- You can be steady without being the only source of calm
+- You can model without fixing
+- You can be present without absorbing
+
+Your regulation is a gift. It's not an obligation.
 
 ---
 
@@ -229,10 +463,12 @@ The most influential leaders are often the most regulated. People follow steadin
 - Where do I over-function, seek approval, or avoid visibility?
 - What would sovereignty look like in my current work situation?
 - What boundaries would serve my professional wellbeing?
+- Which authority figures at work trigger old patterns?
+- What one small shift could I make this week?
 
-**Body cue to notice:** Anxiety before authority interactions, exhaustion from over-performing
+**Body cue to notice:** Anxiety before authority interactions, exhaustion from over-performing, the urge to check if you're okay
 
-**Practice:** Ground before meetings with authority figures
+**Practice:** Ground before meetings with authority figures. Notice the pattern. Choose a different response.
 
 ---
 
@@ -246,16 +482,15 @@ The most influential leaders are often the most regulated. People follow steadin
 
 Work is not separate from sovereignty—it's another arena for practice.
 
-Every meeting, every decision, every interaction with authority is an opportunity to stay in yourself while engaging professionally.
+Every meeting, every decision, every interaction with authority is an opportunity to stay in yourself while engaging professionally. Every email is a chance to hold your center. Every negotiation is a test of whether you can want something and tolerate not getting it.
 
 You can be excellent without being depleted.
 You can be visible without being vulnerable.
 You can lead without performing.
+You can have a career without losing yourself.
 
 That's sovereignty at work.
 
 ---
 
 **[Continue to Chapter 15: Navigating Others' Dysregulation →](./15-navigating-dysregulation.md)**
-
-

--- a/book/vol-3-sovereignty/chapters/15-navigating-dysregulation.md
+++ b/book/vol-3-sovereignty/chapters/15-navigating-dysregulation.md
@@ -14,6 +14,8 @@ This is where sovereignty gets practical.
 
 **How do you stay regulated in the presence of dysregulation—without absorbing, fixing, or abandoning?**
 
+This is perhaps the most demanding test of everything you've learned.
+
 ---
 
 ## Field Note (Before): The Emotional Firefighter
@@ -22,9 +24,13 @@ His friend is spiraling.
 
 Before he can think, he's in problem-solving mode. Offering advice. Managing the crisis. Staying calm so they don't have to.
 
-Hours later, he's exhausted—and he hasn't said a word about his own day.
+He can feel the familiar tightening in his chest—the signal that he's taking on something that isn't his. But he doesn't stop. He can't stop. Stopping feels like abandonment.
 
-He can't figure out why he keeps losing himself.
+Hours later, he's exhausted—and he hasn't said a word about his own day. He drove thirty minutes to be here, cancelled plans, and now he's sitting in his car in the parking lot, too drained to drive home.
+
+He can't figure out why he keeps losing himself. Why his friendships always feel like rescue missions. Why being "the strong one" leaves him so depleted.
+
+He knows this pattern. He just doesn't know how to break it.
 
 ---
 
@@ -32,15 +38,49 @@ He can't figure out why he keeps losing himself.
 
 His friend is spiraling.
 
+He notices the pull. The urgency. The familiar impulse to step in, solve, fix, rescue.
+
+He breathes. He feels his feet on the floor.
+
 He listens. He nods. He doesn't interrupt with solutions.
 
 When there's a pause, he says: "That sounds really hard."
 
-His friend keeps talking. Eventually, they settle.
+His friend keeps talking. He doesn't fill the space. He doesn't offer fixes. He stays present without taking over.
+
+Eventually, his friend settles. The storm passes—not because he intervened, but because he held steady while it moved through.
 
 He didn't fix anything. He didn't absorb anything.
 
 He witnessed—and that was enough.
+
+And when he drives home, he still has himself.
+
+---
+
+## Field Note: The Family Dinner
+
+She knows what's coming.
+
+Her mother is upset about something—the way the table was set, the timing of the meal, some perceived slight that no one else can see.
+
+The room tenses. Her father retreats. Her sister starts explaining, defending, de-escalating.
+
+She watches herself reach for the familiar role: soothe, smooth, manage. She can feel the old choreography in her body, the steps she's danced a thousand times.
+
+But tonight, she doesn't dance.
+
+She stays seated. She breathes. She watches her mother's storm without stepping into it.
+
+The discomfort is immense. Every cell in her body is screaming to fix this, to make everyone comfortable, to restore equilibrium.
+
+She sits with it.
+
+After dinner, her mother is still upset. Her sister is frustrated. Her father is distant.
+
+And she—for the first time in years—is intact.
+
+Nothing got resolved. But she didn't lose herself trying to resolve it.
 
 ---
 
@@ -54,16 +94,21 @@ When someone near you is:
 - Overwhelmed
 - Collapsing
 - Escalating
+- Panicking
+- Spiraling
 
-your nervous system picks up the signal. **Mirror neurons** fire. The **amygdala** scans for threat. Stress hormones prepare you to respond.
+your nervous system picks up the signal. **Mirror neurons** fire, simulating their emotional state in your own body. The **amygdala** scans for threat, uncertain whether their danger is also your danger. Stress hormones prepare you to respond—fight, flight, freeze, or fawn.
 
-This is automatic—it's not a choice.
+This is automatic—it's not a choice. It's how human nervous systems have been designed by millions of years of evolution. We are social creatures, and the emotions of those around us register in our bodies before we consciously perceive them.
 
 For those trained in enmeshed or volatile environments, this contagion is stronger:
-- You feel responsible for their state
-- You feel urgent to fix it
-- You feel guilty if you don't engage
-- Your body reacts as if their emergency is your emergency
+- You feel responsible for their state, as if their dysregulation is a problem you're obligated to solve
+- You feel urgent to fix it, as if leaving them in distress is a moral failure
+- You feel guilty if you don't engage, as if your regulation is somehow abandonment
+- Your body reacts as if their emergency is your emergency, regardless of the facts
+- Their discomfort becomes literally intolerable in your own body
+
+This isn't weakness. It's training. You were conditioned to respond this way because once, it was necessary for survival.
 
 **Sovereignty is the practice of noticing this contagion and choosing not to join it.**
 
@@ -75,55 +120,118 @@ Here's what research shows:
 
 **The most regulated nervous system in the room often sets the tone.**
 
-When you stay grounded while others are activated:
+This is called **co-regulation**—the phenomenon whereby nervous systems in proximity influence each other. When you stay grounded while others are activated:
 - Your calm becomes a reference point
 - Others' nervous systems have something to regulate toward
-- Urgency decreases
-- Clarity increases
+- Urgency decreases as your steadiness provides containment
+- Clarity increases when someone isn't matching the chaos
 
-**Key insight:** You influence others more by staying regulated than by fixing their problems.
+The **polyvagal system** explains this: when your vagal tone is high (indicating safety and regulation), you broadcast cues of safety to those around you. Your facial expression, your voice tone, your posture—all communicate that the environment is not as threatening as their nervous system believes.
 
-**Translation:** Your steadiness is the most valuable thing you can offer a dysregulated person.
+This isn't manipulation. It's biology. Nervous systems are designed to seek regulation, and a regulated person provides an anchor.
+
+**Key insight:** You influence others more by staying regulated than by fixing their problems. Your steadiness does more than your solutions ever could.
+
+**Translation:** Your calm presence is the most valuable thing you can offer a dysregulated person. Not your advice. Not your solutions. Not your willingness to take on their emergency. Your regulated nervous system.
 
 ---
 
 ## What NOT to Do
 
 ### Don't Absorb
+
 Taking on their emotional state as your own doesn't help them—and it depletes you.
 
+When you absorb, you don't reduce the total amount of dysregulation in the room—you just spread it to your own body. Now there are two dysregulated people instead of one.
+
+Signs you're absorbing:
+- You feel their anxiety in your chest
+- Their anger becomes your agitation
+- You leave the interaction exhausted
+- You can't stop thinking about their problem
+- Their mood affects your mood for hours or days
+
+**The truth:** You cannot regulate someone by becoming dysregulated with them. Absorption is not empathy—it's enmeshment.
+
 ### Don't Fix
+
 Offering solutions when someone is flooded often escalates, not calms.
 
+When the limbic system is activated, the prefrontal cortex (where logic and planning happen) is offline. Your brilliant solutions can't land because the part of the brain that processes solutions isn't available.
+
+What feels like helping is often experienced as dismissing: "You shouldn't feel this way—here's how to fix it."
+
+**The truth:** People need to feel felt before they can hear solutions. Fixing prematurely communicates: "I can't tolerate your distress."
+
 ### Don't Match
+
 Escalating to match their energy validates the dysregulation.
 
+If they're yelling and you yell back, you've confirmed that yelling is appropriate. If they're panicking and you panic with them, you've confirmed that panic is warranted.
+
+Matching dysregulation doesn't create connection—it creates amplification.
+
 ### Don't Disappear
+
 Complete withdrawal can feel like abandonment and increase their activation.
 
+There's a difference between holding a boundary and leaving someone in crisis. Disappearing without acknowledgment can trigger abandonment wounds and intensify dysregulation.
+
+The goal is not to abandon but to remain present without absorbing.
+
 ### Don't Take It Personally
+
 Their dysregulation is about their nervous system, not about you.
+
+When someone is activated, they often say things they don't mean, project onto you, or misread your intentions. This isn't about your character—it's about their state.
+
+**The test:** Can you stay in yourself even when someone's dysregulation is directed at you?
 
 ---
 
 ## What TO Do
 
 ### Stay in Your Body
-Ground. Breathe. Feel your feet. Return to yourself as often as needed.
+
+Ground. Breathe. Feel your feet on the floor. Return to yourself as often as needed.
+
+When you notice yourself starting to absorb or react, this is your first move. Come back to your own body. Feel your hands. Notice your breath. Remind your nervous system where you end and they begin.
+
+You may need to do this multiple times in a single interaction. That's normal.
 
 ### Witness Without Absorbing
+
 "I see you're struggling. That sounds hard."
-You acknowledge without taking on.
+
+You acknowledge their experience without taking it on. You communicate presence without promising to fix.
+
+Witnessing says: "I'm here with you in this." It doesn't say: "I'll take this from you."
 
 ### Offer Presence, Not Solutions
-Often people need to be heard before they can hear solutions.
+
+Often people need to be heard before they can hear solutions. Sometimes they never need solutions—they just need to move the emotion through their system.
+
+Presence is: eye contact, steady breathing, open posture, silence that doesn't rush.
+
+Presence says: "There's room for this. You're not too much."
 
 ### Set Limits If Needed
+
 "I can be here for about 15 more minutes."
 "I'm not able to talk about this right now."
+"I care about you, and I need to step away."
+
+Limits are not abandonment. They're honest acknowledgment of your capacity.
+
+You can hold compassion and hold limits simultaneously. One does not negate the other.
 
 ### Model Regulation
+
 Your calm is more powerful than your words.
+
+Speak slowly. Breathe visibly. Lower your volume. Soften your face.
+
+Your nervous system is a teaching tool. When you stay regulated, you offer a template for their nervous system to follow.
 
 ---
 
@@ -133,11 +241,38 @@ Highly empathic people often believe:
 
 **"If I feel their pain, I'm showing that I care."**
 
-But empathy without boundaries is absorption. And absorption doesn't help—it just creates two dysregulated people.
+This belief is understandable. It may have even been trained: perhaps the only way your pain was acknowledged was when someone else felt it with you.
+
+But empathy without boundaries is absorption. And absorption doesn't help—it just creates two dysregulated people where before there was one.
+
+**What absorption actually communicates:**
+- "Your feelings are too big for you to handle alone"
+- "I can only connect with you by joining your suffering"
+- "Separation is abandonment"
 
 **True compassion maintains distinction:**
 
-"I can see your suffering without becoming it. I can care about your pain without carrying it."
+"I can see your suffering without becoming it. I can care about your pain without carrying it. I can stay present without losing myself."
+
+This isn't coldness. This is sustainable care. This is how you remain available instead of burned out.
+
+**The paradox:** You're more helpful when you don't absorb. Your regulation provides a container that pure absorption cannot offer.
+
+---
+
+## The Mirror Neuron Challenge
+
+Mirror neurons are why emotions spread. When you see someone in distress, neurons in your brain fire as if you were in distress yourself. This is the biological basis of empathy—and the mechanism of emotional contagion.
+
+For those with trauma histories, mirror neurons may be hyperactive. You don't just notice others' emotions—you experience them in your own body with full intensity.
+
+**This is not a flaw.** It may have been a survival advantage. Reading others accurately and responding immediately was protective in dangerous environments.
+
+**But it requires management now.**
+
+The work is not to shut down the mirror neurons—it's to add a layer of processing between perception and response. You feel the resonance AND you notice that it's resonance. You experience the pull AND you recognize it as contagion.
+
+This awareness creates a gap. In that gap, choice lives.
 
 ---
 
@@ -147,41 +282,84 @@ But empathy without boundaries is absorption. And absorption doesn't help—it j
 - "That sounds really difficult."
 - "I hear you."
 - "That makes sense that you'd feel that way."
+- "This seems really hard right now."
+- "I can see you're struggling."
 
-**To set limits:**
+**To set limits with compassion:**
 - "I'm not able to be helpful right now."
 - "I can listen for a few minutes, but I'm not able to problem-solve."
 - "I care about you, and I need to step away."
+- "I want to support you, but I'm at capacity."
+- "Let's pause and come back to this later."
 
-**To redirect:**
+**To redirect toward their resources:**
 - "What do you need right now?"
 - "Would it help to take a breath together?"
 - "Is there something specific you need from me?"
+- "What's helped you with this before?"
+- "Who else in your life can support you with this?"
 
 **To exit gracefully:**
 - "I need to go. I'll check in later."
-- "I can see you're struggling. I don't have capacity right now."
+- "I can see you're struggling. I don't have capacity right now, but I'll reach out tomorrow."
 - "I love you. I can't do this conversation right now."
+- "I'm going to step away for a bit. This doesn't mean I don't care."
 
 ---
 
 ## When Dysregulation Becomes Pattern
 
-Some people are chronically dysregulated. They:
-- Escalate frequently
-- Need others to regulate them
-- Don't take responsibility for their state
-- Use crisis to connect
+Some people are chronically dysregulated. Not occasionally struggling—persistently unable to regulate without external intervention.
+
+They:
+- Escalate frequently, with small triggers producing large reactions
+- Need others to regulate them, unable to return to baseline alone
+- Don't take responsibility for their state, treating emotions as things that happen to them
+- Use crisis to connect, as if emergency is the only valid reason for attention
+- Resist tools and strategies, remaining stuck despite offers of help
+- Drain everyone around them, leaving a trail of exhausted supporters
 
 If someone in your life fits this pattern, you have choices:
 
-**Limit exposure:** Reduce time, frequency, or depth of interaction.
+**Limit exposure:**
+Reduce time, frequency, or depth of interaction. You don't need to explain or justify—you can simply be less available.
 
-**Set clear boundaries:** "I'm not able to be your emotional support for this."
+**Set clear boundaries:**
+"I'm not able to be your emotional support for this."
+"I can talk for 15 minutes. After that, I need to go."
+"I care about you, and I can't be available every time you're struggling."
 
-**Don't reward escalation:** Don't give more attention when they escalate.
+**Don't reward escalation:**
+If escalation brings more attention, escalation will continue. This isn't about punishment—it's about not reinforcing patterns that harm both of you.
 
-**Accept reality:** They may not change. Your role is to manage your exposure, not their growth.
+**Accept reality:**
+They may not change. Their growth is not your responsibility. Your role is to manage your exposure, not their development.
+
+**Consider the relationship:**
+Is this relationship sustainable? Does it nourish you, or only drain you? Is there reciprocity, or only one-way giving?
+
+These are hard questions. They're also necessary.
+
+---
+
+## The Fawn Response
+
+Many people who struggle with others' dysregulation have a well-developed **fawn response**—the tendency to appease, please, and accommodate when threatened.
+
+Unlike fight or flight, fawning keeps you close to the threat. It's a survival strategy that works through compliance: "If I make them comfortable, I'll be safe."
+
+Signs you're in fawn response:
+- You abandon your position immediately when someone is upset
+- You apologize reflexively, even when you've done nothing wrong
+- You feel responsible for managing everyone's emotions
+- You can't tolerate anyone being uncomfortable around you
+- You lose track of your own preferences in favor of others'
+
+**The fawn response served you.** In environments where asserting yourself was dangerous, compliance was intelligent.
+
+**But it no longer serves you.** Now, fawning keeps you trapped in one-sided relationships and prevents you from holding your own center.
+
+Recognizing fawn is the first step. When you notice the urge to appease, you can name it: "This is fawn. I'm safe. I don't need to abandon myself."
 
 ---
 
@@ -189,22 +367,63 @@ If someone in your life fits this pattern, you have choices:
 
 Use this when someone around you is dysregulated:
 
-**Step 1:** Notice your own activation.
+**Step 1: Notice your own activation.**
 Where is it in your body? Name it: *"I'm getting activated."*
+Don't try to talk yourself out of it—just notice it.
 
-**Step 2:** Ground before engaging.
-Three breaths. Feet on floor. Return to yourself.
+**Step 2: Ground before engaging.**
+Three breaths. Feet on floor. Hand on chest if needed.
+Return to yourself before attempting to be with them.
 
-**Step 3:** Ask yourself:
-- "Is this my emergency?"
-- "What's mine to do here?"
-- "Can I help without absorbing?"
+**Step 3: Ask yourself three questions:**
+- "Is this my emergency?" (Usually, no.)
+- "What's mine to do here?" (Less than you think.)
+- "Can I help without absorbing?" (Only if regulated.)
 
-**Step 4:** Engage from regulation.
-Speak slowly. Offer presence. Set limits as needed.
+**Step 4: Engage from regulation.**
+Speak slowly. Lower your volume. Offer presence before solutions. Set limits as needed.
 
-**Step 5:** Discharge afterward.
-Walk. Breathe. Shake off what isn't yours.
+**Step 5: Discharge afterward.**
+Walk. Breathe deeply. Shake off what isn't yours. Check in with your own body.
+
+The activation you picked up isn't yours to keep. Let it move through.
+
+---
+
+## A Practice: The Separation Breath
+
+When you're in the presence of someone dysregulated and feel yourself starting to absorb:
+
+**Step 1:** Place one hand on your chest.
+
+**Step 2:** Take a slow breath and say internally: "This is me."
+
+**Step 3:** Exhale and say internally: "That is them."
+
+**Step 4:** Repeat until you feel the boundary reestablish.
+
+This simple practice reminds your nervous system where you end and they begin. It creates distinction without creating disconnection.
+
+---
+
+## A Practice: Post-Exposure Recovery
+
+After extended time with a dysregulated person, you may carry their energy. Use this to discharge:
+
+**Step 1: Acknowledge.**
+"I took on something that wasn't mine."
+
+**Step 2: Move.**
+Walk, shake, stretch—move the stagnant energy through your body.
+
+**Step 3: Cleanse.**
+Shower. Wash your hands intentionally. Change clothes if needed. Use the physical as a metaphor for the energetic.
+
+**Step 4: Refill.**
+What nourishes you? Nature? Music? Silence? Give your system what it needs to return to baseline.
+
+**Step 5: Reflect.**
+What can you do differently next time? Not to blame yourself—but to learn.
 
 ---
 
@@ -213,16 +432,37 @@ Walk. Breathe. Shake off what isn't yours.
 Sometimes sovereignty means grieving that the people around you can't meet you where you are.
 
 You've done the work. They haven't.
+You can regulate. They can't.
+You've changed. They've stayed the same.
 
 This can feel:
-- Lonely
-- Frustrating
-- Sad
-- Isolating
+- Lonely, like you're speaking a language no one else understands
+- Frustrating, when you see patterns they can't see
+- Sad, mourning the connection that could have been
+- Isolating, wondering if you've grown apart from everyone
 
-That grief is valid. And it doesn't mean you should return to old patterns.
+That grief is valid. And it doesn't mean you should return to old patterns to belong again.
 
 You can grieve the gap AND stay sovereign.
+You can feel lonely AND not absorb to feel connected.
+You can miss how things were AND refuse to go back.
+
+The loneliness of sovereignty is real. It's also temporary. As you hold your frequency, you'll find others who match it.
+
+---
+
+## When You Slip
+
+You will absorb sometimes. You will lose yourself sometimes. You will get pulled into someone's storm and only realize it afterward.
+
+This is not failure. This is practice.
+
+What matters is what happens next:
+- Do you notice?
+- Do you return to yourself?
+- Do you learn something for next time?
+
+Sovereignty isn't perfection. It's the commitment to keep returning, no matter how many times you leave.
 
 ---
 
@@ -232,8 +472,10 @@ You can grieve the gap AND stay sovereign.
 - How does their state affect mine?
 - What would it look like to witness without absorbing?
 - What limits might I need to set?
+- Where do I fawn instead of hold my center?
+- What's my recovery practice after exposure?
 
-**Body cue to notice:** Urgency to fix, tightness in chest, automatic caretaking
+**Body cue to notice:** Urgency to fix, tightness in chest, automatic caretaking, loss of your own state
 
 **Practice:** Regulate yourself first, then engage
 
@@ -249,16 +491,22 @@ You can grieve the gap AND stay sovereign.
 
 You will encounter dysregulated people for the rest of your life.
 
+In families, in workplaces, in friendships, in the world. Dysregulation is part of the human experience, and you cannot build walls high enough to avoid it entirely.
+
 Sovereignty isn't avoiding them—it's staying yourself while being near them.
 
 Your regulation is not a wall. It's a gift.
 
 It gives others something to organize around.
+It provides a template their nervous systems can follow.
+It creates safety in spaces that feel unsafe.
 
 And it keeps you intact.
+
+This is the work now: to be in the world without losing yourself. To care without carrying. To witness without absorbing. To love without disappearing.
+
+You can do this.
 
 ---
 
 **[Continue to Chapter 16: Holding Space Without Rescuing →](./16-holding-space.md)**
-
-

--- a/book/vol-3-sovereignty/chapters/16-holding-space.md
+++ b/book/vol-3-sovereignty/chapters/16-holding-space.md
@@ -6,15 +6,18 @@
 
 "Hold space" has become a popular phrase.
 
+It appears in wellness circles, therapy contexts, spiritual communities. Everyone wants to hold space. Everyone wants space held for them.
+
 But many people who think they're holding space are actually:
-- Absorbing emotions
-- Fixing problems
-- Managing outcomes
+- Absorbing emotions that aren't theirs
+- Fixing problems that don't need fixing
+- Managing outcomes they can't control
 - Rescuing people from their own feelings
+- Depleting themselves in the name of support
 
 True space-holding is different.
 
-**It is presence without agenda. Witness without intervention. Support without rescue.**
+**It is presence without agenda. Witness without intervention. Support without rescue. Containment without absorption.**
 
 And it requires sovereignty.
 
@@ -24,15 +27,17 @@ And it requires sovereignty.
 
 Her sister is crying.
 
-She immediately moves into action: tissues, solutions, comfort.
+She immediately moves into action: tissues, solutions, comfort. She lists options. She reminds her sister of her strengths. She offers to call, to come over, to fix.
 
-She says all the right things. She stays until the tears stop.
+She says all the right things. She stays until the tears stop. She makes sure her sister is okay before she allows herself to leave.
 
-She leaves feeling like a good sister—and completely drained.
+She leaves feeling like a good sister—and completely drained. Her own day forgotten. Her own needs on hold.
 
 A week later, her sister is in the same place. Crying. Needing rescue.
 
-The pattern repeats.
+The pattern repeats. The sister never builds capacity. The rescuer never rests.
+
+She doesn't understand why her help doesn't stick. She doesn't see that her rescue is part of the loop.
 
 ---
 
@@ -40,71 +45,119 @@ The pattern repeats.
 
 Her sister is crying.
 
-She sits. Listens. Doesn't reach for tissues.
+She notices the familiar pull: the urgency to fix, the impulse to make it stop, the discomfort of witnessing someone she loves in pain.
 
-The silence stretches.
+She breathes. She sits. Listens. Doesn't reach for tissues.
+
+The silence stretches. She doesn't fill it.
 
 "This is really painful," she says.
 
 Her sister nods. Keeps crying.
 
-She doesn't fix it. She doesn't offer solutions.
+She doesn't fix it. She doesn't offer solutions. She doesn't promise it will be okay.
 
 She stays.
 
-Eventually, her sister exhales. Sits up. Says, "Thank you for just being here."
+Eventually, her sister exhales. Sits up. Looks around. Says, "Thank you for just being here."
 
-Something shifted—without rescue.
+Something shifted—without rescue. Not because she intervened, but because she didn't.
+
+And when she leaves, she still has herself.
+
+---
+
+## Field Note: The Friend in Crisis
+
+He calls at 11pm. Again.
+
+This is the third time this month. The same crisis, different details. The same spiral, different triggers.
+
+In the past, she would have stayed on the phone for hours. Offered advice. Talked him down. Sacrificed her sleep to be a good friend.
+
+Tonight, something is different.
+
+She listens for fifteen minutes. She hears the familiar rhythm—the loop he can't seem to break.
+
+"I care about you," she says. "And I can't be available at this hour anymore. Let's talk tomorrow."
+
+His voice tightens. She feels the pull—the guilt, the fear that she's abandoning him.
+
+She stays with her choice. She says goodnight. She hangs up.
+
+She lies awake for a while, uncomfortable. But she also has her own bed, her own night, her own life.
+
+Something has shifted. Not in him—in her.
 
 ---
 
 ## Why We Rescue
 
-Rescuing feels like love. But it's often:
+Rescuing feels like love. It looks like care. It registers in the body as doing something—which is more comfortable than doing nothing.
+
+But rescue is often:
 - Anxiety disguised as care
 - Control disguised as help
 - Discomfort with others' pain
 - Avoidance of our own helplessness
+- A bid for value through usefulness
 
-For those who grew up as the fixer, helper, or peacekeeper, rescue is automatic.
+For those who grew up as the fixer, helper, or peacekeeper, rescue is automatic. It was survival. It was the only way to matter, to belong, to be safe.
 
-The belief underneath:
+The beliefs underneath:
 - "If I don't fix this, something bad will happen"
 - "Their pain is too much for them to bear"
 - "I'm only valuable when I'm helping"
 - "I can't tolerate their discomfort"
+- "Good people don't stand by when others suffer"
+- "If I don't step in, who will?"
 
 **Rescue is often about our discomfort, not theirs.**
 
+We fix because we can't bear to witness. We solve because we can't sit in uncertainty. We rescue because helplessness is intolerable.
+
+But here's what rescue communicates: "I don't believe you can handle this."
+
+And that's not love. That's doubt.
+
 ---
 
-## Neuroscience Lens: Rescue as Regulation
+## Neuroscience Lens: Rescue as Self-Regulation
 
-When someone we care about is in distress, our **mirror neurons** activate their experience in us.
+When someone we care about is in distress, our **mirror neurons** activate their experience in our own body. We don't just observe their pain—we feel a version of it.
 
-For highly empathic people, this can feel unbearable.
+For highly empathic people, this mirroring can be intense. Their distress becomes our distress. Their emergency becomes our emergency. The boundaries blur.
 
 **Rescue becomes a strategy for regulating our own discomfort.**
 
-If we fix them, we feel better. If they calm down, our nervous system calms down.
+If we fix them, we feel better. If they calm down, our nervous system calms down. If we solve the problem, we no longer have to sit with the intolerable sensation of witnessing suffering without intervening.
 
-**Key insight:** Rescue often serves the rescuer more than the rescued.
+**Key insight:** Rescue often serves the rescuer more than the rescued. We fix to relieve our own distress, not necessarily theirs.
 
-**Translation:** Learning to hold space means learning to tolerate your own discomfort while someone else is suffering.
+**Translation:** Learning to hold space means learning to tolerate your own discomfort while someone else is suffering. It means staying regulated in the face of their dysregulation—without using their change as your calming strategy.
+
+This is hard. It's also essential.
 
 ---
 
 ## What Rescue Actually Does
 
 Rescue:
-- Communicates "You can't handle this"
-- Creates dependence
-- Prevents the other person from building capacity
-- Keeps you in the "helper" role
-- Depletes your resources
-- Often enables patterns to continue
+- Communicates "You can't handle this alone"
+- Creates dependence rather than capacity
+- Prevents the other person from building their own resilience
+- Keeps you in the "helper" role, reinforcing your identity through their need
+- Depletes your resources over time
+- Often enables patterns to continue rather than transform
+- Teaches them that rescue is available, so they don't develop self-rescue
 
 When you rescue someone from their feelings, you don't help them—you prevent their growth.
+
+Feelings are meant to be felt. Struggles are meant to be navigated. Capacity is built through experience, not through being saved from experience.
+
+Every time you rescue, you say: "This is too much for you." Every time they're rescued, they internalize: "This is too much for me."
+
+The kindest thing is often the hardest: letting someone sit in their difficulty while you witness without intervening.
 
 ---
 
@@ -115,19 +168,23 @@ Holding space is:
 - Witness without interpretation
 - Support without fixing
 - Containment without absorption
-- Trust in their capacity
+- Trust in their capacity to navigate their own experience
 
 Holding space says:
 - "I see you."
 - "I trust you can navigate this."
 - "I'm here, and I'm not going anywhere."
-- "Your feelings are allowed."
+- "Your feelings are allowed here."
+- "I don't need this to change for me to stay present."
 
 It does NOT say:
 - "Let me fix this for you."
 - "Here's what you should do."
 - "Don't feel that way."
 - "I'll make it better."
+- "You're too fragile for this."
+
+Holding space requires faith in the other person's capacity—faith they may not have in themselves. It's a form of seeing someone as whole when they feel broken.
 
 ---
 
@@ -145,28 +202,83 @@ The container:
 - Doesn't leak (doesn't absorb)
 - Doesn't crack (doesn't collapse)
 - Stays present (doesn't disappear)
+- Doesn't try to alter what's inside (doesn't fix)
 
 You hold the space. You don't manage what happens inside it.
+
+The container is not passive. It takes strength to hold a container. It takes solidity. It takes the willingness to be present while something moves through that you can't control.
+
+**What happens inside the container is not your responsibility.**
+
+Your responsibility is to be the container: steady, present, available, intact.
+
+---
+
+## The Difference: Container vs. Rescuer
+
+**The Rescuer:**
+- Jumps into the contents
+- Gets wet with their emotions
+- Tries to scoop out the pain
+- Exhausts themselves in the process
+- Makes the experience about their help
+
+**The Container:**
+- Holds the space for the contents
+- Stays dry while witnessing
+- Trusts the process will complete
+- Remains available without depleting
+- Makes the experience about their presence
 
 ---
 
 ## What Holding Space Feels Like
 
 In your body, holding space feels like:
-- Groundedness
-- Spaciousness
-- Calm presence
-- Steady breathing
-- Feet on the floor
+- Groundedness—feet connected to floor
+- Spaciousness—room in your chest
+- Calm presence—steady heartbeat
+- Steady breathing—slow, rhythmic
+- Openness—soft muscles, relaxed jaw
 
 NOT like:
-- Urgency
-- Anxiety
-- Need to fix
-- Tension
-- Breathlessness
+- Urgency—need to do something now
+- Anxiety—tight chest, racing thoughts
+- Need to fix—restless energy in hands
+- Tension—held breath, clenched jaw
+- Breathlessness—constricted lungs
 
 If you feel urgent to fix, you're not holding space—you're in rescue mode.
+
+The physical sensations are your guide. Check in with your body. If you're contracted, constricted, urgent—pause. Return to yourself. Ground. Then decide how to engage.
+
+---
+
+## The Art of Witnessing
+
+Witnessing is more than watching. It's active presence without intervention.
+
+To witness is to:
+- See someone fully, without looking away
+- Remain present without escaping into fixing
+- Allow their experience without needing it to change
+- Hold steady while they move through what they're moving through
+- Communicate through presence: "I'm here. You're not alone. I'm not leaving."
+
+Witnessing is rare. Most people are either:
+- Fixing (trying to change the experience)
+- Fleeing (escaping into distraction or leaving)
+- Absorbing (taking on the experience as their own)
+- Judging (evaluating the experience as right or wrong)
+
+To simply witness—to be present without agenda—is a skill most people never develop.
+
+**What witnessing requires of you:**
+- Tolerance of your own helplessness
+- Regulation of your own discomfort
+- Faith in the other person's capacity
+- Surrender of your need to be useful
+- Acceptance that some things cannot be fixed
 
 ---
 
@@ -174,61 +286,146 @@ If you feel urgent to fix, you're not holding space—you're in rescue mode.
 
 Use this when someone you care about is in distress:
 
-**Step 1:** Ground yourself first.
+**Step 1: Ground yourself first.**
 Feet on floor. Slow breath. Return to your body.
+You cannot hold space if you're ungrounded. Regulation comes first.
 
-**Step 2:** Notice the urge to rescue.
+**Step 2: Notice the urge to rescue.**
 Name it: *"I want to fix this."*
+Don't judge the urge—it's natural. Just notice it.
 
-**Step 3:** Choose presence instead.
+**Step 3: Choose presence instead.**
 Remind yourself: *"My presence is the gift. Not my solutions."*
+Repeat as needed.
 
-**Step 4:** Witness without interpreting.
+**Step 4: Witness without interpreting.**
 Listen. Nod. Make eye contact. Don't fill silences.
+Resist the urge to explain, analyze, or solve.
 
-**Step 5:** Reflect simply.
+**Step 5: Reflect simply.**
+If words are needed, keep them simple:
 "That sounds hard."
 "I see you."
 "I'm here."
+Not: "Have you tried..." or "You should..." or "It'll be okay."
 
-**Step 6:** Trust their capacity.
+**Step 6: Trust their capacity.**
 They can navigate this. You don't have to do it for them.
+Their growth depends on their own navigation, not your rescue.
+
+---
+
+## A Practice: The Five-Minute Hold
+
+When you feel overwhelmed by someone's distress and want to rescue:
+
+**Step 1:** Commit to five minutes of only witnessing.
+Set a mental timer. For five minutes, you will not offer solutions.
+
+**Step 2:** During those five minutes:
+- Listen actively
+- Breathe slowly
+- Stay in your body
+- Let silence exist
+
+**Step 3:** After five minutes:
+Ask: "Is there something specific you need from me?"
+Let them answer. Don't assume.
+
+Often, by the end of five minutes, they've moved through the initial wave and don't need rescue at all.
+
+---
+
+## A Practice: The Helplessness Tolerance
+
+Rescue is often a defense against helplessness. This practice builds tolerance:
+
+**Step 1:** When someone is struggling and you feel the urge to fix, notice the sensation of helplessness underneath.
+
+**Step 2:** Name it: "I feel helpless right now."
+
+**Step 3:** Breathe into it. Don't escape. Don't fix. Just feel helpless.
+
+**Step 4:** Notice that helplessness doesn't destroy you. You can survive feeling helpless. It's uncomfortable, not dangerous.
+
+**Step 5:** From this tolerance, ask: "What's actually needed here?"
+Often the answer is: presence. Not rescue.
 
 ---
 
 ## When Help Is Actually Needed
 
-Holding space is not abandonment.
+Holding space is not abandonment. It's not passive neglect. It's not withholding support.
 
 Sometimes people do need practical help:
 - Information they don't have
 - Resources they can't access
-- Action they can't take
+- Action they genuinely can't take
+- Skills they haven't yet developed
+- Safety they cannot provide themselves
 
-**The difference:**
+**The difference between rescue and help:**
 - Rescue is automatic and unsolicited
 - Help is offered and requested
+- Rescue assumes incompetence
+- Help trusts capacity while offering support
+- Rescue takes over
+- Help empowers
 
 Before offering solutions, ask:
 - "Do you want me to just listen, or do you want input?"
 - "What would be helpful right now?"
-- "Is there something specific you need?"
+- "Is there something specific you need from me?"
+- "Would advice be welcome, or just presence?"
 
 Let them tell you what they need. Don't assume.
+
+When they ask for help, give it. When they don't, offer presence instead.
 
 ---
 
 ## When Holding Space Isn't Enough
 
 Some situations require more than presence:
-- Safety emergencies
-- Mental health crises
-- Abuse or harm
-- Professional intervention needed
+- Safety emergencies (threat of harm to self or others)
+- Mental health crises (active suicidal ideation, psychosis)
+- Abuse or violence (ongoing harm)
+- Medical emergencies
+- Situations where professional intervention is needed
 
 Holding space is not a substitute for professional help when professional help is needed.
 
-Sovereignty includes knowing the limits of what you can hold—and directing people to appropriate resources.
+Sovereignty includes knowing the limits of what you can hold—and directing people to appropriate resources when those limits are reached.
+
+**Signs that presence isn't enough:**
+- They mention harming themselves or others
+- They're unable to function in basic ways
+- The situation is escalating despite your presence
+- You're in over your head
+- Professional support would genuinely help
+
+There's no failure in saying: "This is beyond what I can hold. Let's find you more support."
+
+---
+
+## The Guilt of Not Rescuing
+
+When you first stop rescuing, guilt will arise.
+
+The guilt says:
+- "You're being selfish"
+- "A good person would help"
+- "You're abandoning them"
+- "What if something bad happens?"
+- "You could have done something"
+
+This guilt is predictable. It's the residue of old conditioning—the belief that your worth depends on your usefulness, that love means fixing, that presence isn't enough.
+
+**The guilt is not evidence that you're doing something wrong. It's evidence that you're doing something different.**
+
+Sit with the guilt. Feel it. Don't let it drive you back to rescue.
+
+Over time, as you see that people navigate their own experiences—that they're capable, that they grow from struggle, that your presence was enough—the guilt will soften.
 
 ---
 
@@ -238,15 +435,86 @@ When you hold space without rescuing, you give someone a rare gift:
 
 **The experience of being fully seen without being fixed.**
 
-Most people have rarely, if ever, experienced this.
+Most people have rarely, if ever, experienced this. Their pain has been:
+- Minimized ("It's not that bad")
+- Fixed ("Here's what you should do")
+- Absorbed ("Now I'm upset too")
+- Avoided ("Let's talk about something else")
+- Judged ("You shouldn't feel that way")
 
-When you offer it, something profound happens:
-- They feel less alone
-- They discover their own capacity
-- They build resilience
+What they've rarely received: simple, steady presence. Someone who stayed without needing them to change.
+
+When you offer this, something profound happens:
+- They feel less alone in their experience
+- They discover they can hold more than they thought
+- They build resilience through the experience of navigating difficulty with witness, not rescue
 - They learn they can tolerate their own feelings
+- They develop capacity they wouldn't have developed if rescued
 
 **This is more transformative than any solution you could offer.**
+
+Your steady presence teaches them something about their own capacity. Your non-rescue communicates: "I believe you can handle this."
+
+That belief, held in your presence, becomes something they can internalize.
+
+---
+
+## When They Want Rescue
+
+Some people don't want space held. They want rescue.
+
+They want you to:
+- Fix their problems
+- Take over their struggles
+- Tell them what to do
+- Make the discomfort stop
+- Be the parent they never had
+
+If you refuse to rescue, they may:
+- Get frustrated with you
+- Accuse you of not caring
+- Seek rescue elsewhere
+- Escalate to get a response
+- Pull away from the relationship
+
+This is painful. And it doesn't mean you should rescue.
+
+**What you might say:**
+- "I can be here with you, but I can't fix this for you."
+- "I believe you can navigate this. I'll support you, not take over."
+- "What you're asking feels like more than I can give. Here's what I can offer."
+
+Some relationships won't survive the shift from rescue to presence. Those relationships were built on a dynamic that wasn't sustainable for you.
+
+The relationships that remain—or the new ones that form—will be between adults, not between rescuer and rescued.
+
+---
+
+## Holding Space for Yourself
+
+Everything in this chapter applies to yourself.
+
+Can you hold space for your own feelings without rescuing yourself from them?
+
+Can you witness your own pain without immediately fixing, numbing, or escaping?
+
+Can you tolerate your own helplessness without rushing to action?
+
+Self-rescue looks like:
+- Immediately reaching for distraction when uncomfortable
+- Solving problems before feeling the feelings underneath
+- Staying perpetually busy to avoid internal experience
+- Numbing through substances, screens, or scrolling
+- Fixing external circumstances when internal work is needed
+
+Self-holding looks like:
+- Feeling the feeling before responding
+- Allowing discomfort without escaping
+- Trusting your own capacity to navigate
+- Being present with yourself as you would with a beloved friend
+- Not abandoning yourself when it's hard
+
+The way you treat your own inner experience shapes how you treat others'.
 
 ---
 
@@ -256,8 +524,10 @@ When you offer it, something profound happens:
 - What discomfort am I avoiding when I fix?
 - What would it be like to witness without intervening?
 - Who in my life might benefit from space instead of solutions?
+- Can I tolerate my own helplessness?
+- How do I rescue myself from uncomfortable feelings?
 
-**Body cue to notice:** Urgency, tension, need to make it better
+**Body cue to notice:** Urgency, tension, need to make it better, restlessness in the hands
 
 **Practice:** "My presence is the gift"
 
@@ -273,16 +543,18 @@ When you offer it, something profound happens:
 
 Holding space is one of the most generous and difficult things you can offer.
 
-It requires you to tolerate your own helplessness, your own discomfort, your own urge to fix.
+It requires you to tolerate your own helplessness, your own discomfort, your own urge to fix. It asks you to stay present when everything in you wants to act, to solve, to rescue.
 
-But when you hold space truly—without agenda, without rescue, without absorption—you offer something rare:
+It's the opposite of what you were trained to do. And it's exactly what's needed.
+
+When you hold space truly—without agenda, without rescue, without absorption—you offer something rare:
 
 **Trust in someone's capacity to navigate their own experience.**
 
-That trust transforms.
+That trust transforms. Not because you did something, but because you stayed while they did.
+
+You cannot rescue someone into wholeness. But you can witness them there.
 
 ---
 
 **[Continue to Chapter 17: Teaching Without Converting →](./17-teaching-without-converting.md)**
-
-

--- a/book/vol-3-sovereignty/chapters/17-teaching-without-converting.md
+++ b/book/vol-3-sovereignty/chapters/17-teaching-without-converting.md
@@ -6,15 +6,20 @@
 
 When you've found something that changed your life, the urge to share is natural.
 
-You want others to see what you see. You want to spare them the pain you endured. You want to connect over shared understanding.
+You've seen what you couldn't see before. You understand dynamics that once confused you. You have language for experiences that were nameless.
 
-But teaching becomes harmful when it becomes:
-- Evangelizing
-- Fixing
-- Pressuring
-- Judging those who don't "get it"
+You want others to see what you see. You want to spare them the pain you endured. You want to connect over shared understanding. You want validation that your journey was real.
 
-**Sovereign teaching offers without insisting. It shares without requiring uptake.**
+These impulses are human. They're also where things go wrong.
+
+Teaching becomes harmful when it becomes:
+- Evangelizing—insisting others adopt your framework
+- Fixing—diagnosing people without their consent
+- Pressuring—pushing insight when it's not wanted
+- Judging—dismissing those who don't "get it"
+- Validating—needing others to agree to feel secure in your own knowing
+
+**Sovereign teaching offers without insisting. It shares without requiring uptake. It holds wisdom lightly—available to those who want it, released when they don't.**
 
 ---
 
@@ -22,63 +27,132 @@ But teaching becomes harmful when it becomes:
 
 She sees her sister's relationship clearly.
 
-The pattern. The cycle. The manipulation.
+The pattern. The cycle. The manipulation. She's read the books. She knows the terms. She can name exactly what's happening.
 
-She sends articles. She explains the dynamics. She offers books.
+She sends articles. She explains the dynamics. She offers books, podcasts, resources. She points out the red flags in every story her sister shares.
 
-Her sister gets defensive. The conversation ends in tension.
+Her sister gets defensive. Changes the subject. Starts sharing less.
 
-She doesn't understand. She's trying to help. Why won't her sister listen?
+The conversation ends in tension. The connection frays.
+
+She doesn't understand. She's trying to help. She's offering the insight that saved her own life. Why won't her sister listen?
+
+She can't see that her urgency is pushing her sister away. That her certainty feels like judgment. That her help feels like criticism disguised as care.
 
 ---
 
 ## Field Note (After): The Planted Seed
 
-Her sister is describing the relationship again.
+Her sister is describing the relationship again. The familiar patterns. The same cycle.
 
 She listens. She doesn't diagnose.
 
+She notices the urge to explain, to enlighten, to save. She feels it in her chest—the almost unbearable desire to make her sister see.
+
+She breathes. She stays with the urge without acting on it.
+
 When asked, she shares one observation: "That sounds exhausting."
 
-Her sister pauses. Nods.
+Her sister pauses. Looks down. Nods.
 
-No lecture. No articles. No pressure.
+No lecture. No articles. No framework. Just one honest reflection.
 
-A seed planted—not forced into the ground.
+A seed planted—not forced into the ground. Offered, not insisted upon.
+
+Whether it grows is not hers to control.
+
+---
+
+## Field Note: The Dinner Party
+
+He's at a dinner party. Someone mentions a difficult family member.
+
+In the past, he would have launched into an explanation. Attachment styles. Narcissistic traits. Emotional immaturity. He had the map, and he wanted to share it.
+
+Tonight, he notices the pull. The excitement of having something to offer. The desire to be the one who understands.
+
+He asks a question instead: "What's that like for you?"
+
+The person pauses, surprised. Then opens up more.
+
+He listens. He reflects. He doesn't diagnose.
+
+At the end of the evening, the person thanks him. "I don't know what it is about you, but I felt really heard."
+
+He taught nothing. He offered everything.
 
 ---
 
 ## Why We Want to Teach
 
 The desire to share comes from:
-- Genuine care for others
-- The hope that insight will prevent suffering
-- Connection through shared language
-- Validation of our own journey ("If they see it too, I'm not crazy")
 
-These motivations are understandable.
+**Genuine care for others**
+You suffered. You don't want them to suffer. The impulse is compassionate.
+
+**The hope that insight will prevent suffering**
+If only they knew what you know, they could avoid the pain. This hope is sincere, even when misguided.
+
+**Connection through shared language**
+Having framework in common creates intimacy. You want to be understood, and shared vocabulary makes that possible.
+
+**Validation of our own journey**
+("If they see it too, I'm not crazy")
+This is often the hidden driver. When others confirm your reality, it steadies something inside that still doubts.
+
+These motivations are understandable. They're human.
 
 But they can tip into:
-- Needing others to agree to feel secure
-- Using teaching to avoid our own discomfort
-- Making others' paths about our agenda
+- Needing others to agree to feel secure in your own knowing
+- Using teaching to avoid your own discomfort with their pain
+- Making others' paths about your agenda
 - Judging those who don't "do the work"
+- Defining yourself as the one who understands
 
 **Sovereign teaching releases the need for uptake.**
+
+You can offer what you know. You cannot make anyone receive it. And your security doesn't depend on whether they do.
 
 ---
 
 ## Neuroscience Lens: The "Expert" Trap
 
-When we learn something significant, the brain creates strong neural pathways around that knowledge.
+When we learn something significant, the brain creates strong neural pathways around that knowledge. This learning becomes part of how we see the world.
 
-This can create a **confirmation bias**—we see evidence for what we've learned everywhere.
+This can create a **confirmation bias**—we see evidence for what we've learned everywhere. Every interaction becomes filtered through our new framework. Every relationship shows signs of what we now understand.
 
-It can also create a sense that others **should** see it too. Their failure to see feels frustrating, even threatening.
+It can also create a sense that others **should** see it too. Their failure to see feels frustrating, even threatening. If they can't see what's so obvious to us, either we're wrong (intolerable) or they're blind (frustrating).
 
-**Key insight:** Your understanding is yours. It doesn't obligate others to share it.
+This creates pressure to convince. If we can make them see, our knowing is validated. If they resist, we feel unsteady.
 
-**Translation:** Wisdom that transforms you may not transform others—and that's not failure.
+**Key insight:** Your understanding is yours. It doesn't obligate others to share it. Their different perspective doesn't threaten your truth.
+
+**Translation:** Wisdom that transforms you may not transform others—and that's not failure. It's just different paths.
+
+---
+
+## The Desire for Validation
+
+Here's the truth underneath much evangelical teaching:
+
+**We want confirmation that we're not crazy.**
+
+If others see what we see, our reality is validated. If they use the same language, adopt the same framework, name the same patterns—we feel less alone. Less questionable. More real.
+
+This is especially true for those who grew up in families where reality was denied:
+- Where you were told you didn't see what you saw
+- Where your perceptions were dismissed or attacked
+- Where sanity depended on external agreement
+
+In those environments, having someone confirm your reality felt like oxygen. So now, sharing your knowledge and having it received feels essential.
+
+**But this creates a problem:**
+
+When teaching becomes about your need for validation, you're not really offering—you're seeking. And the other person can feel it. They sense that their agreement matters too much to you. That their rejection would destabilize you.
+
+This pressure pushes people away.
+
+**Sovereign teaching doesn't need the student to learn.** It offers freely and releases completely.
 
 ---
 
@@ -86,38 +160,58 @@ It can also create a sense that others **should** see it too. Their failure to s
 
 **Offering, not insisting:**
 "This was helpful for me" vs. "You need to read this"
+The first leaves space. The second demands.
 
 **Responding to invitation:**
-Sharing when asked, not when you think they should hear it
+Sharing when asked, not when you think they should hear it.
+Wait for the opening. If it doesn't come, the timing isn't right.
 
 **Respecting timing:**
-Trusting that people are on their own timeline
+Trusting that people are on their own timeline.
+What's obvious to you now wasn't obvious to you once. Everyone arrives in their own season.
 
 **Releasing outcome:**
-Letting go of whether they take your advice
+Letting go of whether they take your advice.
+Their choice is their choice. Your security doesn't depend on their uptake.
 
 **Avoiding diagnosis:**
-Not pathologizing others based on what you've learned
+Not pathologizing others based on what you've learned.
+Diagnosis without consent is not help—it's judgment dressed as insight.
 
 ---
 
 ## The Diagnosis Trap
 
-When you learn about narcissism, attachment, or trauma, it's tempting to diagnose everyone.
+When you learn about narcissism, attachment, trauma, or emotional immaturity, it's tempting to diagnose everyone.
 
 "He's definitely avoidant."
 "She's clearly a covert narcissist."
 "That's classic trauma bonding."
+"He has anxious attachment."
+
+The frameworks are useful. They help us make sense of confusing experiences. They give language to what was previously wordless.
+
+But diagnosis has a shadow side.
 
 **Problems with diagnosing:**
-- It reduces people to patterns
-- It positions you as the expert
-- It can feel dismissive or superior
-- It often creates defensiveness, not insight
-- It may be wrong
+
+**It reduces people to patterns.**
+Humans are complex. Frameworks are simplifications. When you diagnose someone, you flatten them into a category that can never capture their wholeness.
+
+**It positions you as the expert.**
+The one who understands while they remain blind. This creates hierarchy, not connection.
+
+**It can feel dismissive or superior.**
+"I've figured you out" can feel more like judgment than understanding.
+
+**It often creates defensiveness, not insight.**
+People don't generally respond well to being analyzed without consent. They close rather than open.
+
+**It may be wrong.**
+You're seeing a slice of someone, filtered through your own history. Your diagnosis might say more about you than them.
 
 **Sovereign approach:**
-Observe patterns privately. Share them only when invited. Let people reach their own conclusions.
+Observe patterns privately. Use frameworks for your own understanding. Share them only when invited. Let people reach their own conclusions. Trust that if they need the framework, they'll find it in their own time.
 
 ---
 
@@ -126,17 +220,23 @@ Observe patterns privately. Share them only when invited. Let people reach their
 Not everyone is ready to hear what you've learned.
 
 Signs they're not ready:
-- Defensiveness
-- Minimizing
+- Defensiveness when you share
+- Minimizing what you're saying
 - Changing the subject
 - Dismissing the concepts
 - Getting angry at you
+- Explaining why this doesn't apply
+- Showing no curiosity about your experience
 
 **What this means:**
-They're not ready. Not that you explained it wrong. Not that you should try harder.
+They're not ready. Not that you explained it wrong. Not that you should try harder. Not that if you just found the right words, they'd understand.
+
+They're simply not ready.
 
 **Sovereign response:**
 Step back. Trust their timing. Stay available without pushing.
+
+If the relationship matters, stay connected on other grounds. If they become ready, you'll be there. If they never do, you can still love them from across the gap.
 
 ---
 
@@ -145,19 +245,45 @@ Step back. Trust their timing. Stay available without pushing.
 **Sharing:**
 - Offering your experience
 - Responding to questions
-- Mentioning resources
-- Expressing your perspective
+- Mentioning resources that helped you
+- Expressing your perspective when asked
+- Speaking from "I" not "you"
 
 **Fixing:**
 - Diagnosing their situation
 - Insisting they see what you see
 - Pushing resources repeatedly
 - Making their growth your project
+- Speaking from certainty about their experience
 
 **The test:**
 Can you share and then release? Or does their response affect your peace?
 
-If their rejection of your advice upsets you, you've crossed from sharing into fixing.
+If their rejection of your advice upsets you, you've crossed from sharing into fixing. If you can offer wisdom and walk away with your center intact regardless of their response, you're sharing sovereignly.
+
+---
+
+## The Judgment Trap
+
+When you've done significant work, there's a temptation to judge those who haven't.
+
+"If only they'd do the work..."
+"They're so unconscious."
+"They'll never change."
+"I can't believe they can't see it."
+
+This judgment often masks:
+- Grief that the relationship can't be what you want
+- Frustration that your insight doesn't transfer
+- Fear that if they don't see it, maybe you're wrong
+- Loneliness at being in a different place
+
+Judgment creates separation. It positions you as evolved and them as behind. It gives you a way to feel superior when you actually feel sad.
+
+**Sovereign approach:**
+Notice the judgment. Ask what's underneath. Feel the grief, the frustration, the fear.
+
+Then remember: you weren't always where you are. You arrived in your own time. They're on their path, and it may look nothing like yours.
 
 ---
 
@@ -166,14 +292,22 @@ If their rejection of your advice upsets you, you've crossed from sharing into f
 **When invited:**
 "I've been reading about this. It really helped me."
 Then stop. See if they want more.
+If they lean in, share. If they don't, release.
 
 **When uninvited but concerned:**
 "I notice something and I'm not sure if it's helpful to share. Would you want to hear it?"
-Respect their answer.
+Respect their answer. If it's no, that's the end.
+If it's yes, share once and release.
 
 **When they're not ready:**
 "I'm here if you ever want to talk about this."
 Then actually let it go.
+Don't follow up. Don't check in. Don't leave articles casually lying around.
+
+**When you want to teach:**
+Ask yourself: "Is this for them, or for me?"
+If it's for validation, hold it.
+If it's genuinely for them, wait for invitation.
 
 ---
 
@@ -181,20 +315,42 @@ Then actually let it go.
 
 When you feel the urge to teach:
 
-**Step 1:** Notice the urge.
-What's driving it? Care? Anxiety? Need for validation?
+**Step 1: Notice the urge.**
+What's driving it? Care? Anxiety? Need for validation? Discomfort with their pain?
 
-**Step 2:** Ask permission.
+**Step 2: Check for invitation.**
+Have they asked? Opened the door? Shown curiosity?
+If not, wait.
+
+**Step 3: Ask permission.**
 "Would it be helpful if I shared something?"
+This simple question changes everything. It gives them agency.
 
-**Step 3:** Say ONE sentence.
-Not a lecture. Not a diagnosis. One observation.
+**Step 4: Say ONE sentence.**
+Not a lecture. Not a diagnosis. Not a framework.
+One observation. One reflection. One sentence.
 
-**Step 4:** Stop.
+**Step 5: Stop.**
 Let them respond. Don't add.
+Resist the urge to elaborate, explain, convince.
 
-**Step 5:** Release the outcome.
+**Step 6: Release the outcome.**
 They heard you. What they do with it is theirs.
+
+---
+
+## A Practice: The Offering Inventory
+
+Before sharing wisdom with someone:
+
+**Ask yourself:**
+- Have they invited this?
+- Am I offering or insisting?
+- Can I release the outcome?
+- Is this about their wellbeing or my validation?
+- Am I prepared for them to reject this completely?
+
+If any answer gives you pause, wait.
 
 ---
 
@@ -207,25 +363,91 @@ When you:
 - Hold boundaries without guilt
 - Make choices from self-trust
 - Lead without performing
+- Navigate difficult people without absorbing
+- Choose yourself without apologizing
 
 people notice.
 
-They may ask how you do it. They may not.
+They may ask how you do it. They may not. But they're watching.
 
-Either way, your presence is a teaching.
+They see that it's possible to live differently. They see someone embodying what they might become. They receive a teaching without a word being spoken.
 
 **You don't have to explain sovereignty to teach it. You can live it.**
+
+And living it is more convincing than any lecture. People rarely argue with embodiment. They may dismiss your words, but they can't dismiss your presence.
+
+---
+
+## When They Watch You Change
+
+Sometimes teaching happens simply because you've changed.
+
+People who knew the old you notice the new you. They see:
+- Boundaries you didn't used to have
+- Peace you didn't used to carry
+- Choices you didn't used to make
+- Regulation you didn't used to maintain
+
+Some will be curious. Some will be threatened. Some will want what you have. Some will resent it.
+
+**You don't have to manage their response.**
+
+Keep becoming who you're becoming. Those who are ready will be drawn to ask. Those who aren't will observe from a distance. Both are valid.
+
+Your transformation is its own teaching. Your presence is your curriculum.
+
+---
+
+## The Loneliness of Knowing
+
+When you see patterns others can't see, you may feel alone.
+
+You watch friends repeat cycles you recognize. You see family members enacting dynamics you understand. You observe pain that could be prevented, if only they knew what you know.
+
+And they don't ask. They don't want to know. They're not ready.
+
+This loneliness is real. It's the price of awareness.
+
+**What helps:**
+- Find others who speak your language
+- Remember that you weren't always here
+- Trust their timing, even when it's slow
+- Release the belief that your knowing obligates them
+- Practice acceptance of the gap
+
+You can love people across the gap. You can care about them without needing them to understand. You can hold your knowing and hold connection simultaneously.
+
+---
+
+## When They Finally Ask
+
+Sometimes, after months or years, someone comes back.
+
+"I think you might be right."
+"Can you tell me more about what you mentioned?"
+"I've been thinking about what you said."
+
+When this happens:
+- Don't say "I told you so"
+- Don't overwhelm them with everything you've been waiting to share
+- Don't make it about your rightness
+- Meet them where they are, not where you are
+- Offer what they can receive, not everything you know
+
+They've arrived in their own time. Honor the arrival.
 
 ---
 
 ## Reader Reflection
 
 - Where do I slip from sharing into fixing?
-- What do I need from others when I share?
+- What do I need from others when I share my understanding?
 - Can I offer wisdom without requiring uptake?
 - How might my journey inspire without my explanation?
+- What validation am I seeking through teaching?
+- Who in my life might benefit from my silence rather than my insight?
 
-**Body cue to notice:** Urgency to explain, frustration when not heard
+**Body cue to notice:** Urgency to explain, frustration when not heard, need to be understood
 
 **Practice:** One sentence, then release
 
@@ -241,18 +463,26 @@ Either way, your presence is a teaching.
 
 You've learned something valuable. Of course you want to share it.
 
+The knowledge that transformed you wants to travel. It wants to reach others who are suffering. It wants to prevent pain, create understanding, build connection.
+
 But sovereign teaching trusts timing you can't see.
 
 It trusts that seeds planted may grow in their own season.
 
 It trusts that your life—not your words—is often the most powerful teaching.
 
+It trusts that people will find their way when they're ready, and that your urgency cannot make them ready.
+
 Offer what you've learned. Then let it go.
+
+Release the need to be understood.
+Release the need to be validated.
+Release the need to save anyone.
+
+What remains is pure offering: wisdom available to those who seek it, released completely when they don't.
 
 That's sovereignty.
 
 ---
 
 **[Continue to Chapter 18: The Sovereign Community →](./18-sovereign-community.md)**
-
-

--- a/book/vol-3-sovereignty/chapters/18-sovereign-community.md
+++ b/book/vol-3-sovereignty/chapters/18-sovereign-community.md
@@ -6,13 +6,13 @@
 
 Sovereignty is not isolation.
 
-It is not self-sufficiency at the expense of connection.
-
-It is not becoming an island.
+It is not self-sufficiency at the expense of connection. It is not becoming an island, impenetrable and alone. It is not armor against the world.
 
 **Sovereignty is the capacity to connect from wholeness rather than need—and to build communities that support that wholeness.**
 
-This final chapter of Part V explores what community looks like when built by sovereign people.
+This is the final destination of everything you've learned: not to stand alone, but to stand with others while remaining yourself. Not to need no one, but to choose your people from clarity rather than desperation.
+
+This chapter explores what community looks like when built by sovereign people.
 
 ---
 
@@ -24,9 +24,15 @@ She understands the patterns. She can hold her own. She doesn't need anyone to c
 
 And she's lonely.
 
-She's outgrown her old friendships but hasn't built new ones. She feels too different, too aware, too much.
+She's outgrown her old friendships but hasn't built new ones. The people she used to connect with no longer speak her language. The conversations that once felt deep now feel surface.
 
-She wonders if sovereignty means being alone.
+She feels too different, too aware, too much.
+
+She tries to return to old patterns, to pretend she doesn't know what she knows. It doesn't work. The dissonance is unbearable.
+
+She wonders if sovereignty means being alone. If the price of awareness is permanent isolation.
+
+Some nights, she questions whether all the work was worth it.
 
 ---
 
@@ -34,30 +40,65 @@ She wonders if sovereignty means being alone.
 
 She found them slowly.
 
-People who speak the same language. Who understand without explanation. Who can be close without enmeshing.
+It didn't happen overnight. It wasn't magic. It was patience, and presence, and showing up as herself even when it felt risky.
+
+First one person. Then another. Then a small circle.
+
+People who speak the same language. Who understand without lengthy explanation. Who can be close without enmeshing. Who can disagree without disconnecting.
 
 They don't fix each other. They witness.
 They don't rescue. They support.
 They don't demand. They invite.
+They don't merge. They stay distinct while staying close.
 
 She's still sovereign. And she's not alone.
+
+The loneliness was a season, not a sentence.
+
+---
+
+## Field Note: The New Friend
+
+He meets someone at a workshop.
+
+In the past, he would have either:
+- Held back, suspicious of connection
+- Overcommitted, desperate for belonging
+
+This time, something different happens.
+
+He's open without being urgent. Interested without being needy. Available without being grasping.
+
+They exchange numbers. They meet for coffee. They talk.
+
+He notices that the conversation flows without effort. That his nervous system feels calm. That he can be himself without performing.
+
+He doesn't know if this will become a deep friendship. He doesn't need to know. He can hold the possibility without clutching it.
+
+This is what connection feels like when you're not using it to fill a hole.
 
 ---
 
 ## Why Sovereignty Needs Community
 
 Human beings are wired for connection. The nervous system needs:
-- Co-regulation with safe others
-- Witness to be seen
-- Belonging without performance
-- Relational experiences of safety
+- **Co-regulation** with safe others—nervous systems calming nervous systems
+- **Witness**—to be seen and known
+- **Belonging** without performance—acceptance without conditions
+- **Relational experiences of safety**—learning through relationship that connection is safe
 
 Sovereignty built in isolation is incomplete. It can become:
 - Avoidant patterns disguised as independence
 - Loneliness disguised as strength
 - Rigidity disguised as boundaries
+- Protection disguised as freedom
+- Fear of vulnerability disguised as self-sufficiency
 
 **True sovereignty is tested and deepened in relationship.**
+
+It's easy to stay regulated when you're alone. The real test is staying regulated in the presence of another. It's easy to hold boundaries with no one around. The test is holding them when someone is asking you to abandon them.
+
+We need community to complete the work—to practice what we've learned in the laboratory of relationship.
 
 ---
 
@@ -65,52 +106,102 @@ Sovereignty built in isolation is incomplete. It can become:
 
 Even the most regulated nervous system benefits from **co-regulation**—the experience of being with someone whose presence calms you.
 
-Research shows:
-- Heart rates synchronize between close others
+Research consistently shows:
+- Heart rates synchronize between close others who feel safe together
 - Stress hormones decrease in safe company
-- The vagus nerve responds to relational safety
+- The **vagus nerve** responds to relational safety, increasing parasympathetic tone
+- Holding hands with a trusted person reduces pain perception
+- Presence of safe others dampens amygdala reactivity
 
-**Key insight:** Sovereignty doesn't mean you don't need others. It means you can choose who you regulate with.
+The nervous system was never designed to regulate entirely on its own. We are social animals. We evolved in tribes, not isolation. Our biology expects connection.
 
-**Translation:** Build community with people whose nervous systems calm rather than activate yours.
+**Key insight:** Sovereignty doesn't mean you don't need others. It means you can choose who you regulate with. It means you're not desperately seeking anyone who will have you—you're carefully selecting those who add to your life.
+
+**Translation:** Build community with people whose nervous systems calm rather than activate yours. Choose people who feel regulating, not depleting. This isn't being picky—it's being wise.
 
 ---
 
 ## What Sovereign Community Is Not
 
 Sovereign community is NOT:
-- Enmeshed groups where everyone must agree
-- Hierarchies where some regulate and others are regulated
-- Performance spaces where you earn belonging
-- Trauma-bonded connections based on shared wounds
-- Groups that require you to shrink to fit
+
+**Enmeshed groups where everyone must agree**
+Where difference is threatening, dissent is punished, and belonging requires conformity.
+
+**Hierarchies where some regulate and others are regulated**
+Where there's a guru at the top and followers below. Where one person holds the answers and others consume.
+
+**Performance spaces where you earn belonging**
+Where you must be impressive, healed, or evolved enough to be welcomed. Where your value depends on your growth stage.
+
+**Trauma-bonded connections based on shared wounds**
+Where the only glue is mutual suffering. Where you bond over damage rather than growth. Where staying stuck is rewarded.
+
+**Groups that require you to shrink to fit**
+Where certain parts of you aren't welcome. Where you must leave aspects of yourself at the door.
+
+**Echo chambers where your views are never challenged**
+Where everyone agrees with everything you say. Where growth stops because discomfort is avoided.
 
 ---
 
 ## What Sovereign Community IS
 
 Sovereign community IS:
-- People who see you without needing to fix you
-- Connections that hold difference without disconnection
-- Relationships where boundaries are respected
-- Spaces where you can be witnessed without being managed
-- Groups that invite rather than demand
-- Communities built on shared values, not shared wounds
+
+**People who see you without needing to fix you**
+Who can witness your struggles without rushing to solve them. Who trust your capacity.
+
+**Connections that hold difference without disconnection**
+Where you can disagree and still remain connected. Where conflict doesn't mean abandonment.
+
+**Relationships where boundaries are respected**
+Where no is a complete sentence. Where your limits are honored, not negotiated.
+
+**Spaces where you can be witnessed without being managed**
+Where your experience is allowed without interpretation. Where you get to be the authority on yourself.
+
+**Groups that invite rather than demand**
+Where participation is chosen, not obligated. Where you show up because you want to, not because you must.
+
+**Communities built on shared values, not shared wounds**
+Where you come together around who you're becoming, not just what you survived.
 
 ---
 
 ## The Qualities of Sovereign Friends
 
 Look for people who:
-- Can tolerate silence
-- Don't need you to be small
-- Respect your boundaries
-- Share without agenda
-- Can disagree without disconnecting
-- Are on their own growth path
-- Don't require you to manage them
-- Celebrate your wins without competition
-- Show up consistently
+
+**Can tolerate silence**
+Don't need to fill every pause. Can sit with quiet without discomfort.
+
+**Don't need you to be small**
+Can celebrate your wins without competition. Aren't threatened by your growth.
+
+**Respect your boundaries**
+Don't push back on your limits. Accept your no without making you feel guilty.
+
+**Share without agenda**
+Offer their experiences without needing you to follow. Teach without evangelizing.
+
+**Can disagree without disconnecting**
+Hold different views without making you wrong. Stay in relationship through conflict.
+
+**Are on their own growth path**
+Committed to their own development. Not waiting for you to save them.
+
+**Don't require you to manage them**
+Can regulate themselves. Don't use you as their primary source of stability.
+
+**Celebrate your wins without competition**
+Feel genuinely happy for your success. Don't need to one-up or diminish.
+
+**Show up consistently**
+Are reliable without being demanded. Present without being pressured.
+
+**Can hold complexity**
+Don't need simple answers. Can sit with nuance, contradiction, uncertainty.
 
 These people are rare. They're also essential.
 
@@ -120,38 +211,97 @@ These people are rare. They're also essential.
 
 **Trauma-bonded community:**
 - Connects primarily through shared pain
-- Requires continuous processing
-- Can keep you focused on wounds
-- May feel activating
+- Requires continuous processing of wounds
+- Can keep you focused on what happened to you
+- May feel activating—the energy of shared crisis
 - Identity built around being wounded
+- Progress can threaten the bond
+- Staying stuck is implicitly rewarded
+- The common ground is what you've survived
 
 **Sovereign community:**
 - Connects through shared growth
 - Processes when needed, lives otherwise
 - Focuses on building, not just healing
-- Feels regulating
-- Identity built around becoming
+- Feels regulating—the energy of shared becoming
+- Identity built around who you're becoming
+- Progress strengthens the bond
+- Moving forward is celebrated
+- The common ground is who you're becoming
 
-Both have value. But if all your connections are trauma-bonded, you may be missing sovereign community.
+Both have value. Trauma-bonded community can be essential in early healing. You need people who understand the specific pain you've endured.
+
+But if all your connections are trauma-bonded, you may be missing sovereign community. You may be staying in the wound rather than building beyond it.
+
+**The question:** Are your relationships helping you heal, or keeping you focused on what needs healing?
+
+---
+
+## The Stages of Finding Your People
+
+**Stage 1: The Desert**
+You've outgrown old connections but haven't found new ones. Everything feels barren. This is painful and necessary.
+
+**Stage 2: The Tentative Reach**
+You start putting yourself in new environments. Workshops. Groups. Communities. You're not sure if you belong yet.
+
+**Stage 3: The Mismatches**
+You meet people who seem right but aren't. You try connections that don't work. This is information, not failure.
+
+**Stage 4: The First Real Connection**
+You find one person who truly gets it. One is enough to start. The loneliness begins to ease.
+
+**Stage 5: The Gradual Gathering**
+Over time, more sovereign people appear. Your circle grows slowly. Quality over quantity.
+
+**Stage 6: The Established Community**
+You have a web of people who support your growth. Not everyone is close, but enough are. You're no longer alone.
+
+This process takes time. Often years. Don't rush it.
 
 ---
 
 ## Building Sovereign Community
 
 ### Start with Quality Over Quantity
+
 One or two people who truly see you is worth more than dozens of surface connections.
 
+Don't chase numbers. Chase depth. Authentic connection with a small handful of people is more nourishing than superficial connection with many.
+
 ### Allow Time
+
 Deep connection builds slowly. Don't rush intimacy.
 
+When you've been lonely, there's a temptation to accelerate—to treat every new connection as the answer to your isolation. This pressure can push people away or lead to connections that aren't actually good for you.
+
+Let relationships unfold at their natural pace. If someone is meant to be in your life, there's time.
+
 ### Be What You're Looking For
+
 Model the sovereignty you want to find. Others like you will recognize it.
 
+If you want regulated friends, be regulated. If you want friends who respect boundaries, respect boundaries. If you want deep connection, be willing to be deep.
+
+Your embodiment becomes a signal. Those who resonate will be drawn to it.
+
 ### Show Up Consistently
+
 Community requires presence over time. Not perfect attendance—consistent availability.
 
+Show up to the gathering. Return to the group. Be there when you said you'd be there. Reliability builds trust.
+
 ### Let Go of Who Can't Meet You
+
 Some friends from earlier phases won't come with you. Grieve this, and keep going.
+
+Not everyone you've loved can follow where you're going. Some relationships are meant for seasons, not lifetimes. This doesn't mean the connection wasn't real—it means it was real for a particular time.
+
+### Initiate
+
+Don't wait to be found. Reach out. Invite. Propose. Initiate.
+
+Sovereign people are often waiting for connection too. But if everyone waits, no one connects. Be the one who reaches out.
 
 ---
 
@@ -159,18 +309,33 @@ Some friends from earlier phases won't come with you. Grieve this, and keep goin
 
 **Places sovereign people tend to be:**
 - Growth-oriented workshops and courses
-- Meditation or mindfulness communities
+- Meditation and mindfulness communities
 - Intentional communities and gatherings
-- Professional development spaces
+- Professional development spaces with depth
 - Creative and artistic communities
 - Nature-based activities
 - Service and volunteer work
+- Book clubs focused on growth topics
+- Therapy groups and recovery communities in later stages
+- Conferences and retreats focused on personal development
 
 **What to look for:**
 - Are people here to grow or to stay stuck?
-- Is there room for individuality?
+- Is there room for individuality within the group?
 - Do people respect boundaries?
 - Is there genuine curiosity about others?
+- Can people hold different views?
+- Is there depth in the conversations, or just surface?
+- Does being here feel regulating or activating?
+
+**What to avoid:**
+- Groups that require conformity
+- Spaces with rigid hierarchy
+- Communities that discourage questions
+- Groups where leaving is punished
+- Spaces that feel consistently activating
+- Communities that shame vulnerability
+- Groups where one person holds all the answers
 
 ---
 
@@ -180,21 +345,48 @@ Take inventory of your current connections:
 
 **Who in my life:**
 - Calms my nervous system?
-- Can hold difference?
+- Can hold difference without disconnecting?
 - Respects my boundaries?
 - Supports my growth?
 - Sees me clearly?
+- Shows up consistently?
+- Celebrates my wins without competition?
 
 **Who in my life:**
 - Activates me chronically?
-- Requires me to manage them?
-- Doesn't respect boundaries?
+- Requires me to manage their emotions?
+- Doesn't respect my boundaries?
 - Keeps me in old patterns?
+- Needs me to be small?
+- Is inconsistent or unreliable?
+- Competes or compares?
 
 **Based on this:**
 - Who do I want to invest more in?
 - Who do I need to create more distance from?
 - Where might I find more sovereign connections?
+- What do I need to become to attract the community I want?
+
+---
+
+## A Practice: The Resonance Check
+
+When you meet someone new:
+
+**Step 1: Notice your nervous system.**
+Does being with this person feel regulating or activating? Calm or agitated? Open or closed?
+
+**Step 2: Check for reciprocity.**
+Is the connection flowing both ways? Are they as interested in you as you are in them? Is there mutual investment?
+
+**Step 3: Observe their relationship to boundaries.**
+How do they respond when you set a limit? Do they respect your no? Do they have their own boundaries?
+
+**Step 4: Look for depth capacity.**
+Can they go beyond surface? Are they curious? Can they hold complexity and nuance?
+
+**Step 5: Trust your body's wisdom.**
+Your nervous system knows before your mind does. If something feels off, pay attention.
 
 ---
 
@@ -202,19 +394,40 @@ Take inventory of your current connections:
 
 Many people experience loneliness during growth.
 
-You've outgrown old patterns—and the people embedded in them.
+You've outgrown old patterns—and the people embedded in them. You've developed new language—and no one around you speaks it. You've changed—and your environment hasn't.
 
 You haven't yet found people who match your new frequency.
 
 **This loneliness is not forever.**
 
-It's a transition. A between-space.
+It's a transition. A between-space. A passage from one community to another.
 
-Use it:
+**Use it:**
 - To deepen your relationship with yourself
 - To clarify what you're looking for
 - To rest from over-giving
 - To trust that your people are out there
+- To practice being alone without being abandoned
+
+The loneliness is real. It's also temporary. If you keep showing up as yourself, you will eventually find others who resonate.
+
+---
+
+## The Grief of Outgrowing
+
+There will be grief in this process.
+
+Grief for friendships that can't make the transition. Grief for the ease of old connections, even if they were unhealthy. Grief for the fantasy that everyone you love could come with you.
+
+**Allow this grief.**
+
+It doesn't mean you're doing something wrong. It means you're doing something significant.
+
+You can love people you've outgrown. You can appreciate what they were to you. And you can let them go, or let them recede, as you continue becoming.
+
+Some relationships will transform. Some will end. Some will stay exactly where they are while you move elsewhere.
+
+All of this is grief. And grief is the price of growth.
 
 ---
 
@@ -226,23 +439,87 @@ Even in sovereign community, boundaries matter.
 - Not everyone in a community will become close
 - You can belong without being best friends with everyone
 - Some connections stay surface-level—that's okay
+- You can be warm without being intimate
+- Not every offer of connection needs to be accepted
 
 **With groups:**
 - You can participate without taking on group identity
 - You can leave if the group no longer fits
 - Your sovereignty comes first
+- Groups can evolve past you, or you past them
+- Belonging doesn't require unlimited access to you
+
+**With yourself:**
+- Notice when you're overextending
+- Track your energy after community interactions
+- Be willing to pull back when you need to
+- Don't sacrifice sovereignty for belonging
+
+---
+
+## When Community Disappoints
+
+Sovereign community is not utopia.
+
+Even good communities will:
+- Have conflict
+- Include people who frustrate you
+- Fail to meet your needs sometimes
+- Evolve in directions you don't expect
+- Include dynamics that activate you
+
+**What to expect:**
+- Imperfection—this is human, not failure
+- Misunderstanding—even good people misunderstand
+- Growth edges—community will push you to grow
+- Limits—no group can meet every need
+- Change—communities shift over time
+
+**The sovereign response:**
+- Stay in relationship with discomfort
+- Communicate clearly when something isn't working
+- Set boundaries when needed
+- Leave when staying would cost too much
+- Don't expect perfection—expect good enough
 
 ---
 
 ## What You Offer to Community
 
 When you show up sovereign:
-- Your regulation becomes a gift
-- Your presence creates safety
-- Your boundaries model what's possible
-- Your growth inspires others
+
+**Your regulation becomes a gift**
+Your calm nervous system helps others regulate. Your steadiness provides a reference point.
+
+**Your presence creates safety**
+When you're grounded, others feel permission to be themselves.
+
+**Your boundaries model what's possible**
+When you hold limits, others learn they can too.
+
+**Your growth inspires others**
+When they see you becoming, they remember they can become.
+
+**Your authenticity invites authenticity**
+When you're real, others feel safer being real.
 
 **You don't just receive from sovereign community. You contribute to it.**
+
+Your presence matters. Your becoming matters. Your showing up, as yourself, contributes to the whole.
+
+---
+
+## The Ripple Effect
+
+When sovereign people gather, something larger happens.
+
+Each person who develops sovereignty becomes a node of regulation in a dysregulated world. Each relationship between sovereign people becomes a model of what's possible. Each community built on sovereignty radiates outward.
+
+You are not just finding your people for yourself.
+
+You are participating in something larger—the slow building of a more sovereign world. One relationship at a time. One community at a time. One regulated nervous system at a time.
+
+Your personal transformation has collective implications.
 
 ---
 
@@ -252,6 +529,8 @@ When you show up sovereign:
 - Who calms me? Who activates me?
 - Where am I lonely? What does that loneliness need?
 - What kind of community am I building—or ready to build?
+- What do I need to become to attract the community I want?
+- What grief do I need to allow for connections I've outgrown?
 
 **Body cue to notice:** Calm vs. activation in different relationships
 
@@ -271,14 +550,28 @@ Sovereignty is not the end of connection.
 
 It is the beginning of a new kind.
 
-Connection where you don't have to shrink. Where you can disagree without disaster. Where you're seen without being managed.
+Connection where you don't have to shrink. Where you can disagree without disaster. Where you're seen without being managed. Where boundaries are respected, not resented. Where your growth is celebrated, not threatened.
 
 This kind of community is rare. It's also possible.
 
+You don't find it by accident. You find it by becoming the kind of person who can participate in it. You find it by showing up, again and again, as yourself. You find it by trusting the process, even through the lonely phases.
+
 And you're ready to build it.
+
+The work of these chapters has prepared you. You can regulate. You can hold boundaries. You can stay in yourself while being with others. You can connect without absorbing. You can love without losing yourself.
+
+Now take what you've learned and build your people.
+
+Not from desperation. Not from loneliness. Not from the old patterns of merging, fawning, or performing.
+
+From sovereignty. From wholeness. From the deep knowing that you are already complete—and that connection makes life richer, not you more whole.
+
+Your people are out there. Some are already in your life, unrecognized. Some you haven't met yet. Some are reading this same book, wondering if they'll ever find their community.
+
+Keep showing up. Keep being yourself. Keep trusting the process.
+
+Community is coming.
 
 ---
 
 **[Continue to the Epilogue →](./11-epilogue.md)**
-
-


### PR DESCRIPTION
Significantly expand chapters 14-18 with greater depth while maintaining
the book's voice and essence:

- Chapter 14 (Sovereignty at Work): Added field notes, expanded work
  patterns (perfectionist, chameleon), imposter syndrome section,
  pre/post-meeting practices, and leadership as sovereignty content

- Chapter 15 (Navigating Dysregulation): Added family dinner vignette,
  expanded mirror neuron and fawn response sections, new practices
  (separation breath, post-exposure recovery)

- Chapter 16 (Holding Space): Added friend in crisis vignette, container
  vs rescuer comparison, witnessing art section, helplessness tolerance
  practice, and self-holding content

- Chapter 17 (Teaching Without Converting): Added dinner party vignette,
  validation seeking exploration, judgment trap section, expanded
  sovereign sharing approaches

- Chapter 18 (Sovereign Community): Added new friend vignette, stages of
  finding people, grief of outgrowing section, community disappointment
  handling, and ripple effect content