### PR TITLE
📚 Expand and deepen Volume 2 chapters 14-17

### DIFF
--- a/book/vol-2-bridge/chapters/14-clean-endings.md
+++ b/book/vol-2-bridge/chapters/14-clean-endings.md
@@ -22,13 +22,19 @@ She writes it out.
 
 Everything she wants to say. Every point, perfectly articulated. Every grievance, finally spoken.
 
-She rehearses it in the shower, in the car, at 3 AM when sleep won't come.
+She rehearses it in the shower, in the car, at 3 AM when sleep won't come. She imagines his face softening. She imagines him finally seeing her—really seeing her. She imagines the relief that will flood her body when he says, "I understand."
 
 When she finally delivers it, he deflects. Defends. Turns it around.
 
+"That's not what happened."
+
+"You're remembering it wrong."
+
+"I can't believe you're still bringing this up."
+
 She leaves feeling worse than before.
 
-The closure she imagined never arrives.
+The closure she imagined never arrives. In its place: more material to replay, more conversations to rehearse, more nights spent wondering what words would have worked.
 
 ---
 
@@ -36,17 +42,37 @@ The closure she imagined never arrives.
 
 She writes it all out.
 
-Every hurt. Every hope. Every thing she wishes had been different.
+Every hurt. Every hope. Every thing she wishes had been different. She doesn't edit for his feelings. She doesn't soften the truth.
 
 She doesn't send it.
 
-She reads it aloud to herself. Witnesses her own pain. Lets the weight of it land.
+Instead, she reads it aloud to herself in an empty room. She lets her voice break. She witnesses her own pain—fully, without managing his reaction.
 
-Then she burns the paper. Watches the smoke rise.
+Then she takes the pages outside. Lights a match. Watches the smoke rise.
 
-Something shifts in her chest.
+Something shifts in her chest. Something unclenches.
 
 She didn't need him to hear it. She needed to say it—and release it.
+
+The conversation with him would have been for his understanding. This ritual was for her completion.
+
+---
+
+## Field Note: The Funeral for the Living
+
+He realizes one day that he's been grieving someone who's still alive.
+
+His mother is there—physically present, posting on social media, sending occasional texts full of guilt trips and cheerful emojis.
+
+But the mother he needed, the one who could have seen him, protected him, chosen him—that person never existed. Or if she did, she was too wounded to stay.
+
+So he holds a private funeral.
+
+He writes a eulogy for the mother he wished he'd had. He speaks it to the empty chair in his therapist's office. He cries for a loss that no one else can see—because the person is still alive, still calling, still expecting him to perform the role of devoted son.
+
+When he's done, he feels strange. Not healed. But released from something he'd been carrying without knowing it.
+
+He was waiting for her to die to grieve. Now he realizes: he can grieve the loss of what never was while she's still living. That grief belongs to him. It doesn't require her participation.
 
 ---
 
@@ -60,37 +86,76 @@ Many people hold onto hope for the perfect exit:
 - You'll have the last word
 - It will feel finished
 
-This fantasy keeps you attached—sometimes for years.
+This fantasy keeps you attached—sometimes for years. It keeps you rehearsing, strategizing, waiting for the right moment.
 
 The conversation you're imagining requires a person who:
+
 - Can hear feedback without defending
 - Can tolerate their own shame
 - Can stay regulated during discomfort
 - Can offer genuine repair
 - Can prioritize your experience over their narrative
+- Can hold complexity without collapsing into victimhood or rage
 
 If that person existed, you probably wouldn't need the conversation in the first place.
 
 ---
 
+## The Anatomy of the Closure Fantasy
+
+Let's be honest about what you're really hoping for:
+
+**The Vindication Fantasy:**
+"When I explain clearly enough, they'll realize I was right. They'll see themselves through my eyes. They'll admit fault."
+
+**The Repair Fantasy:**
+"This time, they'll apologize. A real apology. They'll want to make it right."
+
+**The Witness Fantasy:**
+"They'll finally see the impact. They'll feel the weight of what they did. They'll carry some of it with me."
+
+**The Redemption Fantasy:**
+"This ending will prove I'm not crazy. If they acknowledge it, I can trust my own perception."
+
+**The Release Fantasy:**
+"Once we have this conversation, I'll be free. The weight will lift. I'll finally move on."
+
+Each fantasy contains a need. But the need is yours to fill—not theirs.
+
+---
+
 ## Neuroscience Lens: Why Closure Isn't Conversational
 
-The brain seeks **completion**. Unresolved situations keep neural pathways active, recycling the same thoughts, emotions, and physiological states.
+The brain seeks **completion**. Unresolved situations keep neural pathways active, recycling the same thoughts, emotions, and physiological states. This is called the **Zeigarnik Effect**—the brain's tendency to remember uncompleted tasks more vividly than completed ones.
 
-This is why you keep replaying conversations, imagining different outcomes, rehearsing what you'd say.
+This is why you keep replaying conversations, imagining different outcomes, rehearsing what you'd say. Your brain is treating this relationship as an open file, constantly returning to it, trying to resolve what feels incomplete.
 
 The brain is looking for completion—and mistakenly believes the other person holds the key.
 
 **But completion can be achieved unilaterally.**
 
 The brain doesn't actually need the other person's participation. It needs:
-- Full emotional expression (felt, not just thought)
-- A clear ending signal
-- Redirection of attention
+
+- **Full emotional expression** (felt in the body, not just thought in the mind)
+- **A clear ending signal** (a moment that says "this is over")
+- **Redirection of attention** (new patterns replacing old rumination)
+- **Somatic discharge** (releasing the physical energy stored in the nervous system)
+- **Narrative integration** (making meaning of what happened)
 
 Rituals, ceremony, and somatic release can provide what conversation cannot.
 
-**Key insight:** The urge for "one more conversation" is often the brain seeking completion through an impossible channel.
+**The neuroscience of letting go:**
+
+When you create a ritual ending, you engage multiple brain systems simultaneously:
+
+- **The limbic system** (emotional processing) receives the signal that the threat is over
+- **The prefrontal cortex** (meaning-making) creates a coherent narrative with a clear ending
+- **The motor cortex** (physical action) participates in the release, embedding the ending in the body
+- **The memory system** (hippocampus) encodes this moment as a marker—a "before" and "after"
+
+This is why rituals work. They speak to the brain in its native language: embodied experience.
+
+**Key insight:** The urge for "one more conversation" is often the brain seeking completion through an impossible channel. The conversation won't close the file—but the right ritual might.
 
 ---
 
@@ -102,26 +167,48 @@ When you try to have the closure conversation with an emotionally immature or na
 - "That's not what happened."
 - "You're remembering it wrong."
 - "I don't know what you're talking about."
+- "That was years ago. Why are you still stuck on this?"
+
+*What this does to you:* Activates self-doubt. Makes you question your memory. Leaves you more confused than before.
 
 **They attack:**
 - "You're the one who..."
 - "This is exactly why you're the problem."
 - "I can't believe you're bringing this up."
+- "You're just like your mother/father."
+
+*What this does to you:* Shifts you from processing your pain to defending yourself. Reactivates the original dynamic.
 
 **They collapse:**
 - "I'm such a terrible person."
 - "I guess I can't do anything right."
 - "You're making me feel awful."
+- "Fine, I'm the worst parent/partner ever."
+
+*What this does to you:* Triggers your caretaking programming. Now you're managing their feelings instead of expressing yours.
 
 **They minimize:**
 - "You're making too big a deal of this."
 - "That was years ago."
 - "Why can't you just move on?"
+- "Other people have it worse."
+
+*What this does to you:* Invalidates your experience. Makes you feel like your pain is excessive, unreasonable, wrong.
 
 **They redirect:**
 - "What about what you did?"
 - "I thought we were past this."
 - "You're the one who can't let go."
+- "Remember when you..."
+
+*What this does to you:* Shifts focus to your imperfections. Creates false equivalence between your reactions and their actions.
+
+**They absorb and forget:**
+- "You're right. I'm sorry." (Said in a way that ends the conversation without real acknowledgment)
+- "Okay, I hear you." (Nothing changes)
+- "Let's move forward." (Without actually processing what happened)
+
+*What this does to you:* Gives you words that sound like resolution but feel hollow. Creates confusion about whether anything was actually addressed.
 
 None of these responses give you closure. They give you more material to process.
 
@@ -136,6 +223,7 @@ A clean ending is:
 - Peace that doesn't require their acknowledgment
 - Finishing inside yourself what they cannot finish with you
 - Internal clarity that no longer depends on their understanding
+- A story with an ending you wrote
 
 A clean ending isn't:
 
@@ -144,6 +232,25 @@ A clean ending isn't:
 - Forcing accountability
 - Winning the narrative
 - Changing their story about you
+- Proving you were right
+
+The cleanliness of the ending is measured by your internal state—not by their response.
+
+---
+
+## The Paradox of Clean Endings
+
+Here's what makes this hard:
+
+**The more you need them to understand, the less likely you are to feel closure from the conversation.**
+
+Why? Because the need itself reveals that you're still looking outside yourself for validation. You're still making your peace contingent on their capacity.
+
+**The cleaner ending comes when you no longer need the conversation to happen.**
+
+This doesn't mean you wouldn't appreciate acknowledgment. It means your wholeness doesn't depend on it.
+
+This is the paradox: The path to closure often requires letting go of the need for the closure conversation itself.
 
 ---
 
@@ -156,23 +263,39 @@ There are different ways to end:
 - Becoming less available
 - Gray-rocking into obscurity
 - The relationship dies quietly
+- No dramatic exit
 
-*Best for:* Situations where confrontation would be dangerous or pointless; when you need time to detach; when you're not ready for a clear cut.
+*Best for:* Situations where confrontation would be dangerous or pointless; when you need time to detach; when you're not ready for a clear cut; when you're dealing with someone who would escalate if confronted directly.
+
+*The risk:* Can keep you in limbo. The lack of a clear ending might delay your own processing.
 
 **The Clear Cut:**
 - A final statement
 - No further contact
 - Block and done
+- The relationship ends definitively
 
-*Best for:* When you need the clean break for your own clarity; when continued contact reactivates you; when the slow fade keeps you stuck.
+*Best for:* When you need the clean break for your own clarity; when continued contact reactivates you; when the slow fade keeps you stuck; when you need to protect yourself from hoovering.
+
+*The risk:* May trigger guilt waves, second-guessing, fear that you were too harsh.
 
 **No Announcement:**
 - Just stop
 - No explanation
 - No final letter
 - Simply gone
+- Let them wonder
 
-*Best for:* When any explanation will be weaponized; when you don't owe them understanding; when the exit itself is the statement.
+*Best for:* When any explanation will be weaponized; when you don't owe them understanding; when the exit itself is the statement; when they've lost the privilege of knowing your reasons.
+
+*The risk:* You may carry questions about whether they understood, whether they even noticed.
+
+**The Formal Closure (for relationships that require it):**
+- "I need some space and won't be responding."
+- "I'm stepping back from this relationship indefinitely."
+- Brief, clear, final.
+
+*Best for:* Professional relationships, co-parenting situations, circumstances where complete disappearance isn't possible.
 
 **The truth:** There is no perfect way to end. There is only the way that serves your healing.
 
@@ -182,40 +305,59 @@ There are different ways to end:
 
 Sometimes you need to speak—not for them, but for yourself.
 
+The words need to leave your body. The truth needs to be uttered, even if it's not received.
+
 If you choose to deliver a final message:
 
-**Keep it short.** Long explanations give them more to argue with.
+**Keep it short.** Long explanations give them more to argue with. Each point you make is a potential attack surface.
 
-**Keep it about you.** "I'm choosing to end this" rather than "You did this to me."
+**Keep it about you.** "I'm choosing to end this" rather than "You did this to me." Statements about your choices are harder to dispute than claims about their behavior.
 
-**Don't expect response.** Say it as a closing, not an opening.
+**Don't expect response.** Say it as a closing, not an opening. If you're hoping for dialogue, you're not ready for this to be final.
 
-**Don't need their agreement.** Your experience is valid whether or not they validate it.
+**Don't need their agreement.** Your experience is valid whether or not they validate it. You're not asking for permission.
 
-**Don't stay to process their reaction.** Say it and leave.
+**Don't stay to process their reaction.** Say it and leave. Their response is their business.
+
+**Don't explain your reasons in detail.** The more you explain, the more they have to argue with. "Because this is what I need" is sufficient.
 
 **Example:**
 *"I've thought about this carefully. I'm choosing to step back from this relationship. This isn't a discussion—it's a decision. I wish you well."*
 
 That's enough. Anything more invites negotiation.
 
+**Another example:**
+*"I'm not able to continue this relationship. I won't be explaining further. Please respect this boundary."*
+
+Short. Clear. Final.
+
 ---
 
 ## Internal Closure Rituals
 
-Since closure is internal, you can create it for yourself.
+Since closure is internal, you can create it for yourself. These rituals engage the body, signal the brain, and create the completion your nervous system is seeking.
 
 ### The Unsent Letter
 
 Get it all out. Every grievance. Every hurt. Every thing you wish you'd said. Write until there's nothing left.
 
+Don't edit. Don't be fair. Don't consider their perspective. This letter is for you.
+
+Include:
+- What they did that hurt you
+- How it affected you
+- What you wish they had done instead
+- What you needed and didn't get
+- What you're releasing now
+
 Then choose what to do with it:
 - Burn it and watch it disappear
 - Bury it in the earth
-- Release it into water
+- Release it into water (only if biodegradable)
+- Tear it into tiny pieces
 - Delete it with intention
 
-The act of disposal is the completion signal.
+The act of disposal is the completion signal. Your brain receives the message: *This is over.*
 
 ### The Empty Chair
 
@@ -223,39 +365,96 @@ Set up an empty chair. Speak to them as if they're there.
 
 Say everything. Don't hold back. Don't be polite. Don't edit.
 
+Let your voice shake. Let the tears come. Let the anger rise.
+
+You can speak to:
+- The person they actually are
+- The person you wish they had been
+- The parent you needed but didn't have
+- The partner you thought you were getting
+
 When you're done, stand up and leave the room.
 
 That was the conversation. It's over now.
+
+Variation: Record yourself. Listen back. Witness your own truth. Then delete the recording.
 
 ### The Timeline Ending
 
 Write the story of the relationship as a narrative—with a clear ending.
 
-*"We met in 2015. For years, I tried to make it work. I explained, adjusted, waited. In 2023, I chose to leave. The story ended there."*
+Don't write about them. Write about you and them. Your story.
 
-Writing an ending tells the brain: *This chapter is closed.*
+Include:
+- How it began
+- What you hoped for
+- What actually happened
+- The moments that mattered
+- The turning points
+- How it ended
+
+End with a clear statement:
+
+*"We met in 2015. For years, I tried to make it work. I explained, adjusted, waited. In 2023, I chose to leave. The story ended there. I am the author now."*
+
+Writing an ending tells the brain: *This chapter is closed. The story continues, but that plot line is resolved.*
 
 ### The Ceremonial Release
 
 Write their name on paper. Or a photo. Or an object that represents the relationship.
 
 Create a small ceremony:
+- Find a quiet space
 - Light a candle
-- Speak what you're releasing
-- Burn, bury, or discard the object
+- Hold the object or paper
+- Speak what you're releasing (aloud)
+- Burn, bury, or discard the object with intention
 - Extinguish the candle
+- Leave the space
 
-Ceremony works because it engages the body and creates a sensory marker for the brain.
+Ceremony works because it engages the body and creates a sensory marker for the brain. The smell of the smoke, the warmth of the candle, the sound of your voice—all become encoded as *the ending.*
 
 ### The Final Exhale
 
-Sit quietly. Breathe in the relationship—all of it. The good, the bad, the grief, the hope.
+Sit quietly. Close your eyes.
 
-Then exhale it out. Slowly. Completely.
+Breathe in the relationship—all of it. The good, the bad, the grief, the hope, the anger, the love.
 
-Repeat until something shifts in your body.
+Feel it all filling your chest.
 
-This practice tells the nervous system: *We are letting this go.*
+Then exhale it out. Slowly. Completely. Imagine it leaving your body.
+
+Repeat until something shifts. Until your chest feels lighter. Until your shoulders drop.
+
+This practice tells the nervous system: *We are letting this go. It doesn't live here anymore.*
+
+### The Return Ritual
+
+If you have objects, letters, photos—things that carry their energy—you can return them.
+
+Not to the person. To the universe.
+
+Box them up. Take them to a thrift store, a recycling center, a fire pit.
+
+As you release them, say: "These no longer belong to me. I return them to wherever they need to go."
+
+If disposal feels too harsh, you can simply move them. Put them in storage you won't access. Remove them from daily visibility.
+
+What you're doing: reclaiming your space. Signaling to your environment—and your brain—that this chapter is closed.
+
+### The Grief Walk
+
+Take a long walk. Alone.
+
+As you walk, let the relationship move through you. Memory by memory. Feeling by feeling.
+
+Don't analyze. Just feel.
+
+When you're ready, find a natural marker—a tree, a stone, a bend in the path.
+
+Stand there. Say goodbye. Then continue walking.
+
+You're leaving something behind. Physically enacting the ending.
 
 ---
 
@@ -267,6 +466,7 @@ Closure doesn't feel like:
 - Making them understand
 - Getting even
 - Vindication
+- Triumph over them
 
 Closure feels like:
 - Neutrality
@@ -275,8 +475,18 @@ Closure feels like:
 - Moving on without looking back
 - Peace that doesn't require their participation
 - Thinking of them without activation
+- Indifference where obsession used to live
 
 It's quiet. It's not triumphant. It's just... done.
+
+**The markers of genuine closure:**
+
+- You can hear their name without your heart rate changing
+- You can encounter a memory without spiraling
+- You don't need to know what they're doing
+- You don't rehearse conversations anymore
+- You can wish them well without it meaning anything about your relationship with them
+- The story is in the past tense
 
 ---
 
@@ -287,19 +497,60 @@ One of the hardest parts of a clean ending is accepting:
 **They may never understand.**
 
 They may:
-- Tell a different story
-- Paint you as the villain
+- Tell a different story forever
+- Paint you as the villain in every retelling
 - Never acknowledge what happened
 - Die without apologizing
 - Genuinely believe they did nothing wrong
+- Convince others that you're the problem
+- Rewrite history entirely
 
 Can you be okay with that?
 
 This is the real test of clean endings. Not whether they understand—but whether you can be complete without their understanding.
 
-**The integration:**
+**The internalization to practice:**
 
 *"My truth is valid even if it's never validated."*
+
+*"Their inability to see me doesn't change what happened."*
+
+*"I don't need their story to match mine. I know what I lived."*
+
+**Why this matters:**
+
+If your sense of closure depends on them eventually "getting it," you're still attached. You're still waiting. You're still organizing around them.
+
+True closure means: your understanding of what happened doesn't require their agreement.
+
+---
+
+## The Fear Behind the Need for Acknowledgment
+
+Why is it so hard to let go of the need to be understood?
+
+Because underneath that need are deeper fears:
+
+**The fear of being crazy:**
+"If they don't acknowledge it, maybe it didn't happen the way I remember. Maybe I'm the problem."
+
+**The fear of being unseen:**
+"If no one witnesses my pain, does it exist? Was it real?"
+
+**The fear of injustice:**
+"If they don't face consequences, if they never have to reckon with what they did, how can I move on?"
+
+**The fear of aloneness:**
+"If I'm the only one who knows this truth, I'm alone with it forever."
+
+These fears are real. They deserve compassion.
+
+And: you can address each one without their participation.
+
+- Your memories are valid. Gaslighting doesn't erase what happened.
+- Your pain is real. Witnesses can be therapists, friends, your own writing.
+- Justice isn't always external. Sometimes justice is your freedom.
+- You're not alone. Others have lived similar stories. Community exists.
 
 ---
 
@@ -308,24 +559,36 @@ This is the real test of clean endings. Not whether they understand—but whethe
 Letting go isn't instant. It has phases:
 
 **Phase 1: Separation**
-You stop engaging. Create physical and emotional distance.
+You stop engaging. Create physical and emotional distance. Stop feeding the dynamic with your energy.
+
+*This phase feels like:* Relief mixed with terror. Freedom mixed with abandonment.
 
 **Phase 2: Grief**
-You feel the loss. The sadness, anger, relief, confusion—all of it.
+You feel the loss. The sadness, anger, relief, confusion—all of it. You may cycle through multiple emotions in a single day.
+
+*This phase feels like:* Waves. Unpredictable waves.
 
 **Phase 3: Processing**
-You make sense of what happened. Not for them—for you.
+You make sense of what happened. Not for them—for you. You name the patterns, understand the dynamics, integrate the experience.
+
+*This phase feels like:* Clarity arriving in pieces.
 
 **Phase 4: Rebuilding**
-You construct a life that doesn't include them.
+You construct a life that doesn't include them. New routines, new relationships, new identity.
+
+*This phase feels like:* Strange. Unfamiliar. Sometimes exciting.
 
 **Phase 5: Neutrality**
-They become a memory, not an activation.
+They become a memory, not an activation. Thoughts of them don't flood you. The charge diminishes.
+
+*This phase feels like:* Peace. Not happiness—just peace.
 
 **Phase 6: Integration**
-The experience becomes part of your story—not the center of it.
+The experience becomes part of your story—not the center of it. You are more than what happened. The wound becomes wisdom.
 
-This takes time. Months. Sometimes years. There's no shortcut.
+*This phase feels like:* Wholeness.
+
+This takes time. Months. Sometimes years. There's no shortcut. Anyone who tells you to "just move on" doesn't understand the territory.
 
 ---
 
@@ -333,17 +596,50 @@ This takes time. Months. Sometimes years. There's no shortcut.
 
 Sometimes, after you think you're done, the grief returns.
 
-A song. A date. A dream. A random memory.
+A song. A date. A dream. A random memory. A smell. A phrase someone uses.
+
+The wave rises. You think: "I thought I was past this."
 
 This doesn't mean you haven't healed. It means you're human.
 
-Grief doesn't disappear; it transforms. The waves get smaller and less frequent—but they don't stop completely.
+Grief doesn't disappear; it transforms. The waves get smaller and less frequent—but they don't stop completely. Maybe ever.
 
-When old grief returns:
-- Let it move through you
-- Don't make it mean you've failed
-- Return to your practices
-- Trust the overall trajectory
+**When old grief returns:**
+- Let it move through you (don't fight it)
+- Don't make it mean you've failed (you haven't)
+- Don't make it mean you need to reach out (you don't)
+- Return to your practices (rituals, grounding, support)
+- Trust the overall trajectory (the waves are getting smaller)
+
+**The image that helps:**
+
+Think of grief like weather. Storms come. They pass. You're not the storm—you're the sky. The sky remains, no matter what moves through it.
+
+---
+
+## The Difference Between Ending and Punishing
+
+Sometimes the desire for closure is actually a desire for punishment.
+
+Check yourself:
+
+**Ending sounds like:**
+- "I need to protect my peace."
+- "This relationship doesn't work for me."
+- "I'm choosing to stop engaging."
+
+**Punishing sounds like:**
+- "I want them to feel what I felt."
+- "I need them to suffer consequences."
+- "I want them to see what they lost."
+
+Ending is about you. Punishing is about them.
+
+Both impulses are human. But only one creates clean endings.
+
+If you're leaving to make them feel something, you're still attached to their experience. You're still orienting around them.
+
+Clean endings don't require them to feel anything. They only require you to be free.
 
 ---
 
@@ -354,6 +650,8 @@ What closure conversation are you still holding onto?
 What would it mean to create closure internally, without their participation?
 
 What ritual might help you signal completion to your nervous system?
+
+What would you need to believe in order to stop waiting for their acknowledgment?
 
 ---
 
@@ -366,4 +664,3 @@ What ritual might help you signal completion to your nervous system?
 ## One-Line Anchor
 
 *"Closure is something I create—not something they give me."*
-

--- a/book/vol-2-bridge/chapters/15-hope-without-waiting.md
+++ b/book/vol-2-bridge/chapters/15-hope-without-waiting.md
@@ -20,9 +20,11 @@ His birthday is next month. Maybe she should reach out. Maybe this is the year h
 
 She hasn't dated seriously in two years. Not because no one is available—but because part of her is still waiting. What if he changes? What if she misses the moment?
 
-Her life is organized around a possibility that shows no sign of arriving.
+Her apartment has the same furniture arrangement it had when they were together. She hasn't moved the extra chair. She hasn't taken down that one photo. She hasn't rearranged her life because... what if?
 
 She calls it hope. But it functions like a pause button.
+
+Her life is organized around a possibility that shows no sign of arriving.
 
 ---
 
@@ -32,11 +34,39 @@ She thinks of him sometimes. Fondly. Sadly.
 
 She wishes him well—genuinely. She hopes he finds peace, healing, whatever he needs.
 
-And she dates. She travels. She builds a life.
+And she dates. She travels. She builds a life. She moved the furniture. She took down the photo. Not in anger—in release.
 
 Not because she's given up on him. But because she's stopped waiting for him to begin.
 
 Hope still exists. It just doesn't run her calendar anymore.
+
+She doesn't check his social media. She doesn't track his birthday approaching. She doesn't imagine scenarios of reconciliation.
+
+And strangely, this feels more like love than the waiting ever did.
+
+---
+
+## Field Note: The Open Door That Kept Her Trapped
+
+For three years after going low-contact with her mother, she kept "the door open."
+
+She would respond to occasional texts. She would send birthday cards. She would answer the phone when her mother called at odd hours.
+
+She told herself this was the compassionate thing to do. She wasn't closing the door on healing. She wasn't being rigid.
+
+But every interaction reactivated her. Every text sent her back into the same loops. Every phone call left her dysregulated for days.
+
+The door wasn't open to connection. It was open to chaos.
+
+One day her therapist asked: "What would it mean to close the door as an act of love—for yourself?"
+
+She realized: the open door wasn't hope. It was a way to avoid fully feeling the loss. As long as the door was open, she didn't have to grieve.
+
+When she finally closed it—gently, with a brief message that she needed space indefinitely—something shifted.
+
+She grieved hard for weeks. But then something else arose: space. Room to breathe. The beginning of a life that wasn't organized around possibility.
+
+She still hopes her mother heals. She just doesn't leave herself exposed while waiting for it.
 
 ---
 
@@ -51,14 +81,42 @@ The trap is when hope becomes:
 - Staying emotionally available "just in case"
 - Orienting toward a future that may never come
 - Using hope to avoid grief
+- Keeping one foot in the relationship while claiming to have left
+- Maintaining hypervigilance for signs of change
 
 **Waiting is a trauma response, not devotion.**
 
-When you grew up in unpredictable environments, you learned to wait. Wait for the mood to pass. Wait for them to calm down. Wait for things to get better.
+When you grew up in unpredictable environments, you learned to wait. Wait for the mood to pass. Wait for them to calm down. Wait for things to get better. Wait for the parent you glimpsed briefly to return.
 
-That waiting felt like love. It felt like loyalty.
+That waiting felt like love. It felt like loyalty. It felt like the only option.
 
 But waiting is not hope. Waiting is suspension.
+
+---
+
+## The Anatomy of Waiting
+
+Let's name what waiting actually involves:
+
+**Chronic vigilance:**
+Scanning for signs of change. Interpreting every message, every silence, every interaction for evidence that things might be different.
+
+**Life on hold:**
+Not fully committing to new relationships, new locations, new identities—because what if?
+
+**Partial presence:**
+Being only half-here because part of your attention is always oriented toward them.
+
+**Strategic availability:**
+Staying accessible enough that they could reach you if they wanted to.
+
+**Rumination as connection:**
+Thinking about them constantly as a way of staying bonded—even from distance.
+
+**Fantasy maintenance:**
+Keeping alive the movie of the relationship you wish you'd had, the person you wish they'd been.
+
+Waiting isn't passive. It's exhausting. It takes enormous energy to maintain suspension.
 
 ---
 
@@ -66,9 +124,27 @@ But waiting is not hope. Waiting is suspension.
 
 The brain processes hope and waiting differently.
 
-**Hope** activates the prefrontal cortex—future-oriented thinking, planning, meaning-making. It can coexist with present-moment engagement.
+**Hope** activates the prefrontal cortex—future-oriented thinking, planning, meaning-making. It can coexist with present-moment engagement. Hope says: "This could be good." It's a cognitive orientation that doesn't require vigilance.
 
-**Waiting** activates the threat-detection system. The brain stays alert for change, scanning for signs, maintaining vigilance. The present becomes a waiting room for a future that may never arrive.
+**Waiting** activates the threat-detection system. The brain stays alert for change, scanning for signs, maintaining vigilance. The present becomes a waiting room for a future that may never arrive. Waiting keeps the stress response engaged.
+
+**The neurochemistry of waiting:**
+
+When you wait, your brain maintains a low-grade stress response:
+- Elevated cortisol (chronic alertness)
+- Norepinephrine activation (vigilance)
+- Suppressed dopamine (reduced pleasure in present experiences)
+
+This is why waiting is exhausting. Your body is in a sustained state of anticipation. It never fully relaxes because the "situation" is never resolved.
+
+**The neurochemistry of healthy hope:**
+
+When you hope without waiting, the brain can engage:
+- Prefrontal cortex (abstract future-thinking)
+- Default mode network (relaxed reflection)
+- Full engagement with present experience
+
+You can hold a hopeful thought and then return to your life. The thought doesn't hijack your attention or keep your nervous system activated.
 
 **Key insight:** You can carry hope in the background while living fully in the present. Waiting, by contrast, keeps the nervous system in chronic anticipation.
 
@@ -79,19 +155,34 @@ The brain processes hope and waiting differently.
 ## What Unhealthy Hope Looks Like
 
 **Orienting hope:**
-You structure your life around the possibility of change. You stay accessible. You check in periodically. You hold space in case they come around.
+You structure your life around the possibility of change. You stay accessible. You check in periodically. You hold space in case they come around. You don't make permanent decisions because things might change.
+
+*How it sounds:* "I'm keeping my options open." "I want to leave the door ajar." "I don't want to do anything I can't undo."
 
 **Magical thinking hope:**
-You believe if you just find the right words, the right timing, the right approach—they'll finally get it.
+You believe if you just find the right words, the right timing, the right approach—they'll finally get it. You read books about communication, you practice conversations, you wait for the perfect moment.
+
+*How it sounds:* "If I could just explain it differently..." "Maybe if I try one more time..." "I think they're almost ready to hear me."
 
 **Loyalty-based hope:**
-You feel giving up hope means being disloyal. Real love never gives up, right?
+You feel giving up hope means being disloyal. Real love never gives up, right? A good child never stops believing their parent can change.
+
+*How it sounds:* "I don't want to abandon them." "What if I'm wrong about them?" "Giving up on them feels like giving up on love itself."
 
 **Avoidance hope:**
-Hope lets you avoid the grief of accepting what is.
+Hope lets you avoid the grief of accepting what is. As long as you hope, you don't have to fully feel the loss.
+
+*How it sounds:* "I'm not ready to close that door." "Maybe it's not as bad as I think." "I want to stay positive."
 
 **Bargaining hope:**
-You hope as a way to stay connected—as if hoping keeps the relationship alive.
+You hope as a way to stay connected—as if hoping keeps the relationship alive. Hope becomes a form of magical tethering.
+
+*How it sounds:* "If I keep hoping, I'm still connected to them." "My hope keeps the possibility alive." "As long as I don't give up, there's still a chance."
+
+**Identity-based hope:**
+You've been the one who hopes for so long that you don't know who you'd be without it. The hope has become part of your identity.
+
+*How it sounds:* "I'm the one who never gives up." "I've always been the one who believes in people." "This is just who I am."
 
 In all of these, hope is functioning as a way to stay attached—not as a way to move forward.
 
@@ -100,19 +191,29 @@ In all of these, hope is functioning as a way to stay attached—not as a way to
 ## What Healthy Hope Looks Like
 
 **Released hope:**
-You hope for their wellbeing without organizing your life around it. You wish them growth without waiting for it.
+You hope for their wellbeing without organizing your life around it. You wish them growth without waiting for it. You can think of them kindly without tracking their progress.
+
+*How it sounds:* "I hope they find healing." *Full stop.* Not: "I hope they find healing and realize what they had with me."
 
 **Background hope:**
-It exists, but it doesn't run your choices. You hope—and you also live your life.
+It exists, but it doesn't run your choices. You hope—and you also live your life. The hope is like a thought that passes through, not a structure you inhabit.
+
+*How it sounds:* "I think of them sometimes and wish them well. Then I go about my day."
 
 **Grief-integrated hope:**
-You've grieved what isn't, and you can still hope for what might be—without the hope being a defense against the grief.
+You've grieved what isn't, and you can still hope for what might be—without the hope being a defense against the grief. The hope comes after the grief, not instead of it.
+
+*How it sounds:* "I've accepted that things aren't what I wanted. And I can still hope for their healing—without needing it to change anything for me."
 
 **Non-attached hope:**
-You carry hope—you don't wait with it.
+You carry hope—you don't wait with it. The hope doesn't require any particular outcome to remain intact.
+
+*How it sounds:* "I hope they grow. If they do, great. If they don't, my life continues."
 
 **Generalized hope:**
 You hope they find healing—not specifically with you, but in their life. You release the need for it to include you.
+
+*How it sounds:* "I hope they find peace. I don't need to be part of that story."
 
 ---
 
@@ -126,6 +227,10 @@ You hope they find healing—not specifically with you, but in their life. You r
 | Doesn't delay your life | Pauses your life |
 | Holds possibility lightly | Grips possibility tightly |
 | Nervous system regulated | Nervous system vigilant |
+| Present-moment engagement | Future-oriented suspension |
+| Can be released | Feels impossible to let go of |
+| Comes from wholeness | Comes from need |
+| A thought that passes | A state you inhabit |
 
 You can hope someone heals without waiting for it to happen before you move forward.
 
@@ -137,11 +242,19 @@ Here's what no one tells you:
 
 **Sometimes, truly letting go is what allows something to return—and sometimes it doesn't.**
 
-You can't let go strategically. You can't release them in hopes that your release brings them back.
+You can't let go strategically. You can't release them in hopes that your release brings them back. That's not letting go—that's a sophisticated form of manipulation (even if you're only manipulating yourself).
 
 True release means: *"I hope they heal—and I'm living my life either way."*
 
 If that release happens to create space for reconnection, fine. But you can't engineer it. The moment you're releasing-to-get-them-back, you're not actually releasing.
+
+**The test:**
+
+Can you genuinely not know if they'll come back—and be okay either way?
+
+If yes: that's release.
+
+If no: there's more work to do.
 
 ---
 
@@ -155,8 +268,22 @@ Hope needs to rest when:
 - It's preventing you from building a life
 - It's exhausting you
 - It's the only thing keeping you connected to someone
+- It's become an obsession rather than a feeling
+- It's making you interpret every interaction through the lens of possibility
+- It's become an excuse for not moving forward
+- It's indistinguishable from denial
 
 Letting hope rest doesn't mean giving up. It means putting it in the background and letting life take the foreground.
+
+**The practice:**
+
+Imagine taking your hope and placing it on a shelf. It's still there. You can see it. You haven't thrown it away.
+
+But it's not in your hands anymore. It's not something you carry constantly.
+
+You can glance at it sometimes. You can take it down when you want to.
+
+But mostly, you let it rest. And you live your life.
 
 ---
 
@@ -171,12 +298,16 @@ You can:
 - Send good thoughts
 - Hope for their growth
 - Care about their wellbeing
+- Hold tenderness for who they might become
 
 Without:
 - Engaging
 - Staying in contact
 - Explaining yourself
 - Waiting for change
+- Checking for signs
+- Orienting around them
+- Leaving yourself available
 
 This keeps the heart open without leaving you vulnerable.
 
@@ -184,11 +315,34 @@ This keeps the heart open without leaving you vulnerable.
 
 Close your eyes. Picture them.
 
+Not as they were in conflict. Not as the person who hurt you. Just... them. In their wholeness. In their struggling. In their wounding.
+
 Say internally: *"I wish you healing. I wish you peace. I release you to your journey—and I return to mine."*
 
 Let them fade from your mental field.
 
 Open your eyes and return to your day.
+
+This practice accomplishes several things:
+- It allows love to flow (which feels better than bitterness)
+- It doesn't require their participation
+- It completes the energetic loop internally
+- It doesn't leave you waiting for anything
+- It maintains your heart's openness without maintaining the relationship
+
+---
+
+## The Neuroscience of Distant Love
+
+When you send love without engagement, you're doing something interesting in your brain:
+
+**You're completing the attachment impulse without activating the attachment behavior.**
+
+The impulse to love is human. The behavior of attaching—seeking proximity, staying available, orienting around—is what becomes problematic.
+
+By internally generating the feeling of well-wishing, you satisfy the loving impulse. By not acting on it, you don't reactivate the attachment dynamic.
+
+This is why the practice works: it acknowledges the love without feeding the bond.
 
 ---
 
@@ -201,14 +355,27 @@ This can be healthy if:
 - You're not testing for response
 - You're not maintaining hope through the gesture
 - It feels true to who you are
+- You can send it and truly forget about it
+- Your peace doesn't depend on what happens next
 
 This is not healthy if:
 - You're waiting to see how they respond
 - You're hoping the gift will open a door
 - You feel resentful if they don't reciprocate
 - It's a disguised attempt at reconciliation
+- You analyze their response (or lack of one)
+- You feel activated after sending it
+- You're doing it to prove something (to them or to yourself)
 
 Check your motive. Clean gifts have no hooks.
+
+**The hook test:**
+
+Before sending something, ask: "If they don't respond, if they don't acknowledge it, if they throw it away—how will I feel?"
+
+If the answer is "disappointed," "hurt," or "angry"—there's a hook.
+
+If the answer is "the same as I feel now"—it might be clean.
 
 ---
 
@@ -228,26 +395,60 @@ Check your motive. Clean gifts have no hooks.
 
 This practice separates love from attachment, hope from dependence.
 
+**Daily version:**
+
+When you think of them, pause. Notice the thought without feeding it.
+
+Say to yourself: "I wish you well. And I return to my life now."
+
+Then actually return. Do something. Engage with what's in front of you.
+
+The thought will return. Do it again. The practice is in the repetition.
+
 ---
 
 ## When They Come Back
 
 Sometimes, after distance, they reach out.
 
-This can feel like hope paying off. But pause:
+This can feel like hope paying off. The moment you've been waiting for. Proof that you were right to believe.
+
+But pause.
 
 **Before re-engaging, ask:**
 
 - Has anything actually changed?
+- What evidence is there of growth (not just words, but patterns)?
 - Am I responding from regulation or relief?
-- What evidence is there of growth?
 - Can I stay boundaried if nothing has changed?
 - Am I hoping this time is different—or am I observing that it is?
 - Is this genuine movement—or just another cycle?
+- How do I feel in my body right now? Regulated or activated?
+- What would my wisest self advise?
 
-One message doesn't mean transformation. Approach with caution.
+One message doesn't mean transformation. One conversation doesn't mean change. One apology doesn't mean repair.
 
 **The test:** Changed behavior over time, not words in a moment.
+
+**What to watch for:**
+
+Genuine change shows up as:
+- Acknowledgment without defensiveness
+- Accountability without collapse
+- Changed behavior without needing to be asked
+- Consistency over months (not days or weeks)
+- Interest in understanding, not just reconnecting
+- Tolerance of your boundaries
+
+The same old pattern shows up as:
+- Love-bombing after absence
+- Big gestures without sustained follow-through
+- Words that promise but actions that don't match
+- Pressure to "move past it" quickly
+- Expectation that your distance means you owe them something
+- Making you responsible for their feelings about your absence
+
+**Approach with caution.** Return doesn't mean reconciliation. Reconciliation requires repair. Repair requires time.
 
 ---
 
@@ -264,10 +465,23 @@ You may feel:
 - Confusion (was I wrong?)
 - Freedom (now I can move on)
 - Guilt (did I give up too soon?)
+- Vindication (I was right about them)
+- Emptiness (what do I do with this space?)
 
-All of these are valid.
+All of these are valid. All of them can coexist.
 
 The silence doesn't mean you were wrong to hope. It means the hope didn't materialize—and now you grieve that, too.
+
+**The grief beneath the silence:**
+
+When they don't come back, you're grieving:
+- The relationship you had
+- The relationship you wanted
+- The person you hoped they'd become
+- The version of yourself who believed
+- The story that had a different ending
+
+This is layered grief. Let it have space.
 
 ---
 
@@ -284,10 +498,21 @@ Part of releasing unhealthy hope is being willing to grieve.
 - They may never change
 - I may never get what I needed
 - This door may be closed forever
+- I cannot make them see me
+- I cannot love them into health
+- My hope doesn't change their capacity
 
 Feeling that grief is not giving up. It's integrating reality.
 
 And paradoxically, it's often what allows healthy hope to emerge—hope that isn't dependent on outcomes, but simply holds space for possibility.
+
+**The sequence:**
+
+1. Feel the hope
+2. Notice what grief the hope is protecting you from
+3. Let yourself feel the grief
+4. Let the grief move through you
+5. Notice what remains after the grief: possibly, a cleaner hope
 
 ---
 
@@ -302,8 +527,33 @@ It's about the kind of person you want to be:
 - One who can wish well without waiting
 - One who can stay soft without staying vulnerable
 - One who can grieve and still be open
+- One who can release without closing their heart
 
 Hope, held this way, is a practice—not a strategy for getting them back.
+
+**The reframe:**
+
+Instead of: "I hope they change."
+
+Try: "I hope—period. For them, for me, for life itself."
+
+Hope becomes generalized rather than specific. It becomes a quality you embody rather than a bet you're placing on one outcome.
+
+---
+
+## When Hope Becomes Freedom
+
+There's a moment—maybe it comes gradually, maybe it arrives suddenly—when hope stops being a waiting game and becomes a form of freedom.
+
+You can hope for them. You can love them from afar. You can wish them everything you wish for anyone.
+
+And you can also: date freely, move forward fully, build a life completely.
+
+These aren't contradictions. They're both true.
+
+The hope doesn't require the waiting. The love doesn't require the engagement. The softness doesn't require the vulnerability.
+
+When you arrive here, you've found the bridge: moving forward while staying kind.
 
 ---
 
@@ -314,6 +564,8 @@ Where are you waiting instead of hoping?
 What would it look like to hold hope in the background while living fully in the foreground?
 
 What grief might be hiding underneath your hope?
+
+What would it mean to love them from a distance, without needing anything back?
 
 ---
 
@@ -326,4 +578,3 @@ What grief might be hiding underneath your hope?
 ## One-Line Anchor
 
 *"Love can exist without orientation. I wish them well from a distance."*
-

--- a/book/vol-2-bridge/chapters/16-slow-burn.md
+++ b/book/vol-2-bridge/chapters/16-slow-burn.md
@@ -12,6 +12,64 @@ Understanding the difference between activation and safety may be the most impor
 
 ---
 
+## Field Note (Before): The Fireworks
+
+Three weeks in and she's never felt anything like this.
+
+He texts her good morning. He texts her goodnight. He wants to know about her childhood, her dreams, her fears. He says things like "I've never met anyone like you" and "Where have you been my whole life?"
+
+When they're apart, she thinks about him constantly. When they're together, she feels electric. When he doesn't respond for a few hours, she spirals.
+
+She tells her friends: "I've never had chemistry like this."
+
+What she doesn't tell them: she hasn't slept well in weeks. She's neglecting her work. She can't concentrate on anything else. She feels like she's in free fall.
+
+She calls it passion. Her nervous system knows it as something else: familiar danger dressed up as destiny.
+
+---
+
+## Field Note (After): The Quiet Beginning
+
+She almost didn't go on a second date.
+
+He was nice enough. Smart. Kind. Stable. But there wasn't... a spark.
+
+Her friend asked: "Are you attracted to him?"
+
+She said: "I think so? But it's not the same. It's not electric. I don't think about him all the time."
+
+Her friend asked: "Is that bad?"
+
+She paused. She'd never considered that constant obsession wasn't the baseline. That thinking about someone "all the time" wasn't the measure of connection.
+
+So she went on a second date. And a third. And a fourth.
+
+Slowly—so slowly—something grew. Not an explosion. A warmth. A steadiness. A feeling of being able to breathe.
+
+By month three, she realized: this is what attraction feels like when it's not tangled up in fear.
+
+---
+
+## Field Note: The Boring Man Who Saved Her Life
+
+She told her therapist she was worried.
+
+"He's so... stable. He doesn't trigger me at all. I'm not anxious. I'm not trying to decode his texts. I'm not strategizing about how to make him like me more."
+
+Her therapist asked: "And that worries you?"
+
+"Yeah. I feel like... if there's no drama, there's no depth. Like maybe I don't really care about him. Like maybe he's boring."
+
+Her therapist leaned back. "What if boring is just what safety feels like when you're not used to it?"
+
+She didn't answer. But she kept dating him.
+
+A year later, she understood. He wasn't boring. He was consistent. And her nervous system had to relearn that consistency wasn't the same as indifference.
+
+The man she almost dismissed for being "too calm" became the safest relationship she'd ever had.
+
+---
+
 ## What Is a Fast Burn?
 
 **Fast Burn Definition:**
@@ -22,6 +80,8 @@ A fast burn is a rapid emotional bonding characterized by:
 - Feeling "chosen" or "seen" within days/weeks
 - Urgent forward movement (meeting family, labels, future planning)
 - A sense of destiny or fate
+- High emotional peaks and valleys
+- Difficulty thinking about anything else
 
 **What a fast burn feels like:**
 - Electric
@@ -30,12 +90,37 @@ A fast burn is a rapid emotional bonding characterized by:
 - Chemistry
 - Urgency
 - Soul-level connection early
+- Can't eat, can't sleep, can't focus
+- Obsessive thinking
+- Relief when they respond, panic when they don't
 
-**What's actually happening:**
-- Dopamine spike (novelty, excitement)
-- Cortisol spike (anxiety, fear of loss)
+**What's actually happening in your nervous system:**
+- Dopamine spike (novelty, excitement, reward-seeking)
+- Cortisol spike (anxiety, fear of loss, threat response)
+- Norepinephrine surge (hypervigilance, heightened alertness)
 - Familiar activation pattern being triggered
 - Your attachment system recruiting hard to secure connection
+- Stress response masquerading as passion
+
+---
+
+## The Neurochemistry of a Fast Burn
+
+When you fall fast, your brain creates a cocktail that feels like love but functions like addiction:
+
+**Dopamine:** The "more" chemical. Creates craving, anticipation, the high when you see them, the crash when you don't. The same pathway activated by gambling, shopping, substances.
+
+**Cortisol:** The stress hormone. Elevated when you're anxious about the relationship, waiting for a response, afraid of loss. Creates urgency. Makes the relationship feel important, even life-or-death.
+
+**Norepinephrine:** The alertness chemical. Makes you hyperaware of everything they do. Amplifies every interaction. Makes small gestures feel huge.
+
+**Phenylethylamine (PEA):** The "infatuation" chemical. Creates euphoria, excitement, loss of appetite, sleeplessness. Burns out after 6-24 months.
+
+This combination creates an intoxicating experience. It feels like the most important thing that's ever happened.
+
+But here's the problem: **This exact neurochemical profile can be triggered by threat, not just love.**
+
+For those who grew up in unpredictable environments, the nervous system doesn't distinguish between "exciting because good" and "exciting because dangerous." Intensity is intensity. And intensity feels like home.
 
 ---
 
@@ -43,9 +128,11 @@ A fast burn is a rapid emotional bonding characterized by:
 
 For those who grew up in dysregulated environments, fast burn dynamics feel familiar:
 
-- Intensity = love (that's what you knew)
-- Anxiety = passion (that's how love felt)
-- Quick bonding = safety (the faster you lock in, the safer you are)
+- **Intensity = love** (that's what you knew)
+- **Anxiety = passion** (that's how love felt)
+- **Quick bonding = safety** (the faster you lock in, the safer you are)
+- **Constant attention = being valued** (if they're focused on you, you matter)
+- **Drama = depth** (if it's easy, it must not mean much)
 
 Your nervous system is looking for what it knows, not what it needs.
 
@@ -53,6 +140,19 @@ Fast burns often trigger the same neurochemical cascade as the abuse cycle:
 - Activation → Relief → Bonding
 
 This is why you can feel so deeply connected to someone you barely know—and why that connection can feel more "real" than something steadier.
+
+**The pattern:**
+
+1. You meet someone and feel an immediate intense connection
+2. The relationship escalates quickly (texts all day, meeting family, I love you's)
+3. You feel seen, chosen, special
+4. Small conflicts or distance create huge anxiety
+5. Reconciliation creates relief and deeper bonding
+6. The cycle repeats, each round intensifying the attachment
+7. You feel increasingly dependent, increasingly unable to imagine life without them
+8. You mistake this dependence for love
+
+This is trauma bonding in its early stages. And it feels incredible—until it doesn't.
 
 ---
 
@@ -62,22 +162,48 @@ This is why you can feel so deeply connected to someone you barely know—and wh
 
 A slow burn is a gradual emotional bonding characterized by:
 - Attraction that grows over time
-- Stability
-- Consistent patterns
-- No urgency
-- Depth builds through shared experience, not instant recognition
+- Stability without intensity
+- Consistent patterns without drama
+- No urgency to escalate
+- Depth that builds through shared experience, not instant recognition
+- Ability to maintain your own life while dating
+- Nervous system stays regulated
 
 **What a slow burn feels like (initially):**
 - Nice but not electric
 - Comfortable but not exciting
 - Easy but not thrilling
 - Steady but not "meant to be"
+- Pleasant, but you can still think about other things
+- Calm
 
-**What's actually happening:**
+**What's actually happening in your nervous system:**
 - Your nervous system is regulating
 - Safety is being established
 - Trust is building through consistency
-- Attachment is forming slowly and securely
+- Oxytocin is developing slowly (through repeated positive contact)
+- Attachment is forming gradually and securely
+- Your prefrontal cortex stays online (you can think clearly)
+
+---
+
+## The Neurochemistry of a Slow Burn
+
+A slow burn engages different brain chemistry:
+
+**Oxytocin:** The bonding hormone. Released through repeated positive physical contact, eye gazing, presence. Builds slowly. Creates lasting attachment, not just infatuation.
+
+**Serotonin:** Stays stable (instead of dropping like in infatuation). Keeps you calm, able to think, not obsessive.
+
+**Endorphins:** The comfort chemicals. Released through physical closeness, laughter, comfortable silence. Create warmth, not fireworks.
+
+**Low cortisol:** Your stress response stays calm. You're not anxious when they don't text. You're not spiraling when there's silence. You're not in survival mode.
+
+This chemistry doesn't feel as exciting because it's not activating your threat response. It feels... nice. Sustainable. Maybe even a little boring.
+
+But here's what matters: **This chemistry builds something that lasts.**
+
+The fast burn chemicals burn out after 6-24 months. The slow burn chemicals deepen over time. One creates addiction; the other creates attachment.
 
 ---
 
@@ -90,10 +216,19 @@ If you're used to intensity, slow burns feel:
 - Not enough chemistry
 - Settling
 - Wrong
+- Like something's missing
+- Too easy
+- Suspiciously calm
 
 This is your nervous system talking—not your wisdom.
 
 Your system learned: **Intensity = Connection. Calm = Indifference.**
+
+This learning was adaptive. In a chaotic home, intensity signaled that something important was happening. Calm moments were just the pause before the next storm. You learned to attune to intensity, to interpret it as significance.
+
+So when someone shows up calmly, consistently, without drama—your nervous system doesn't know how to read it. It feels like nothing's happening. It feels like they don't care.
+
+But that's not reality. It's a trained perception.
 
 Unlearning this takes time. A slow burn might feel neutral at first because your system doesn't know how to recognize safety as attraction.
 
@@ -110,34 +245,45 @@ Not all slow-seeming relationships are slow burns.
 - But lacks progressive emotional depth
 - Surface connection without genuine intimacy
 - Avoidant dynamics disguised as "taking it slow"
-- Neither person becomes vulnerable
+- Neither person becomes truly vulnerable
 - Stagnant, not building
 
 **How it shows up:**
 
-"We've been dating for months, and nothing feels wrong, but nothing feels deep either. We're comfortable. But am I actually known?"
+"We've been dating for months, and nothing feels wrong, but nothing feels deep either. We're comfortable. But am I actually known? Do they actually see me?"
 
 The false slow burn can feel like a slow burn, but it's actually **avoidant distance dressed as intentional pacing**.
 
 **Warning signs of a false slow burn:**
-- Emotional conversations are avoided
-- You don't feel seen—you feel accepted
-- There's no discomfort or growth edge
-- Both of you might be hiding
+- Emotional conversations are avoided or deflected
+- You don't feel seen—you feel accepted (there's a difference)
+- There's no discomfort or growth edge—just flatness
+- Both of you might be hiding behind the "slow pace"
 - Time passes, but depth doesn't increase
+- You know facts about their life but not their interior world
+- Vulnerability is offered and not received (or never offered)
+- You're comfortable but not close
+
+**The distinction:**
+
+A true slow burn: depth increases gradually, even if pace is slow
+A false slow burn: pace is slow and depth remains static
 
 ---
 
 ## How to Tell the Difference
 
 | Fast Burn | Slow Burn | False Slow Burn |
-|-----------|-----------|----------------|
+|-----------|-----------|-----------------|
 | Intense early | Calm early | Calm early |
 | Moves quickly | Moves gradually | Doesn't move |
 | Urgency, chemistry | Ease, steadiness | Avoidance, comfort |
 | Feels like destiny | Feels like potential | Feels like stagnation |
 | Nervous system activated | Nervous system regulated | Nervous system protected |
 | May crash hard | Builds over time | Never deepens |
+| Obsessive thinking | Able to focus on other things | Indifferent, maybe |
+| High peaks and valleys | Steady warmth | Flatness |
+| Drama in conflicts | Repair in conflicts | Conflicts avoided |
 
 ---
 
@@ -153,39 +299,63 @@ If you're committed to building secure attachment through dating, here's a phase
 - 1–2 dates per week maximum
 - Short dates (60–90 minutes)
 - Public places
+- Minimal texting between dates
+
+**Internal practice:**
+- Before dates: Ground yourself. Set intention to observe.
+- During dates: Notice how your body feels. Regulated? Activated?
+- After dates: Don't analyze for hours. Journal briefly and let go.
+- Between dates: Maintain your life. Don't reorganize around them.
 
 **Practice:**
 - Don't analyze between dates
 - Don't text constantly
-- Ask: "How regulated do I feel after this interaction?"
+- Don't start imagining the future
+- Ask yourself: "How regulated do I feel after this interaction?"
 
 **Warning signs to note:**
-- Love-bombing
-- Future-faking
-- Intensity pressure
-- Inconsistency
+- Love-bombing (excessive flattery, gifts, intensity, future-casting)
+- Future-faking (talking about your future together before you've built a present)
+- Intensity pressure (pushing for more time, more commitment, more quickly)
+- Inconsistency (hot one day, cold the next)
+- Too much too fast (I love you's, relationship labels, meeting family—all before you really know each other)
 
 ---
 
 ### Phase 2: Calibration (Weeks 5–8)
 
-**Goal:** Increase exposure. Begin testing for rupture and repair.
+**Goal:** Increase exposure. Begin testing for rupture and repair capacity.
 
 **Pace:**
 - 2 dates per week
-- Begin longer dates (meals, walks)
-- Optional: low-stakes shared activities
+- Begin longer dates (meals, walks, activities)
+- Optional: low-stakes shared activities (cooking together, hiking)
+- Can introduce more regular communication
+
+**Internal practice:**
+- Start noticing patterns, not just moments
+- Introduce small needs. See how they respond.
+- Track the difference between words and actions.
 
 **Practice:**
-- Minor disagreements: how are they handled?
-- Notice: Does their behavior match their words?
-- Introduce small needs. Do they respond well?
+- Minor disagreements: how are they handled? Does the person defend, attack, withdraw, or stay present?
+- Notice: Does their behavior match their words over time?
+- Introduce small needs. Do they respond well? Do they remember?
+- Share something vulnerable. How is it received?
 
-**Growth signals:**
-- Consistent patterns
-- Respectful pace
-- Willingness to repair
+**Growth signals (green flags):**
+- Consistent patterns over weeks
+- Respectful pace (no pushing)
+- Willingness to repair after minor conflict
 - No retaliation for boundaries
+- Interest in your interior world, not just your attention
+
+**Warning signals (red flags):**
+- Inconsistency between words and actions
+- Disappearing after conflict
+- Needing to "win" disagreements
+- Subtle criticism or correction
+- Dismissing your needs as "too much"
 
 ---
 
@@ -195,32 +365,90 @@ If you're committed to building secure attachment through dating, here's a phase
 
 **Pace:**
 - Increase time and emotional depth
-- Begin integrating into routines
-- Optional: meet trusted friends
+- Begin integrating into routines (but maintain your own life)
+- Optional: meet trusted friends (not family yet for most)
+- More spontaneous contact is okay
+
+**Internal practice:**
+- Express needs clearly and directly
+- Tolerate difference without fixing
+- Stay grounded after conflict (don't spiral)
+- Maintain your identity, friendships, hobbies
 
 **Practice:**
-- Express needs clearly
-- Tolerate difference without fixing
-- Stay grounded after conflict
+- Express a need and see what happens
+- Have a disagreement and observe the repair
+- Notice if you feel more or less yourself over time
+- Track if they're integrating you or just enjoying you
 
 **Questions to hold:**
-- Do I feel more like myself with this person?
-- Can I disagree without fear?
-- Is safety growing, or am I managing them?
+- Do I feel more like myself with this person, or less?
+- Can I disagree without fear of punishment or abandonment?
+- Is safety growing, or am I managing them to create the illusion of safety?
+- Are they curious about me, or just comfortable with me?
 
 ---
 
 ### Phase 4: Decision (Months 3–6)
 
-**Goal:** Assess readiness for commitment.
+**Goal:** Assess readiness for commitment based on observed patterns.
 
 **Practice:**
-- Review: Has this person been consistent?
-- Check: Am I regulated or activated?
-- Decide: Is this relationship aligned with secure attachment?
+- Review: Has this person been consistent over time, or just in moments?
+- Check: Am I regulated in this relationship, or chronically activated?
+- Decide: Is this relationship aligned with secure attachment or replicating old patterns?
+
+**Questions for decision:**
+- Do I trust this person's consistency, or just their intentions?
+- Can I be fully myself here?
+- Does this relationship add to my life or consume it?
+- Am I choosing this or defaulting to it?
 
 **Integration statement:**
 *"I choose relationships that regulate me—not just excite me."*
+
+---
+
+## When to Walk Away from a Slow Burn
+
+Slow burns aren't always right. Sometimes a slow burn is genuinely not a match.
+
+**Walk away if:**
+- Attraction isn't growing—it's stagnant
+- After 8-12 dates, you still feel nothing
+- You're forcing yourself to feel something that isn't there
+- It's not just calm—it's flat
+- The other person can't or won't meet you emotionally
+- You're avoiding the truth by calling it "giving it time"
+
+**The difference:**
+
+- Slow burn that's working: comfort that gradually warms into attraction
+- Slow burn that's not a match: indefinite neutrality that never shifts
+
+Trust this distinction. Not everything deserves more time. Sometimes the slow burn isn't a slow burn—it's just not a match.
+
+---
+
+## Field Note: Two Paths
+
+She dated two men that year.
+
+The first: Electric. Constant contact. Talked about their future after two weeks. She couldn't eat. She couldn't sleep. She couldn't focus. When he went quiet for a few hours, she spiraled. She felt more alive than she ever had.
+
+It lasted three months. The crash was brutal.
+
+The second: Calm. Steady. She wasn't sure at first. He was interesting but not consuming. She could focus on her work after their dates. She didn't analyze his texts for hidden meanings.
+
+She almost ended it after date four because she was worried about the lack of "spark."
+
+She's still with him three years later.
+
+The first man activated her trauma response and called it passion.
+
+The second man regulated her nervous system and let love build.
+
+She learned: the spark she'd been chasing was fear in disguise.
 
 ---
 
@@ -229,6 +457,68 @@ If you're committed to building secure attachment through dating, here's a phase
 **What we call "chemistry" is often familiarity.**
 
 **What we call "boring" is often safety we haven't learned to trust yet.**
+
+**What we call "the spark" is often a nervous system in threat response.**
+
+**What we call "settling" is often what healthy love actually feels like.**
+
+Your work isn't to find someone who sets you on fire. Your work is to learn to feel warmth—and recognize that as love.
+
+---
+
+## How to Retrain Your Attraction
+
+If you keep being pulled toward fast burns and rejecting slow ones, here's the work:
+
+**1. Study your attraction history.**
+Who have you been most attracted to? What were they like? What patterns do you see?
+
+**2. Track the outcomes.**
+How did those fast-burn relationships end? What did they cost you?
+
+**3. Notice your nervous system.**
+When you're attracted to someone, check: Am I activated or regulated? Is this excitement or anxiety?
+
+**4. Give slow burns more time.**
+If someone doesn't set you on fire but doesn't give you red flags, give it 6-8 dates minimum before deciding.
+
+**5. Redefine attraction.**
+Instead of "Do I feel chemistry?" ask "Do I feel safe? Am I regulated? Do I like who I am around them?"
+
+**6. Get support.**
+Work with a therapist who understands attachment. Talk to friends who have healthy relationships. Let them reality-check you.
+
+---
+
+## When Slow Burns Ignite
+
+Here's the thing no one tells you:
+
+**Slow burns often become the deepest loves.**
+
+When attraction builds slowly, it's building on a foundation of:
+- Knowledge of who the person actually is
+- Trust that's been tested over time
+- Safety that's been proven through consistency
+- Intimacy that developed through shared experience
+
+That foundation holds. It doesn't crash after three months when the dopamine wears off.
+
+Many people in long-term healthy relationships describe the same thing: "I wasn't sure at first. They grew on me. Now I can't imagine life without them."
+
+That's what secure attachment looks like. Not a wildfire. A steady flame.
+
+---
+
+## Reader Reflection
+
+Think about your attraction history. What patterns do you see?
+
+What's your nervous system's relationship to intensity vs. calm?
+
+Have you ever dismissed someone healthy because they were "too boring"?
+
+What would it mean to give a slow burn more time?
 
 ---
 
@@ -241,4 +531,3 @@ If you're committed to building secure attachment through dating, here's a phase
 ## One-Line Anchor
 
 *"Slow burn feels boring only until safety becomes attractive."*
-

--- a/book/vol-2-bridge/chapters/17-dating-after-trauma.md
+++ b/book/vol-2-bridge/chapters/17-dating-after-trauma.md
@@ -8,9 +8,81 @@ Dating after trauma is not the same as dating before awareness.
 
 You know more now. You've seen patterns. You've done the work.
 
-But your nervous system still runs old programs.
+But your nervous system still runs old programs. Your attraction is still wired to what's familiar. Your attachment system still recruits the same way it always has.
 
 This chapter is a practical guide to the first 90 days—the most critical window for pattern interruption.
+
+---
+
+## Field Note (Before): The Old Way
+
+She jumped in immediately.
+
+The profile looked promising. The first date felt electric. By date three, they were texting constantly. By date five, she was rearranging her schedule around him. By date eight, she'd told him things she hadn't told anyone.
+
+She called it "finally finding someone who gets me."
+
+Her therapist called it "moving at the speed of your anxiety."
+
+Six weeks later, the mask slipped. He wasn't who he seemed. But by then, she was already attached. Already making excuses. Already wondering if she was the problem.
+
+The exit took months. The recovery took longer.
+
+She kept asking herself: "How did I not see it?"
+
+The answer: she wasn't looking. She was merging.
+
+---
+
+## Field Note (After): The New Way
+
+She tried something different.
+
+First date: she noticed he was charming, attentive, maybe a little too effusive. She noted it. She went home.
+
+She didn't analyze. She didn't text him for hours. She didn't imagine their future.
+
+Second date: still charming. But also: followed through on what he said. Remembered what she'd shared. Asked questions. Didn't push.
+
+She noted this too. And she kept her weekend plans.
+
+Third date: a small conflict arose. He handled it well—took responsibility, stayed calm, didn't make it about him.
+
+Fourth date: she introduced a small need. "I prefer if you text before calling." He said "okay" without making it an issue.
+
+She didn't fall in love. She didn't decide he was "the one." She observed. She stayed in her life. She let time reveal who he actually was.
+
+By month three, she knew him. Not the version he presented—the version he consistently was.
+
+That's when she chose him. Not from intensity. From data.
+
+---
+
+## Field Note: The Red Flag She Almost Ignored
+
+Three weeks into dating someone new, she noticed something.
+
+He interrupted her. Not always, but often. Especially when she was talking about something important to her.
+
+Her first instinct: explain it away. He's excited. He's just a passionate person. It's not a big deal.
+
+Her second instinct: check her body. Tight chest. Familiar feeling. The feeling she used to call "nothing."
+
+She decided to name it on the fourth date. "I notice I get interrupted sometimes. It makes it hard to finish my thoughts."
+
+His response: defensive. "I'm just enthusiastic. You're sensitive."
+
+She went home. She didn't argue. She didn't try to explain herself better.
+
+She just... noticed.
+
+By date six, she'd seen the pattern in other ways. Her concerns were dismissed. Her preferences were negotiated away. She was adapting to him; he wasn't meeting her.
+
+She ended it before it became harder to leave.
+
+A year earlier, she would have stayed for months, trying to be "less sensitive."
+
+Now, she trusted the data.
 
 ---
 
@@ -22,13 +94,48 @@ Before entering the dating world after trauma, check:
 
 If you're still in crisis, still highly activated, still fresh from the relationship or family system—pause. Date yourself first.
 
+Signs you might not be ready:
+- You're desperately seeking someone to fill a void
+- The thought of being alone feels unbearable
+- You're still processing intense grief or anger daily
+- You're looking for someone to rescue you or fix things
+- You're entering dating to prove something (to yourself or your ex)
+- You can't imagine saying "no" to someone you're attracted to
+
+Signs you might be ready:
+- You feel stable, even if not perfect
+- You're curious about dating, not desperate for it
+- You can regulate yourself after difficult emotions
+- You have support (therapy, friends, practices)
+- You're willing to walk away if something isn't right
+- You know your patterns and can name them in real time
+
 **Do you know your patterns?**
 
 Review Chapter 6 (Childhood Roles → Adult Dating Patterns) and Chapter 7 (Attachment Styles). Know what you're prone to so you can catch it in real time.
 
+Common patterns to watch for in yourself:
+- Moving too fast when you feel "chemistry"
+- Ignoring red flags because you want it to work
+- Over-functioning to earn love
+- Dissociating during conflict instead of staying present
+- Making yourself smaller to avoid upsetting someone
+- Confusing intensity with connection
+- Waiting for the other person to define the relationship
+- Not expressing your needs
+
 **Do you have support?**
 
 Dating after trauma is easier with a therapist, trusted friend, or community who can reality-check with you.
+
+The value of external support:
+- Someone to share the data with ("Here's what happened on the date")
+- Someone to reality-check your interpretations
+- Someone who knows your patterns and can spot them before you do
+- Someone to ground you when you're activated
+- Someone to celebrate wins and process losses with
+
+If you don't have this, consider building it before you date. Join a support group. Find a therapist. Cultivate friendships with people in healthy relationships.
 
 ---
 
@@ -39,8 +146,39 @@ The first 90 days are when:
 - Fast burn chemistry peaks
 - Red flags are most visible (and most ignored)
 - Your nervous system decides "safe" or "familiar"
+- Masks are hardest to maintain
+- Patterns start to emerge
 
 If you can stay regulated and observant for 90 days, you'll have much clearer data on who this person actually is.
+
+**The 90-day window:**
+
+- Days 1-30: Initial presentation. Most people can maintain any persona for this long.
+- Days 31-60: Stress emerges. Real patterns start showing. Masks slip.
+- Days 61-90: Consistency (or inconsistency) becomes clear. You've seen them in different contexts, moods, situations.
+
+At 90 days, you're not seeing the representative. You're starting to see the person.
+
+---
+
+## The Core Principle: Observation Over Attachment
+
+Most people date to attach. They're looking for someone to merge with, fall for, commit to.
+
+Dating after trauma requires a different approach: **date to observe.**
+
+Your job in the first 90 days is not to fall in love. It's to collect data.
+
+**Data includes:**
+- What they do (not just what they say)
+- How they behave over time (not just on a good day)
+- How they handle stress, conflict, disappointment
+- How they treat waitstaff, strangers, their own family
+- Whether their actions match their words
+- How you feel in your body during and after interactions
+- Whether you're becoming more or less yourself
+
+You're not building a case for or against them. You're just watching. And letting time reveal what it reveals.
 
 ---
 
@@ -52,57 +190,95 @@ If you can stay regulated and observant for 90 days, you'll have much clearer da
 - Regulate before, during, and after dates
 - Notice activation (positive and negative)
 - Don't interpret—just observe
+- Don't make decisions from intensity
+- Maintain your regular life
 
 **What to watch for:**
 
 ✓ **Green flags:**
-- Consistent follow-through
-- Respectful pacing
-- Genuine curiosity (not interrogation)
+- Consistent follow-through (they do what they say)
+- Respectful pacing (no rushing)
+- Genuine curiosity (they ask questions and listen)
 - Capacity to hear "no" gracefully
 - Stable mood across interactions
+- Balance of give and receive in conversation
+- Respect for your time and boundaries
+- No excessive flattery or future-casting
 
 ✗ **Red flags:**
-- Love-bombing (excessive flattery, gifts, future-casting)
+- Love-bombing (excessive flattery, gifts, intensity, "you're different")
 - Inconsistency between words and actions
-- Pressure to escalate (physical, emotional, time)
+- Pressure to escalate (physical, emotional, commitment, time)
 - Victimhood narratives about all exes
 - Dismissing or minimizing your concerns
+- Excessive focus on themselves
+- Needing to know where you are, who you're with
+- Moving too fast in any dimension
+- Stories that don't quite add up
 
 **Questions to ask yourself:**
 - How do I feel 24 hours after seeing them?
 - Do I feel more or less like myself around them?
 - Am I observing or already fantasizing?
+- Am I regulated or activated?
+- Am I maintaining my own life or reorganizing around them?
+
+**Practices for this phase:**
+- Don't text between dates more than necessary
+- Don't analyze the relationship with friends obsessively
+- Keep your regular commitments and routines
+- Journal briefly after each date: what you noticed, how you felt
+- Check in with your support system
 
 ---
 
 ### Weeks 5–8: Calibration
 
 **Your internal focus:**
-- Begin introducing small needs
+- Begin introducing small needs and seeing how they respond
 - Observe how they handle feedback
 - Notice rupture and repair patterns
+- Track consistency over weeks, not moments
 
 **What to watch for:**
 
 ✓ **Green flags:**
-- Can tolerate feedback without defensiveness
-- Maintains interest after a "no"
-- Follows through on what they say
-- Shows curiosity about your inner world
-- Respects your pacing
+- Can tolerate feedback without defensiveness ("When you interrupted me, I felt unheard" → they listen, adjust)
+- Maintains interest after a "no" (doesn't punish you for having boundaries)
+- Follows through on what they say over time
+- Shows curiosity about your inner world, not just your attention
+- Respects your pacing without pushing
+- Handles minor stress well
+- Has their own life, friends, interests
 
 ✗ **Red flags:**
-- Retaliation or withdrawal after boundaries
-- Needs to be right
-- Subtle criticism or correction
+- Retaliation or withdrawal after boundaries (silent treatment, sulking, distancing)
+- Needs to be right in disagreements
+- Subtle criticism or correction ("You're too sensitive," "That's not how you should feel")
 - Avoidance of emotional topics
-- Inconsistent effort
+- Inconsistent effort (hot one week, cold the next)
+- Makes you responsible for their feelings
+- Early possessiveness or jealousy
+- Pressure to commit before you're ready
 
 **Questions to ask yourself:**
-- Can I express a need without fear?
+- Can I express a need without fear of punishment or abandonment?
 - How do they respond to disappointment?
 - Am I feeling more regulated or more activated over time?
+- Do their actions match their words?
+- Am I making excuses for inconsistency?
+
+**How to introduce needs:**
+
+Small, clear, direct. No drama. Just information.
+
+Examples:
+- "I prefer texting to calling—is that okay?"
+- "I need some time between dates to recharge."
+- "I'd rather not meet your friends yet. I want more time together first."
+- "That comment bothered me. Can we talk about it?"
+
+Watch how they respond. Not their words—their behavior after.
 
 ---
 
@@ -112,27 +288,48 @@ If you can stay regulated and observant for 90 days, you'll have much clearer da
 - Deepen without merging
 - Maintain your own life and connections
 - Assess compatibility, not just chemistry
+- Decide whether to continue based on patterns
 
 **What to watch for:**
 
 ✓ **Green flags:**
-- Consistent presence (not just early effort)
+- Consistent presence (not just early effort that fades)
 - Genuine interest in your life outside the relationship
-- Ability to disagree without drama
-- Integration feels natural, not forced
+- Ability to disagree without drama, escalation, or withdrawal
+- Integration feels natural, not forced or pressured
 - You're becoming more yourself, not less
+- They have their own emotional regulation
+- They take responsibility without defensiveness
+- Repair happens after conflict
 
 ✗ **Red flags:**
-- Early push for exclusivity with pressure
-- Isolation from your friends/family
-- Escalating intensity without proportional time
+- Early push for exclusivity with pressure ("Why won't you commit?")
+- Isolation from your friends/family (subtle or direct)
+- Escalating intensity without proportional time together
 - You're adapting to them more than they're meeting you
 - Relationship feels like work already
+- Their interest seems contingent on your compliance
+- You're managing their emotions regularly
+- You feel drained after time together
 
 **Questions to ask yourself:**
 - Am I choosing this person or defaulting to them?
 - Is this relationship adding to my life or consuming it?
 - Do I feel regulated and seen—or activated and managed?
+- Am I being myself or performing?
+- Is this sustainable?
+
+**The month 3 check-in:**
+
+At month 3, take stock:
+- Who have they been across multiple contexts?
+- How have they handled stress, conflict, disappointment?
+- Do their actions consistently match their words?
+- How do you feel in your body with them?
+- Do you trust them—not their intentions, their demonstrated patterns?
+
+If the answers are mostly positive: continue with intention.
+If the answers are mixed or concerning: pay attention to the data.
 
 ---
 
@@ -145,22 +342,50 @@ Before making any significant decision about the relationship:
 - Don't reply to an intense message immediately
 - Don't commit to something new when activated
 - Don't decide whether to stay or go from flooding
+- Don't have a "big talk" when either of you is dysregulated
+- Don't make permanent decisions from temporary emotions
 
 Intensity fades. Patterns clarify. Trust the version of yourself that emerges after the wave passes.
+
+**How it works:**
+
+Something happens that activates you—a conflict, an exciting development, a red flag, an urge to escalate.
+
+Instead of acting: pause. Note what happened. Note how you feel. Then wait.
+
+After 72 hours, revisit:
+- Does this still feel as urgent?
+- What does my regulated self think about this?
+- What does the pattern over time suggest?
+- What would I advise a friend in this situation?
+
+Act from that place. Not from the intensity.
 
 ---
 
 ## When Chemistry Is Actually Activation
 
 Remember: What you feel as "chemistry" may be:
-- Familiar activation patterns
+- Familiar activation patterns from childhood
 - Anxiety being mistaken for excitement
 - Your attachment system grabbing for security
 - Trauma bonding dynamics in early form
+- Your nervous system recognizing something old
 
 **Ask:** "Is this chemistry or recognition?"
 
 If it feels like you've known them forever after two dates—pause. That's probably your nervous system recognizing something old, not finding something new.
+
+**The chemistry test:**
+
+After the first few dates, ask yourself:
+- Can I think about other things when we're apart?
+- Am I sleeping normally?
+- Am I eating normally?
+- Can I focus on work and other parts of my life?
+- Do I feel grounded or untethered?
+
+If you're completely consumed, unable to focus, not sleeping, not eating—that's not love. That's activation. And activation isn't a good basis for attachment decisions.
 
 ---
 
@@ -170,10 +395,24 @@ If someone feels:
 - Nice but not exciting
 - Easy but not thrilling
 - Comfortable but not electric
+- Pleasant but not consuming
 
 **Ask:** "Is this boring or regulated?"
 
 Give it time. Slow burn attraction grows. Fast burn attraction often crashes.
+
+**The boring test:**
+
+Stay curious about someone who feels "too calm" for at least 6-8 dates—assuming there are no red flags.
+
+Notice if, over time:
+- Warmth develops
+- You look forward to seeing them
+- Conversations deepen
+- Physical attraction grows
+- You feel more comfortable being yourself
+
+If none of this happens after 8-10 dates, it might just not be a match. But if it does—you might be learning to recognize safety as attractive.
 
 ---
 
@@ -187,14 +426,18 @@ As your nervous system heals:
 - Adrenaline decreases
 - Urgency softens
 - Hyperarousal quiets
+- The edge that drove intensity fades
 
 This can feel like:
 - Less desire overall
 - Less sexual obsession with new people
 - Less fantasy-driven arousal
 - Less immediate "spark"
+- Needing more time to develop sexual interest
 
 **This is not dysfunction. It's your sexuality decoupling from threat.**
+
+When your nervous system has been in chronic activation, sexual arousal can become entangled with stress hormones. As you heal, that entanglement loosens—and sexuality has to reorganize.
 
 ### Old Patterns May Surface
 
@@ -203,20 +446,35 @@ You might find yourself:
 - Repulsed by people who feel safe (and "boring")
 - Confused about whether you're attracted or just activated
 - Aroused after conflict or tension (old pattern)
+- Dissociating during physical intimacy
+- Feeling nothing where you expected to feel something
+- Drawn to recreating old dynamics
 
-**This is normal.** Your nervous system is still running old programs.
+**This is normal.** Your nervous system is still running old programs. They don't disappear overnight.
+
+### Sexual Responses That May Emerge
+
+**Arousal to anxiety:** You may find yourself aroused when anxious about the relationship. This is the old wiring—intensity triggering sexual response.
+
+**Freeze response:** You may feel nothing when physical intimacy happens. Numbness. Dissociation. This is protective—your system checking out because intimacy felt dangerous.
+
+**Disgust at safety:** You may feel repulsion toward someone kind and stable. Not because they're wrong for you, but because safety feels foreign.
+
+**Confusion about desire:** You may not know if you want someone or just want the intensity they represent. The signals are scrambled.
 
 ### What Helps
 
-**Go slow with physical intimacy.** Give yourself time to track what's actually happening in your body.
+**Go slow with physical intimacy.** Give yourself time to track what's actually happening in your body. Notice the difference between wanting something and feeling pressured to perform.
 
 **Notice the difference between activation and desire:**
-- Activation: urgency, racing thoughts, can't stop thinking about them
-- Desire: warmth, curiosity, openness, no pressure
+- Activation: urgency, racing thoughts, can't stop thinking about them, need, anxiety
+- Desire: warmth, curiosity, openness, no pressure, choice, presence
 
-**Don't chase the spark.** The "spark" you're used to might have been fear. Let attraction grow differently.
+**Don't chase the spark.** The "spark" you're used to might have been fear. Let attraction grow differently—slowly, from safety.
 
 **Trust the neutral.** If someone feels comfortable but not electric, that might be safety. Give it time before deciding.
+
+**Communicate with partners.** If you're in a situation where physical intimacy is expected, communicate. "I'm learning about my own patterns. I might need to go slow." A partner who respects this is giving you valuable information.
 
 ### The Grief Beneath This
 
@@ -224,8 +482,9 @@ There may be grief here too:
 - For the intensity you've lost
 - For the passion that was actually danger
 - For the person you were before you knew the difference
+- For the sexuality that felt more alive (even if it was destructive)
 
-Let that grief be felt. It's part of the bridge.
+Let that grief be felt. It's part of the bridge. You're mourning a version of yourself—and a version of desire—that served you once but doesn't anymore.
 
 ### What Comes Later
 
@@ -235,6 +494,8 @@ Desire returns—but cleaner:
 - Without urgency
 - Without needing intensity to ignite
 - Without self-loss in the process
+- Connected to safety, not danger
+- Chosen, not compulsive
 
 For now, just notice. Track what your body does. Trust that confusion is part of the path.
 
@@ -250,6 +511,8 @@ After each date, check your energy:
 - Curious but not obsessive
 - Able to focus on other things
 - Open but not anxious
+- Present in your body
+- Able to do your normal activities
 
 **Activated energy after a date:**
 - Thinking about them constantly
@@ -257,8 +520,22 @@ After each date, check your energy:
 - Anxious about next contact
 - Difficulty focusing on other things
 - Already imagining the future
+- Racing thoughts
+- Sleep disruption
+- Appetite changes
 
 Neither is "right" or "wrong"—but activated energy is information. It means your nervous system is in a heightened state, and that's worth noting.
+
+**The energy audit practice:**
+
+After each date, pause. Ask yourself:
+- What's my body doing right now?
+- Can I focus on other things?
+- Do I feel grounded or untethered?
+- Am I analyzing or at ease?
+- Am I myself or performing?
+
+Track this over time. Notice patterns. Let the data inform your choices.
 
 ---
 
@@ -266,13 +543,52 @@ Neither is "right" or "wrong"—but activated energy is information. It means yo
 
 "Trust your gut" is common advice. But for trauma survivors, the gut can be confused.
 
-Your body may feel danger where there's safety. It may feel safety where there's danger.
+Your body may feel danger where there's safety. It may feel safety where there's danger. It may confuse intensity with connection, anxiety with attraction, familiarity with rightness.
 
 **Instead of asking:** "Does this feel right?"
 
 **Ask:** "Does this feel regulated?"
 
-Regulated doesn't mean perfect. It means your nervous system isn't flooding or shutting down. It means you can think clearly, not just feel intensely.
+Regulated doesn't mean perfect. It means your nervous system isn't flooding or shutting down. It means you can think clearly, not just feel intensely. It means you're present, not dissociating.
+
+**The regulation check:**
+
+- Am I in my body right now?
+- Can I think clearly about this?
+- Am I feeling or reacting?
+- Is my nervous system calm, activated, or frozen?
+- Can I hold complexity (they have good and challenging qualities)?
+- Am I present or checked out?
+
+Over time, as you heal, your gut becomes more reliable. But in early healing, supplement gut feelings with observation, time, and external reality-checking.
+
+---
+
+## Common Traps in Dating After Trauma
+
+**The "different this time" trap:**
+Believing that your feelings of intensity mean this person is different—when intensity is the pattern, not the exception.
+
+**The "they need me" trap:**
+Being drawn to someone who seems wounded, believing you can help them. Caretaking becomes attraction.
+
+**The "I can handle it" trap:**
+Seeing red flags but believing you're now strong enough to manage them. You don't need to test your healing on dangerous people.
+
+**The "scarcity" trap:**
+Staying with someone who isn't right because you believe healthy options are rare or that you're lucky anyone wants you.
+
+**The "maybe they'll change" trap:**
+Hoping that early concerning behavior is a phase rather than a pattern. People can change—but betting on it is a gamble.
+
+**The "I'm being too picky" trap:**
+Second-guessing valid concerns because you feel you should be more flexible. Your needs are not negotiable.
+
+**The "I owe them" trap:**
+Feeling obligated to continue because they've been nice to you or because ending things would hurt them.
+
+**The "I've already invested" trap:**
+Staying because you've put time, energy, or emotion in—rather than assessing what's actually true now.
 
 ---
 
@@ -281,12 +597,87 @@ Regulated doesn't mean perfect. It means your nervous system isn't flooding or s
 Within the first 90 days, you should know the answer to:
 
 - How do they handle conflict?
-- Can they take responsibility?
-- Can they hear feedback?
-- Can they tolerate difference?
-- Do their actions match their words?
+- Can they take responsibility without defensiveness or collapse?
+- Can they hear feedback about their behavior?
+- Can they tolerate difference (you having different opinions, needs, preferences)?
+- Do their actions match their words over time?
 
 You learn this through observation and small tests—not interrogation.
+
+**Small tests:**
+
+- Introduce a preference and see if they respect it
+- Share something vulnerable and see how they hold it
+- Say "no" to something and observe the aftermath
+- Disagree on something low-stakes and notice how they respond
+- Express a concern and see if they hear it
+
+**What you're looking for:**
+
+- Curiosity, not defensiveness
+- Acceptance, not dismissal
+- Adaptation, not rigidity
+- Repair, not punishment
+- Presence, not withdrawal
+
+---
+
+## When to End It
+
+Ending a connection in the first 90 days isn't failure. It's discernment.
+
+**End it if:**
+- Red flags are present and consistent
+- You're making excuses for their behavior
+- You feel worse about yourself over time
+- They can't handle feedback without retaliation
+- Your boundaries are chronically tested or ignored
+- You're doing all the work
+- You're adapting to them but they're not meeting you
+- Your nervous system is consistently activated
+- You're losing yourself to keep them
+
+**How to end it:**
+
+Brief. Clear. Kind but firm.
+
+"This has been nice, but I don't think we're a match. I wish you well."
+
+You don't need to explain your reasons in detail. You don't need their agreement. You don't need to process it together.
+
+Exit cleanly. Don't ghost unless safety requires it. But don't over-explain either.
+
+---
+
+## When to Continue
+
+**Continue if:**
+- Green flags are present and consistent
+- You feel regulated (not just excited)
+- You're becoming more yourself, not less
+- They can handle feedback and repair after rupture
+- Your boundaries are respected
+- They show up consistently over time
+- You feel safe—not in love, but safe
+- There's progressive deepening (not just comfortable stagnation)
+
+**And then:**
+
+Keep observing. Keep checking in with yourself. Keep your life and support system.
+
+Commitment isn't a decision you make once. It's a decision you keep making, based on ongoing evidence.
+
+---
+
+## Reader Reflection
+
+Are you ready to date, or do you need more time in healing first?
+
+What patterns from your history are you most likely to repeat?
+
+What support do you have in place for reality-checking?
+
+How will you know if you're observing or merging?
 
 ---
 
@@ -299,4 +690,3 @@ You learn this through observation and small tests—not interrogation.
 ## One-Line Anchor
 
 *"I choose pacing over pressure, clarity over chemistry."*
-


### PR DESCRIPTION
Significantly expanded four chapters with additional field notes,
deeper neuroscience explanations, more practical guidance, and
richer exploration of concepts while preserving all original essence.

Chapters expanded:
- Ch 14: Clean Endings - added closure rituals, fear analysis, grief phases
- Ch 15: Hope Without Waiting - added hope anatomy, waiting neurochemistry
- Ch 16: Slow Burn vs Fast Burn - added neurochemistry, false slow burns
- Ch 17: Dating After Trauma - added traps, tests, readiness assessment