### PR TITLE
📚 Add Volume 6 Part III: Ethical Foundations (Chapters 9-12)

### DIFF
--- a/book/vol-6-guide/chapters/09-ethics-of-lived-experience.md
+++ b/book/vol-6-guide/chapters/09-ethics-of-lived-experience.md
@@ -1,0 +1,431 @@
+# Chapter 9: The Ethics of Lived Experience
+
+## When Your Wound Becomes Your Credential
+
+---
+
+Your story is not a parlor trick.
+
+It is not something you deploy to create instant connection. It is not a shortcut to trust. It is not proof that you understand—though it may be part of why you do.
+
+Your lived experience is real. It has shaped you. It may be why people find their way to you, why your words land differently, why you can sit with pain that makes others look away.
+
+**But lived experience is not automatically ethical guidance.**
+
+This chapter explores the edge between authentic sharing and harmful disclosure, between using your story to serve and using it to position, between connection that heals and revelation that burdens.
+
+Because your wound can become a gift. Or it can become a weapon. The difference is in how you hold it.
+
+---
+
+## Field Note (Before): The Overshare
+
+She knew exactly what her client was feeling.
+
+The same shame. The same confusion about why she couldn't leave. The same self-blame that made no sense from the outside but felt like truth from inside.
+
+So she shared. She told her client about her own abusive relationship. The years she stayed. The way she finally left. The healing that came after.
+
+Her client went quiet.
+
+At first, she thought it was recognition. Relief.
+
+Later, the client said: "I didn't know if I was supposed to be taking care of you after that. I wasn't sure if this was still about me."
+
+The session had shifted. The container had cracked. Her sharing—genuine, well-intentioned—had cost her client the space she needed.
+
+---
+
+## Field Note (After): The Calibrated Disclosure
+
+Same practitioner. Different client. Similar material.
+
+She felt the pull to share. The recognition. The knowing.
+
+But she paused. Asked herself: *Is this for them or for me?*
+
+She chose a different path.
+
+"I want you to know that what you're describing is something I understand—not just professionally, but personally. I've walked this territory. If that's ever helpful to know, it's there. Right now, I want to stay with what's happening for you."
+
+The client's eyes softened. "That helps. Knowing you get it."
+
+The session continued—with the client at the center.
+
+*The lived experience was acknowledged. The container was preserved.*
+
+---
+
+## The Authority of the Wound
+
+There is a kind of authority that comes from having been in the fire.
+
+When someone who has survived speaks to someone who is surviving, something different happens. The words land differently. The nervous system responds differently. There is a resonance that formal training cannot replicate.
+
+**This is real. And it has limits.**
+
+The authority of the wound qualifies you to say: *I know this landscape. I have been lost here too.*
+
+It does not automatically qualify you to say: *I know the way out—for you.*
+
+---
+
+## What Lived Experience Is and Isn't
+
+### Lived Experience IS:
+
+- A source of genuine understanding
+- A foundation for empathy that isn't abstract
+- A credential in the original sense—something that creates credibility
+- A reason people may trust you faster
+- An asset when held with skill
+- Part of why you're called to this work
+
+### Lived Experience ISN'T:
+
+- A substitute for training in clinical contexts
+- Permission to skip learning about other presentations
+- Evidence that you know what someone else needs
+- A pass on your own ongoing healing
+- Proof that your way is the way
+- A reason to skip ethical frameworks
+
+**The Synthesis:** Your experience opens doors. Skill and ethics determine what you do once inside.
+
+---
+
+## The Neuroscience of Resonance
+
+When someone who has lived through trauma speaks to another trauma survivor, something neurological happens.
+
+**Mirror neurons activate differently.** The listener's nervous system recognizes something in the speaker's regulation, in their embodied presence, in the way they speak from inside the experience rather than about it.
+
+**The stress response calibrates.** If you've survived and are now regulated, your nervous system communicates: *This can be survived. Safety is possible on the other side.* This is implicit, below conscious awareness. It's why peer support works.
+
+**But the reverse is also true.** If you're not regulated—if you're speaking from activation rather than integration—your nervous system communicates threat. Your disclosure becomes contagion rather than comfort.
+
+**The deciding factor:** Not whether you've had the experience, but whether you've metabolized it enough to be present without being activated.
+
+---
+
+## The Ethics of Disclosure
+
+Every time you share from your lived experience, you're making an ethical choice—whether you realize it or not.
+
+### Questions to Ask Before Disclosing:
+
+**1. Is this disclosure for them or for me?**
+
+Honest answer required. Not the answer you can defend, but the truth underneath.
+
+- For them: They need to know they're not alone, and my disclosure creates that.
+- For me: I want to be seen as someone who understands. I want connection. I want to feel my experience matters.
+
+Both can be true. But if it's primarily for you, reconsider.
+
+**2. Is this the right moment?**
+
+Timing matters. Disclosure in the wrong moment can:
+- Shift focus away from their experience
+- Overwhelm when they're already overwhelmed
+- Create a sense of obligation to care for you
+- Distract from what they were about to say
+
+The right moment is usually when they're stable enough to receive it, curious about your experience, or explicitly asking.
+
+**3. How much detail do they need?**
+
+Less is usually more. They don't need your full story. They need enough to know you understand.
+
+- Too little: "I get it." (Empty—no real connection)
+- Just right: "I've been where you are. I know this confusion from the inside."
+- Too much: Ten minutes of your story, complete with unprocessed emotion.
+
+Calibrate. You can always share more if they want it. You can't unsay what's been said.
+
+**4. Can I share this without being activated?**
+
+If telling your story dysregulates you, you're not ready to use it therapeutically.
+
+Watch for:
+- Your voice changing
+- Losing track of time
+- Getting pulled into the story rather than telling it
+- Needing their reaction to feel okay
+- Feeling depleted after sharing
+
+If you can't stay present while sharing, the material needs more of your own work first.
+
+**5. Does this disclosure serve the relationship or shift it?**
+
+Healthy disclosure deepens trust while maintaining roles. Unhealthy disclosure blurs roles, creates obligation, or inverts the relationship.
+
+---
+
+## Field Note: The Reversal
+
+She was coaching a woman through grief after leaving a narcissistic relationship.
+
+The coach shared her own story—her ex, her recovery, her years of rebuilding.
+
+It was genuine. It was relevant. It was also twenty minutes.
+
+By the end, the client was asking: "How are you now? Are you okay?"
+
+The session had reversed. The client was now caretaking the coach.
+
+*Lived experience, when not contained, can flip the helper-helped dynamic.*
+
+---
+
+## The "I've Been Through This Too" Trap
+
+There is a subtle trap in lived experience: the assumption that your experience maps onto theirs.
+
+**What you survived:** Covert narcissistic abuse from a parent.
+
+**What they're surviving:** Overt narcissistic abuse from a partner.
+
+Related? Yes. The same? No.
+
+**The trap:** Assuming your path is their path. Your timeline is their timeline. What worked for you will work for them.
+
+**The escape:** Holding your experience lightly. Offering it as one map, not the map. Staying curious about where theirs differs.
+
+---
+
+## The Spectrum of Disclosure
+
+Not all disclosure is equal. There are levels.
+
+| Level | Description | Example |
+|-------|-------------|---------|
+| **No disclosure** | You don't mention your experience at all | "Let's explore what that's like for you." |
+| **Implicit acknowledgment** | You signal understanding without detailing | "I understand. Not just professionally." |
+| **General disclosure** | You acknowledge the category without details | "I've been through something similar." |
+| **Specific disclosure** | You share relevant details | "I was in an abusive relationship for years." |
+| **Detailed disclosure** | You share your full story | "Let me tell you about my ex..." |
+| **Ongoing integration** | Your experience becomes central to your work | Writing, speaking, content based on your story |
+
+**The principle:** Start lower on the spectrum. Move up only when clearly in service.
+
+---
+
+## When Disclosure Helps
+
+Disclosure can be powerful when:
+
+**They feel alone.** Knowing you've been there breaks the isolation. "You're not crazy. I've felt exactly this."
+
+**They're questioning their reality.** Your confirmation validates their perception. "Yes, that's gaslighting. I recognize it."
+
+**They don't think recovery is possible.** Your presence—regulated, functional, healing—is evidence. You don't have to say anything; you are the disclosure.
+
+**They explicitly ask.** "Have you ever been through anything like this?" A direct question deserves an honest answer.
+
+**Your regulation is medicine.** When you speak from integration, your nervous system communicates: *This can be survived.*
+
+---
+
+## When Disclosure Hurts
+
+Disclosure can harm when:
+
+**They're not ready to hear it.** They're still in survival. Your story adds to their overwhelm.
+
+**It shifts focus to you.** Even briefly, if they're now holding your experience, the container has leaked.
+
+**It creates obligation.** They now feel they owe you care, understanding, or reciprocal disclosure.
+
+**It's competitive.** Subtly implying yours was worse, or better, or more significant.
+
+**It's unprocessed.** You're sharing from the wound, not the scar. Your activation becomes their burden.
+
+**It colonizes their experience.** Your story overwrites theirs. They start to see themselves through your lens rather than discovering their own.
+
+---
+
+## The Peer Support Distinction
+
+Lived experience operates differently in different contexts.
+
+### Peer Support
+
+- Your experience is your primary qualification
+- Mutuality is appropriate—you're both survivors
+- Disclosure is expected and central
+- The power differential is intentionally minimal
+- You're offering companionship, not treatment
+
+### Professional Helping (Therapy, Coaching)
+
+- Your experience supplements your training
+- You hold more responsibility for the container
+- Disclosure should be strategic and limited
+- Clear role distinction matters
+- You're offering expertise alongside understanding
+
+### Informal Helping (Friend, Community Member)
+
+- Your experience is part of who you are
+- Reciprocity is natural
+- Boundaries are less formal but still needed
+- You're offering care, not clinical service
+- Know when to refer out
+
+---
+
+## Field Note: The Peer Who Became a Burden
+
+He found her in a support group. A peer. Someone who had been through the same thing.
+
+At first, it was perfect. She understood. She didn't judge. She'd walked the path.
+
+But she kept needing to tell her story. Every time they talked, it came back to her. Her trauma. Her recovery. Her insights.
+
+He started to feel like an audience for her ongoing processing.
+
+Eventually, he stopped reaching out. He needed a peer, not a performer.
+
+*Lived experience is not a license for endless processing on someone else's time.*
+
+---
+
+## The Ethics of Using Your Story Professionally
+
+If you're a content creator, speaker, or author using your lived experience:
+
+### Before You Publish/Share:
+
+**1. Has this material been processed?**
+
+If it still activates you, it's not ready for public consumption. Your audience will feel the activation, even if they can't name it.
+
+**2. Whose story is this?**
+
+If your healing involved other people—an abusive parent, ex, family system—be clear about what's yours to share. (This is expanded in Chapter 12: Confidentiality & Story Stewardship.)
+
+**3. Is this for service or for supply?**
+
+Honest check. Content about your experience can be healing for others. It can also be a way to get attention, validation, or narcissistic supply. Know which is driving you.
+
+**4. Are you centering yourself or the reader?**
+
+Your story is the vehicle, not the destination. The reader should leave thinking about their own situation, not just your fascinating journey.
+
+**5. Is this from scar or wound?**
+
+Scar: healed enough to talk about without bleeding.
+Wound: still raw, still needing tending.
+
+Share from scar. Tend your wound privately.
+
+---
+
+## The "Wounded Healer" Archetype
+
+Carl Jung introduced the wounded healer—the idea that our wounds become our medicine.
+
+**The light side:** Your suffering gives you capacity to sit with others' suffering. Your journey gives you a map.
+
+**The shadow side:** Your wound remains central to your identity. You need clients to validate your healing. You haven't finished your own work.
+
+**The integration:** The wound is part of your history, not the center of your identity. You help from overflow, not need.
+
+---
+
+## A Practice: The Disclosure Audit
+
+Before your next session, call, or piece of content:
+
+1. **What am I about to disclose?** Name it specifically.
+
+2. **Why am I disclosing this?** Be honest about all the reasons.
+
+3. **Is this from scar or wound?** Can I share without being activated?
+
+4. **What is the benefit to them?** Specific, not assumed.
+
+5. **What is the risk to them?** Specific, not dismissed.
+
+6. **What is the minimum effective dose?** How little can I share while still serving?
+
+7. **Is there a better way to meet this need?** Could I validate without disclosing?
+
+---
+
+## A Practice: The Three-Breath Pause
+
+When you feel the impulse to share your experience:
+
+**Breath 1:** Pause. Don't speak yet.
+
+**Breath 2:** Ask internally: *Is this for them or for me?*
+
+**Breath 3:** If for them, speak. If for you—or if you're not sure—wait. Let the moment breathe.
+
+You can always share later. You cannot unshare.
+
+---
+
+## A Practice: The After-Session Check
+
+After you've disclosed lived experience:
+
+1. **How do I feel?** Depleted? Regulated? Activated? Relieved?
+
+2. **How did they respond?** Did they receive it? Did it shift the dynamic?
+
+3. **Would I do it again?** With this person, in this context, at this moment?
+
+4. **What did I learn?** For next time.
+
+This builds discernment over time.
+
+---
+
+## When You Should Never Disclose
+
+Some contexts are not appropriate for lived experience disclosure:
+
+- **Crisis intervention:** They need you focused on them, not your story.
+- **First sessions:** Build rapport before revealing personal history.
+- **When you're activated:** If telling it dysregulates you, don't.
+- **When it's not relevant:** Not every session needs your backstory.
+- **When they haven't consented:** Don't ambush people with your trauma.
+- **When you're seeking validation:** That's what your therapist is for.
+- **When boundaries are already blurry:** Don't add more complexity.
+
+---
+
+## The Integration
+
+Your lived experience is a gift. A real one.
+
+It gives you access others don't have. Understanding that can't be taught. Credibility that opens doors.
+
+**And it requires stewardship.**
+
+Not suppression—you don't need to hide who you are or what you've survived.
+
+But calibration. Discernment. Ongoing attention to the question: *Who is this serving?*
+
+The most powerful use of your story is often invisible. It lives in your regulated presence, your knowing nods, your lack of shock at what they share. You don't have to tell your story to offer its gifts.
+
+Your wound became your wisdom. Now let the wisdom lead.
+
+---
+
+## Integration Line
+
+> *"My experience gives me understanding. It doesn't give me authority over their experience."*
+
+---
+
+## One-Line Anchor
+
+> *"I share from scar, not wound—and only when it serves them more than me."*
+
+---
+
+**[Continue to Chapter 10: Referral — When to Pass the Baton →](./10-referral-when-to-pass-the-baton.md)**

--- a/book/vol-6-guide/chapters/10-referral-when-to-pass-the-baton.md
+++ b/book/vol-6-guide/chapters/10-referral-when-to-pass-the-baton.md
@@ -1,0 +1,449 @@
+# Chapter 10: Referral — When to Pass the Baton
+
+## The Skill of Knowing Your Limits
+
+---
+
+There is a moment in every helper's journey when they face someone whose needs exceed their capacity.
+
+Maybe it's the client whose depression is deeper than your coaching can reach. The friend whose suicidal ideation requires clinical intervention. The community member whose trauma history reveals itself as something far beyond peer support.
+
+**This moment is a test.**
+
+Not of your skill—but of your ego.
+
+The helper who cannot refer is not protecting the person in front of them. They are protecting their own image of themselves as the one who heals. This is the shadow of the healer dressed as devotion.
+
+Knowing when to pass the baton is not failure. It is the highest expression of ethical helping.
+
+---
+
+## Field Note (Before): The Coach Who Couldn't Let Go
+
+Her client was struggling. Really struggling.
+
+What had started as career coaching had revealed a history of childhood abuse, severe depression, and patterns that ran far deeper than any career question.
+
+She knew, somewhere in her body, that this needed more than she could offer. But she also knew the client trusted her. Had chosen her. Didn't want to start over with someone new.
+
+So she kept going. Stretched her sessions longer. Did extra research on trauma. Told herself she could learn enough to meet this.
+
+Three months later, the client's crisis escalated. An ER visit. A near-miss.
+
+In the aftermath, the client said: "I wish you had told me I needed more help. I thought because you kept seeing me, I was okay."
+
+*Her need to be enough had cost them both.*
+
+---
+
+## Field Note (After): The Coach Who Made the Call
+
+Different coach. Similar crossroads.
+
+Her client's material was going deeper than their container could hold. She could feel it—the weight was beyond her scope.
+
+She didn't wait for crisis. She named it:
+
+"I want to talk about something important. I'm noticing that what's coming up for you goes deeper than what I'm trained to hold. I think you'd really benefit from working with a trauma therapist—someone who has specialized tools for this. I can help you find the right person, and I can stay in your corner while you do that work. What I can't do is be the right container for what's emerging. And I care about you too much to pretend otherwise."
+
+The client was scared. And also relieved.
+
+"You're not abandoning me?"
+
+"I'm making sure you get what you actually need. That's the opposite of abandonment."
+
+*The referral wasn't rejection. It was care.*
+
+---
+
+## Why Referral Is So Hard
+
+If referral is just "connecting someone with appropriate care," why does it feel so loaded?
+
+Because referral touches our deepest fears as helpers:
+
+**Fear of inadequacy.** "If I were good enough, I could handle this."
+
+**Fear of abandonment projection.** "They'll feel rejected. Like I'm giving up on them."
+
+**Fear of losing connection.** "Once they go to someone else, they won't need me."
+
+**Fear of being wrong.** "What if I'm overreacting? What if they're fine?"
+
+**Fear of being replaceable.** "If someone else can help them, what was I even doing?"
+
+**The shadow wants you to be everything.** Referral requires you to accept that you are not—and never will be.
+
+---
+
+## The Neuroscience of Scope
+
+Your nervous system was trained in a context.
+
+If you're a peer supporter, your nervous system learned to hold peer-level distress. If you're a coach, it learned to hold growth-oriented challenge. If you're a therapist, it learned to hold clinical-level material.
+
+**When material exceeds your training, your nervous system knows—even if your ego doesn't.**
+
+Signs your system is recognizing out-of-scope material:
+
+- Persistent unease about a particular client
+- Dreaming about their situation
+- Dreading sessions
+- Feeling pulled in over your head
+- Over-preparing, over-researching
+- Seeking extra supervision or consultation
+- Relief when they cancel
+- Vigilance you can't shake after sessions
+
+These are not signs of weakness. They are signals from a system that knows its edges. Listen to them.
+
+---
+
+## The Scope Matrix
+
+Different helpers have different scopes. Referral is about knowing yours.
+
+| Helper Type | In Scope | Usually Out of Scope |
+|-------------|----------|---------------------|
+| **Peer Supporter** | Shared experience, emotional support, resource navigation, lived-experience guidance | Clinical disorders, crisis intervention, active suicidality, complex trauma |
+| **Life Coach** | Goals, transitions, mindset, accountability, life design | Mental health diagnoses, trauma processing, suicidal ideation, substance dependence |
+| **Trauma-Informed Coach** | Nervous system education, resilience building, pattern recognition | Deep trauma processing, PTSD treatment, dissociative disorders |
+| **Licensed Therapist** | Mental health treatment, trauma processing, clinical disorders | Medication management, medical conditions, specialized populations outside training |
+| **Specialized Therapist** | Deep work in specialization (trauma, eating disorders, etc.) | Outside specialization, medical needs, conditions requiring higher care |
+| **Psychiatrist** | Medication evaluation and management, severe mental illness | Long-term talk therapy, coaching-style work |
+
+**Know your lane.** Not as limitation—as clarity.
+
+---
+
+## The Referral Indicators
+
+### Immediate Referral Needed
+
+These situations require you to stop and refer—now:
+
+| Indicator | Why It's Urgent |
+|-----------|-----------------|
+| **Active suicidal ideation with plan** | Life safety—this needs clinical response |
+| **Active homicidal ideation** | Safety for them and others |
+| **Psychotic symptoms** | Needs psychiatric evaluation |
+| **Severe self-harm** | Medical and psychiatric needs |
+| **Active eating disorder symptoms** | Medical complications possible |
+| **Substance crisis** | Specialized intervention required |
+| **Domestic violence crisis** | Safety planning needs expertise |
+| **Child abuse disclosure** | Mandatory reporting likely |
+
+If you encounter these, your job is connection to appropriate resources, not continued support.
+
+### Referral Strongly Recommended
+
+These situations suggest your work should be supplemented or transferred:
+
+| Indicator | What It Suggests |
+|-----------|------------------|
+| **Symptoms worsening despite your work** | The intervention isn't matching the need |
+| **Dissociation during sessions** | Trauma work needed with specialized training |
+| **Unable to function in daily life** | Higher level of care needed |
+| **Your expertise is exceeded** | Specific training required (addiction, eating disorders, etc.) |
+| **You're dreading sessions** | Your system knows something your ego doesn't |
+| **They need medication evaluation** | You can't provide this; they need someone who can |
+| **Legal or forensic implications** | Specialized expertise required |
+| **The relationship isn't helping** | Sometimes the fit is wrong, even if no one did anything wrong |
+
+### Referral Worth Considering
+
+These situations invite reflection:
+
+| Indicator | What to Consider |
+|-----------|------------------|
+| **Material keeps exceeding your container** | Is this a scope issue or a support issue? |
+| **You're working harder than they are** | Is this helping or enabling? |
+| **Your own material is activated** | Can you stay clean, or do you need to step back? |
+| **You're the only support** | Diversification is healthy |
+| **The work has stalled** | Fresh perspective might help |
+| **They've outgrown what you offer** | Success looks like leaving |
+
+---
+
+## Field Note: The Referral That Saved a Life
+
+He was a coach who specialized in helping survivors rebuild their careers after trauma.
+
+One client mentioned suicidal thoughts. Casually. Almost offhand.
+
+He didn't let it pass. He didn't panic. He followed the protocol he'd trained for.
+
+"I hear you. I'm glad you told me. I need to ask some more questions, because this is something I take seriously."
+
+He assessed. The ideation was passive but present. There was no plan. But there was hopelessness.
+
+"What you're describing is really important, and it's beyond what I can hold as a coach. I want to help you get connected with a therapist who specializes in this—someone who can be there in a way I'm not trained to be. Can we do that together right now?"
+
+She resisted. She didn't want to start over. She didn't want to feel broken.
+
+"You're not broken. You're carrying more than one person should hold. A therapist won't make you start over—they'll add to your support. I'm not going anywhere. I just need you to have someone who can catch what I can't."
+
+She called the therapist that week. Within a month, she was stabilized. Within six months, she was back in coaching—and alive.
+
+*The referral wasn't rejection. It was rescue.*
+
+---
+
+## How to Make a Referral
+
+### Step 1: Name It Directly
+
+Don't hedge. Don't apologize. Name what you're seeing.
+
+"I'm noticing that what we're working with is going beyond what I can hold as a [coach/peer supporter/etc.]."
+
+"This is important enough that I think you need specialized support."
+
+"I want to make sure you're getting care that matches what you're dealing with."
+
+### Step 2: Validate Their Experience
+
+They may feel scared, rejected, or ashamed. Meet that.
+
+"This isn't because something is wrong with you. It's because what you're carrying is significant."
+
+"I know starting with someone new feels hard. Your feelings about that make sense."
+
+"This is me taking you seriously, not dismissing you."
+
+### Step 3: Offer a Bridge
+
+Don't just drop them. Build a bridge.
+
+**Options:**
+- "I have a few people I can recommend. Want me to share their information?"
+- "Would it help if I stayed on while you get connected?"
+- "I can email an introduction if that would make it easier."
+- "Let's talk next week to see how the search is going."
+
+### Step 4: Be Clear About Your Role Going Forward
+
+Will you continue seeing them? In what capacity? Be explicit.
+
+"I can still be in your corner for the career stuff while you work with a therapist on the deeper material."
+
+"I think it makes sense for me to step back while you work with someone more suited to this."
+
+"Once you're stabilized, we can revisit whether coaching makes sense again."
+
+### Step 5: Follow Up
+
+Referral doesn't end with a name and number. Check in.
+
+"How did the first session go?"
+
+"Did you find someone who felt like a fit?"
+
+"Is there anything else you need to get connected?"
+
+---
+
+## Referral Language That Works
+
+| Instead of... | Try... |
+|---------------|--------|
+| "I can't help you with this." | "This needs specialized care that goes beyond what I offer." |
+| "You're too complicated for me." | "What you're dealing with deserves someone with specific training for this." |
+| "I'm not qualified." | "I want to make sure you're getting the right kind of support." |
+| "I have to refer you out." | "I think the best thing I can do for you is connect you with someone who specializes in this." |
+| "I'm firing you as a client." | "I care about you enough to make sure you get what you actually need." |
+
+---
+
+## The Ego Trap: Being Everything
+
+There is a version of the helper who cannot refer. Not because they've assessed and decided against it—but because their ego won't allow it.
+
+**Signs you're in this trap:**
+
+- Telling yourself you're "almost trained enough" to handle it
+- Researching frantically to fill gaps rather than referring
+- Believing the relationship is more important than appropriate care
+- Fearing that referring makes you look inadequate
+- Convincing yourself that they'd fall through the cracks with anyone else
+- Making exceptions for "just this one client"
+
+**The honest question:** Is my reluctance to refer about them—or about me?
+
+---
+
+## Building Your Referral Network
+
+You cannot refer if you don't know where to send people. Build your network before you need it.
+
+### Categories to Have Covered:
+
+- **Licensed therapists** (general and specialized: trauma, addiction, eating disorders, etc.)
+- **Psychiatrists** (for medication evaluation)
+- **Crisis resources** (hotlines, crisis centers, ER protocols)
+- **Support groups** (12-step, peer support, specific conditions)
+- **Sliding-scale options** (for clients without resources)
+- **Specialists** (EMDR, somatic, DBT, etc.)
+- **Complementary practitioners** (bodywork, nutrition, etc.—if relevant)
+
+### How to Build It:
+
+1. **Ask colleagues.** Who do they refer to? Who do they trust?
+2. **Attend trainings.** Meet people whose work you respect.
+3. **Build relationships.** Have coffee with potential referral partners.
+4. **Test the waters.** Send a few clients before you're desperate.
+5. **Keep notes.** Track who works well for what.
+6. **Update regularly.** People move, retire, change focus.
+
+---
+
+## What to Do in Crisis
+
+If someone is in immediate danger:
+
+### If You're In Session:
+
+1. **Stay calm.** Your regulation is their lifeline right now.
+2. **Assess.** "Are you thinking of hurting yourself? Do you have a plan? Do you have access to means?"
+3. **Do not leave them alone.** Virtually or physically.
+4. **Connect to crisis resources.** 988 (Suicide & Crisis Lifeline), local crisis line, ER.
+5. **Document.** Time, what was said, what you did.
+
+### If They Disclose and You're Ending Session:
+
+1. **Do not end session.** Extend until they're safe or connected.
+2. **Create safety plan together.** What will they do tonight? Who will they call?
+3. **Get commitment.** "Can you agree to call me or a crisis line before you do anything?"
+4. **Follow up.** Check in within 24 hours.
+
+### Know Your Legal Requirements:
+
+If you're a mandated reporter, know your state/country's requirements for:
+- Suicidal ideation
+- Homicidal ideation
+- Child abuse
+- Elder abuse
+- Vulnerable adult abuse
+
+When in doubt, consult. Err on the side of safety.
+
+---
+
+## Field Note: The Referral That Wasn't Rejected
+
+She'd been dreading this conversation.
+
+Her client was clearly struggling with addiction—something she wasn't trained to treat. But their relationship was strong. The work was good, outside of this one issue.
+
+She expected resistance. She expected abandonment wounds to flare.
+
+Instead, her client said: "Honestly? I was wondering when you'd say something. I knew this was beyond what we were doing. I just didn't want to be the one to name it."
+
+The referral went smoothly. An addiction specialist joined the team. The coaching continued—cleaner, more focused.
+
+*Sometimes they're waiting for permission.*
+
+---
+
+## When Referral Is Refused
+
+Sometimes you make the referral and they decline.
+
+**If it's not urgent:**
+- Respect their autonomy
+- Document that you recommended and they declined
+- Revisit periodically
+- Stay within your scope regardless
+
+**If it is urgent:**
+- Be more direct about your concerns
+- Explain the risks of not getting care
+- If there's imminent danger, crisis protocols apply regardless of their consent
+- Consult with supervisors or colleagues
+- Document everything
+
+**You cannot force care** (in most situations). But you can be clear about what you're willing to offer within your scope.
+
+---
+
+## The Long-Term Gift
+
+The client you refer out often comes back.
+
+Not because the referral failed—but because they're now ready for what you offer. They've done the deep work. They're stabilized. They're ready for coaching, growth, forward movement.
+
+**The referral was the bridge.**
+
+Or they don't come back. Because they're better. Because they've moved on. Because your job was to connect them to what they needed—and you did.
+
+Either way, the referral was the gift.
+
+---
+
+## A Practice: The Scope Inventory
+
+For each person you're currently working with:
+
+1. **What is the primary issue we're addressing?**
+2. **Is this within my scope of practice/training?**
+3. **Are there secondary issues that might be outside my scope?**
+4. **Have I noticed any warning signs that suggest referral?**
+5. **If I were to refer, who would I refer to?**
+
+Do this monthly. Don't wait for crisis.
+
+---
+
+## A Practice: The Referral Script
+
+Write out your referral script before you need it. Practice it.
+
+**Example:**
+
+"I want to share something important. I've been noticing that what we're working with is going beyond what I'm trained to hold. I think you'd really benefit from working with [a therapist/a specialist/someone with specific training in X]. This isn't because I'm giving up on you—it's because I care about you enough to make sure you get the right support. I can help you find someone, and I can stay in your corner [in this capacity]. What comes up for you when I say that?"
+
+Make it yours. Say it out loud. Get comfortable with it.
+
+---
+
+## A Practice: The Referral Network Audit
+
+Answer these questions:
+
+1. **Do I have referrals for crisis situations?** (Numbers saved, not just Googled.)
+2. **Do I have referrals for common needs?** (Therapy, psychiatry, addiction, etc.)
+3. **Do I have sliding-scale options for clients without resources?**
+4. **Have I personally connected with my referrals?** (Or are they just names?)
+5. **When did I last update my list?**
+
+Fill gaps before you need to use them.
+
+---
+
+## The Integration
+
+Your job as a helper is not to be everything.
+
+Your job is to be the right thing—when you're the right thing. And to connect to the right thing when you're not.
+
+Referral is not failure. It is precision. It is humility. It is the acknowledgment that this person's healing matters more than your ego's need to be the healer.
+
+The helper who cannot refer has mistaken devotion for competence.
+
+The helper who refers well has mastered both.
+
+---
+
+## Integration Line
+
+> *"The highest expression of care is connecting someone to what they actually need—even when that isn't me."*
+
+---
+
+## One-Line Anchor
+
+> *"I would rather refer and help than retain and harm."*
+
+---
+
+**[Continue to Chapter 11: Dual Relationships & Boundary Complexity →](./11-dual-relationships-boundary-complexity.md)**

--- a/book/vol-6-guide/chapters/11-dual-relationships-boundary-complexity.md
+++ b/book/vol-6-guide/chapters/11-dual-relationships-boundary-complexity.md
@@ -1,0 +1,485 @@
+# Chapter 11: Dual Relationships & Boundary Complexity
+
+## When They're Your Client and Your Friend
+
+---
+
+In clinical textbooks, boundaries are clean lines.
+
+In real life, they are rarely so simple.
+
+What happens when your client is also your neighbor? Your fellow survivor? Your business partner's ex? Your child's teacher? Your best friend's sister?
+
+What happens when you're a helper in a small community where everyone knows everyone—and referring out means sending them to your ex's new partner?
+
+What happens when you're the only person with your expertise serving a marginalized population—and turning someone away means they get no help at all?
+
+**Dual relationships are not always avoidable. But they are always navigable—if you do it with eyes open.**
+
+This chapter is about navigating the complexity, not pretending it doesn't exist.
+
+---
+
+## Field Note (Before): The Friend Who Became a Client
+
+They had been friends for years.
+
+When her friend started struggling—really struggling—she offered to help. She was a coach, after all. She had the skills. It felt natural.
+
+At first, it worked. The structure helped. The familiarity made it easier to go deep.
+
+But then things got complicated.
+
+Her friend started texting between sessions—as a friend, but about client material. She felt resentment when she wasn't available. She expected discounts, then stopped paying at all.
+
+"I thought we were friends," she said, when the coach tried to reinstate the fee. "I didn't think this was really work to you."
+
+The friendship fractured. The coaching ended badly. Both felt betrayed.
+
+*Neither relationship could survive being both at once.*
+
+---
+
+## Field Note (After): The Boundary That Preserved the Friendship
+
+Same coach. Different friend. Similar crisis.
+
+Her friend was going through something hard. The old urge surfaced: *I should help. I could help. It's what I do.*
+
+But she remembered. So she did something different.
+
+"I can tell you're going through a lot. I want you to know—I'm here as your friend, and that's where I want to stay. If you want a coach, I can help you find someone great. But I've learned that I can't be both for someone I care about this much. I hope that makes sense."
+
+Her friend paused. "Actually, that makes me feel safer. I don't have to perform for you."
+
+The friendship deepened. The friend found a coach elsewhere. When they talked, it was as friends—free from the weight of the helping role.
+
+*The boundary wasn't rejection. It was protection.*
+
+---
+
+## What Is a Dual Relationship?
+
+A dual relationship (also called multiple relationship) exists when you have more than one type of relationship with the same person.
+
+**Examples:**
+
+| Type 1 | Type 2 | Complexity |
+|--------|--------|------------|
+| Therapist | Friend | Who are you at brunch? |
+| Coach | Business partner | Do you coach them or consult with them? |
+| Peer supporter | Fellow church member | What happens in the pew after group? |
+| Mentor | Colleague | Do they owe you deference or equality? |
+| Healer | Romantic interest | Power dynamics become intimate |
+| Group facilitator | Personal friend | Whose needs take priority? |
+| Teacher | Student's parent | Do you teach the child or parent the adult? |
+
+**The problem isn't always the dual relationship itself. The problem is unexamined dual relationships—where neither party knows which role is active, or where one role bleeds into another without consent.**
+
+---
+
+## Why Dual Relationships Are Complicated
+
+### Power Dynamics Get Murky
+
+In any helping relationship, there is a power differential. You know things about them that they haven't told others. You hold expertise or experience they're seeking. You have influence over their wellbeing.
+
+When you add another relationship, that power doesn't disappear—it diffuses. It can show up in unexpected places.
+
+**Example:** You're coaching someone who is also in your social circle. In coaching, you notice their avoidance patterns. At a party, they're avoiding a conversation—and you know why. Do you say something? Stay silent? Either choice is complicated.
+
+### Role Confusion Breeds Resentment
+
+When roles blur, expectations collide.
+
+They expect you to be available like a friend but wise like a coach. They expect free labor because you're friends but professional quality because you're a coach. They expect confidentiality like a client but intimacy like a friend.
+
+**You can't meet all expectations simultaneously.** And when you fail one, they feel betrayed—even if you were succeeding at another.
+
+### Secrets Get Complicated
+
+What you know in one role may be relevant to the other role—but sharing would violate the first.
+
+**Example:** You're a therapist who sees someone in your friend group. In therapy, they reveal they're cheating on their partner—who is also in your friend group. At the next dinner party, you're sitting across from both of them.
+
+Your knowledge is now a weight you carry in both relationships.
+
+---
+
+## The Ethics Frameworks
+
+Different helping professions handle dual relationships differently.
+
+### Licensed Therapists (Strictest)
+
+Most licensing boards require therapists to avoid dual relationships whenever possible, and to manage them carefully when they cannot be avoided.
+
+**APA Ethics Code (paraphrased):** Avoid multiple relationships that could reasonably be expected to impair objectivity, competence, or effectiveness, or to risk exploitation or harm.
+
+**Key principle:** The power differential in therapy is significant enough that other relationships with clients must be minimized or managed very carefully.
+
+### Coaches (Less Formal)
+
+Coaching lacks standardized licensing in most places. Ethics depends on training organization and personal standards.
+
+**ICF Ethics (paraphrased):** Coaches should be aware of power dynamics and avoid relationships that could impair objectivity or create conflicts of interest.
+
+**Reality:** Coaches often work in contexts where dual relationships are common—business partnerships, communities, networks.
+
+### Peer Support (Complex)
+
+Peer support is inherently relational. The shared experience is the point. Clean separation may not be possible—or even desirable.
+
+**The challenge:** How do you maintain enough role distinction to be helpful without sacrificing the mutuality that makes peer support work?
+
+### Informal Helpers (No Formal Code)
+
+If you're the friend everyone comes to, there is no professional body governing you.
+
+**Which makes the ethical responsibility entirely yours.**
+
+---
+
+## Field Note: The Small Town Therapist
+
+She was the only trauma-specialized therapist within a hundred miles.
+
+Every client she took was someone she might see at the grocery store, the school pickup, the town hall meeting. Every client was connected to someone else she might take as a client. Every social interaction carried the shadow of therapeutic knowledge.
+
+She developed systems:
+
+**Clear agreements.** Every client understood: "We may see each other in town. If we do, I'll follow your lead. If you acknowledge me, I'll be friendly. If you prefer not to, I'll pretend we're strangers. Either is fine."
+
+**Compartmentalization.** She trained herself to set down therapeutic knowledge when in social settings. Not always possible—but intentional.
+
+**Consultation.** She had a peer consultation group two hours away who helped her navigate the complexities unique to small-town practice.
+
+**Self-disclosure.** She named the situation openly: "You should know that I'm the therapist for [someone you might know]. I will never reveal that, and I'll keep our work just as private. If that's uncomfortable, I can help you find someone in the city."
+
+*The dual relationships were inevitable. The navigation was optional—and she chose to navigate carefully.*
+
+---
+
+## The Small Community Challenge
+
+If you serve a small community—geographically or socially—dual relationships may be unavoidable.
+
+**Small town.** You're the only helper. Everyone is connected.
+
+**Marginalized community.** You're one of few people with shared identity doing this work. Referring out means referring to someone who may not understand.
+
+**Tight-knit professional world.** Your clients and colleagues overlap. Confidentiality has new meaning when everyone knows everyone.
+
+**Recovery community.** You're helping people you also sit in meetings with. The lines between peer and helper are deliberately blurry.
+
+**Religious/spiritual community.** You're a pastoral counselor in your own congregation. You know things about people you worship with.
+
+### Navigation Principles for Small Communities:
+
+**1. Name it openly.**
+
+Don't pretend the overlap doesn't exist. Discuss it. Get consent.
+
+"Before we work together, I want to acknowledge that we may see each other at [community context]. Here's how I suggest we handle that..."
+
+**2. Err toward over-communication.**
+
+When in doubt, discuss. Don't assume they're okay with something. Ask.
+
+"How was it for you when we ran into each other at the conference? Is there anything we need to adjust?"
+
+**3. Let them lead in public.**
+
+They get to decide if and how you're acknowledged in social settings. Follow their lead.
+
+**4. Maintain internal boundaries.**
+
+Even if external boundaries are blurry, you can maintain internal ones. Compartmentalize what you know. Don't let therapy-knowledge inform social interactions.
+
+**5. Find outside consultation.**
+
+When you're embedded in a community, you need outside perspective. Someone who isn't enmeshed in the same system.
+
+---
+
+## Field Note: The Queer Therapist
+
+He was a gay therapist serving the LGBTQ+ community in a mid-sized city.
+
+The community was small enough that almost everyone knew everyone. He'd dated the brother of one client. He'd protested alongside another. His ex was best friends with a third.
+
+Referring out wasn't always possible—not everyone trusted straight therapists, and not everyone could afford the drive to the next city.
+
+He developed a practice:
+
+**Radical transparency.** At intake, he disclosed: "The queer community here is small. We may know people in common. If at any point our connections feel too close, we can discuss options."
+
+**Active boundary-checking.** When connections surfaced, he named them: "I just realized I know your roommate. How does that land for you? Do you want to continue, or would you prefer I help you find someone else?"
+
+**Self-awareness.** He tracked his own reactions. When a client's story activated him because of personal connections, he brought it to supervision.
+
+**Community care.** He was part of a network of LGBTQ+ therapists who referred to each other when conflicts were too significant.
+
+*The dual relationships were the price of serving his community. The ethics were how he paid it.*
+
+---
+
+## The Social Media Complication
+
+Modern helping relationships face a unique complexity: social media.
+
+### The Blurring
+
+- They follow your personal account and see your vacations, opinions, struggles
+- You see their public posts and know things they didn't tell you
+- They interact with your content alongside everyone else
+- The boundaries between professional and personal are algorithmically collapsed
+
+### Navigation Options
+
+**Option 1: Complete separation.**
+
+Have professional accounts only. Don't accept follows from clients. Clear policy.
+
+Pros: Clean boundaries. No confusion.
+Cons: May seem cold. Doesn't work for all business models.
+
+**Option 2: Public persona only.**
+
+Accept professional follows. Keep content professional. No personal sharing.
+
+Pros: Accessible but boundaried.
+Cons: Feels inauthentic. May be hard to maintain.
+
+**Option 3: Transparency about what they'll see.**
+
+"If you follow me, you'll see my real life. That includes [whatever it includes]. If that would complicate our work, you might prefer not to follow."
+
+Pros: Honest. Gives them choice.
+Cons: Puts the boundary management on them.
+
+**Option 4: Explicit agreements.**
+
+Discuss it at the start: "What's your preference about social media? I can explain my policy, and we can find what works for both of us."
+
+Pros: Collaborative. Respects their agency.
+Cons: Requires a conversation not everyone wants to have.
+
+**There is no perfect answer.** But there should be a conscious answer.
+
+---
+
+## The Romantic/Sexual Complication
+
+Some dual relationships are absolutely prohibited—and this is one of them in most contexts.
+
+### Licensed Therapists
+
+Most licensing boards prohibit romantic/sexual relationships with current clients and with former clients for 2-5 years after termination (varies by jurisdiction). Some prohibit them forever.
+
+This is not arbitrary. The power differential in therapy creates a context where genuine consent is compromised. What feels like mutual attraction may be transference. What feels like choice is shaped by the therapeutic relationship.
+
+### Coaches/Unlicensed Helpers
+
+There may be no legal prohibition, but the ethical concerns remain.
+
+**The power differential doesn't disappear because you're unlicensed.** They still looked to you for guidance. You still knew their vulnerabilities. You still held influence over their self-perception.
+
+**Best practice:** Avoid romantic relationships with anyone you've served in a helping capacity. If feelings develop, end the professional relationship first and allow significant time before pursuing anything else.
+
+### When Attraction Arises (For You)
+
+It happens. You're human. Someone you're helping is also someone you find attractive.
+
+**What to do:**
+
+1. **Notice without acting.** Attraction is information, not instruction.
+2. **Examine it.** Is this about them, or about the intimacy of the helping role?
+3. **Get consultation.** Talk to a supervisor or peer. Immediately.
+4. **Don't disclose to them.** This shifts the burden to them inappropriately.
+5. **Consider transfer.** If you can't be helpful without it interfering, transfer care.
+6. **Never act while they're a client.** Ever.
+
+---
+
+## The Pre-Existing Relationship Question
+
+What about when the relationship came first?
+
+**Friend wants to become client:**
+
+This is almost always a bad idea. The friendship will contaminate the work. The work will contaminate the friendship. You'll lose both.
+
+**Better approach:** "I love our friendship too much to risk it. Let me help you find someone great—and I'll stay in your corner as your friend."
+
+**Family member needs help:**
+
+You are not objective. You cannot be. And they can't be fully honest with someone who will see them at Thanksgiving.
+
+**Better approach:** Be supportive as family. Connect them to professional help elsewhere.
+
+**Ex-partner needs help:**
+
+No. The power dynamics are too fraught. The history is too present. The potential for harm (to them and to you) is too high.
+
+**Exception considerations:**
+
+Some contexts are more tolerant of pre-existing relationships:
+- Peer support (where mutuality is the point)
+- Specialized communities where you're the only option
+- Situations where the help is brief and bounded
+
+Even then: name it, discuss it, get consent, be prepared to stop.
+
+---
+
+## A Decision Framework
+
+When facing a potential dual relationship, ask:
+
+### 1. Is This Avoidable?
+
+Can they get this help from someone else without undue burden? If yes, refer.
+
+If truly unavoidable (small community, specialized need, no alternatives), proceed to question 2.
+
+### 2. What Are the Power Dynamics?
+
+How significant is the power differential in the helping relationship? How might it affect the other relationship?
+
+The greater the power differential, the more careful you need to be.
+
+### 3. What's the Risk of Harm?
+
+If this goes wrong, what's the damage? To them? To you? To the other relationship?
+
+Higher stakes = more caution.
+
+### 4. Can We Navigate This Together?
+
+Can you discuss the complexity openly? Get their consent? Check in regularly?
+
+If they can't discuss it, that's a warning sign.
+
+### 5. Do I Have Outside Perspective?
+
+Is someone outside this system helping you see clearly? Consultation is essential, not optional.
+
+### 6. What Does My Body Say?
+
+Underneath the reasoning, what does your gut say? Unease is data.
+
+---
+
+## A Practice: The Relationship Mapping
+
+For each person you currently help:
+
+1. **What is our primary helping relationship?** (Therapy, coaching, peer support, informal helping)
+
+2. **What other relationships do we have?** (Friend, colleague, community member, relative, etc.)
+
+3. **What relationships do we share?** (Common friends, colleagues, community connections)
+
+4. **What complications could arise?** (Confidentiality conflicts, role confusion, power dynamics)
+
+5. **Have we discussed this?** (If not, should we?)
+
+6. **What boundaries might we need?** (Social media, public encounters, mutual connections)
+
+---
+
+## A Practice: The Role Clarity Check-In
+
+Periodically ask yourself—and consider asking them:
+
+"Which role am I in right now?"
+
+"Which role do they expect me to be in?"
+
+"Are we aligned?"
+
+This is especially useful:
+- At the start of conversations
+- When context shifts (from session to social encounter)
+- When you feel confused about what's expected
+- When requests feel "off"
+
+---
+
+## A Practice: The Dual Relationship Audit
+
+Before entering a dual relationship, complete this honestly:
+
+**1. Describe the two relationships:**
+First relationship:
+Second relationship:
+
+**2. What is the power differential in the helping relationship?** (1-10 scale)
+
+**3. What is the potential for harm if this goes wrong?** (1-10 scale)
+
+**4. Is this dual relationship avoidable?** (Yes/No)
+If yes, why am I not avoiding it?
+
+**5. Have I discussed this complexity with them?** (Yes/No)
+If no, what's preventing me?
+
+**6. Do I have outside consultation on this?** (Yes/No)
+If no, who could I consult?
+
+**7. What is my gut saying?**
+
+**8. Decision and reasoning:**
+
+---
+
+## Field Note: The Boundary That Built Trust
+
+He was a peer supporter in a recovery community. Everyone in his circle was also in recovery. The lines between helper and helped were deliberately blurry.
+
+But when someone asked him to sponsor them, he paused.
+
+"You're a close friend, and I want to keep it that way. In sponsorship, I'd have to be more direct with you—maybe in ways that would strain our friendship. I'd rather stay your friend and help you find a sponsor who can be more objective."
+
+His friend was disappointed. Then grateful.
+
+"You're right. I probably couldn't hear hard things from you without it messing with our friendship."
+
+They found him a different sponsor. The friendship deepened.
+
+*The dual relationship was avoided—and both relationships were stronger for it.*
+
+---
+
+## The Integration
+
+Dual relationships are not inherently unethical. They are inherently complex.
+
+The question is not: "Can I avoid all dual relationships?" (Often you can't.)
+
+The question is: "Am I navigating this with eyes open? With consent? With ongoing attention?"
+
+The helper who never examines their dual relationships will harm—usually without knowing.
+
+The helper who navigates them consciously may serve more deeply—in communities, in contexts, in relationships that simple boundaries could never reach.
+
+It requires more attention. More honesty. More willingness to have awkward conversations.
+
+**But if you're going to help in the real world—where people are connected and communities overlap—this is the work.**
+
+---
+
+## Integration Line
+
+> *"The complexity is not the problem. The unexamined complexity is the problem."*
+
+---
+
+## One-Line Anchor
+
+> *"When roles blur, clarity becomes essential—even when boundaries can't be."*
+
+---
+
+**[Continue to Chapter 12: Confidentiality & Story Stewardship →](./12-confidentiality-story-stewardship.md)**

--- a/book/vol-6-guide/chapters/12-confidentiality-story-stewardship.md
+++ b/book/vol-6-guide/chapters/12-confidentiality-story-stewardship.md
@@ -1,0 +1,530 @@
+# Chapter 12: Confidentiality & Story Stewardship
+
+## The Sacred Weight of Being Told
+
+---
+
+Someone told you their story.
+
+Not the public version. Not the cleaned-up, Instagram-ready version. The real one. The one with shame in it. The one they haven't told anyone else. The one that costs them something to say out loud.
+
+**You now carry something that doesn't belong to you.**
+
+This is the privilege and the burden of helping work: you become a keeper of stories that are not yours to tell.
+
+Confidentiality is not a technicality. It is not a legal checkbox. It is the ethical foundation of trust—the reason they told you at all.
+
+This chapter is about holding what you've been told with the reverence it deserves.
+
+---
+
+## Field Note (Before): The Content That Cost Trust
+
+She was a content creator. Her work was about healing—sharing wisdom, helping people feel less alone, building community.
+
+And her content was good. Relatable. Specific. The specificity was what made it land.
+
+The problem was where the specificity came from.
+
+She was drawing from client sessions. Not quoting directly—but using their stories, their patterns, their breakthroughs as material. Changed enough to avoid recognition. Similar enough to feel authentic.
+
+One day, a client saw a post. Recognized herself. Said nothing for weeks.
+
+Then, in session: "I saw that post. About the woman who keeps choosing unavailable men. That was me, wasn't it?"
+
+The coach hesitated too long.
+
+"I trusted you," the client said. "I told you things I haven't told anyone. And you used them for content."
+
+The session ended. The client never came back. The trust was gone.
+
+*The story wasn't the coach's to tell—even anonymized.*
+
+---
+
+## Field Note (After): The Content That Protected Trust
+
+Same coach. Years later. Wiser.
+
+She still created content. Still shared wisdom. But she'd changed what she drew from.
+
+Now she wrote from her own experience—her healing, her patterns, her journey. Or she wrote from composite examples—clearly marked as illustrative, not drawn from specific clients. Or she asked permission—explicit, documented, with the right to refuse.
+
+One client asked: "Do you ever write about your clients?"
+
+"Only with explicit permission, and only when I've shared the exact content first. I'll never share anything recognizable without your say-so. Your story is yours."
+
+The client relaxed. Shared something she'd been holding back.
+
+*Trust was protected. The work deepened.*
+
+---
+
+## What Confidentiality Actually Is
+
+Confidentiality is the agreement—explicit or implicit—that what is shared in the helping relationship stays in the helping relationship.
+
+### The Scope of Confidentiality
+
+| What It Covers | What It Doesn't Cover |
+|----------------|----------------------|
+| Content of sessions | That they're your client (sometimes) |
+| Personal disclosures | What they share publicly elsewhere |
+| Emotional material | What's already public knowledge |
+| Details of their life | Information shared with explicit permission to disclose |
+| Their identity as your client (usually) | Legally mandated disclosures (see below) |
+
+### The Exceptions
+
+Most helping relationships include legal or ethical exceptions:
+
+**Mandatory reporting:** If they disclose child abuse, elder abuse, or abuse of vulnerable adults, you may be required to report—depending on your role and jurisdiction.
+
+**Imminent danger:** If they're an imminent threat to themselves or others, confidentiality yields to safety.
+
+**Court orders:** Subpoenas and court orders may compel disclosure (though therapists often have more protection than other helpers).
+
+**With explicit permission:** They can consent to specific disclosures.
+
+**Consultation:** Most ethical frameworks permit confidential consultation with colleagues for professional development (without identifying details).
+
+These exceptions should be disclosed at the start of the relationship. No one should be surprised that you have limits.
+
+---
+
+## The Neuroscience of Being Held
+
+When someone tells you something vulnerable and you hold it safely, something happens in their nervous system:
+
+**Vagal safety.** The social engagement system registers: *This person can be trusted with my truth.*
+
+**Reduced shame activation.** Shame lives in secrecy. When a secret is held without judgment, shame decreases.
+
+**Implicit learning.** They're learning—below consciousness—that vulnerable disclosure doesn't lead to harm.
+
+**When confidentiality is broken, the reverse happens:**
+
+The nervous system registers betrayal. The shame that was lessening floods back. The implicit learning becomes: *Vulnerability is dangerous. People cannot be trusted.*
+
+This is why confidentiality breaches are so damaging. It's not just about the information—it's about the nervous system learning that trust is not safe.
+
+---
+
+## Story Stewardship: Beyond Confidentiality
+
+Confidentiality is the minimum. Story stewardship is the aspiration.
+
+**Confidentiality says:** I won't tell your secrets.
+
+**Story stewardship says:** I will hold your story with the reverence it deserves—not just because I have to, but because it's sacred.
+
+### What Story Stewardship Looks Like
+
+**Recognizing the weight.** You understand that what they told you cost them something. You don't treat it casually.
+
+**Not performing insight.** You don't share their material in consultation to show how clever you are. You share it when necessary for their care.
+
+**Protecting even when permitted.** Just because you could share something doesn't mean you should.
+
+**Considering secondary exposure.** Their story may touch other people's stories. Telling theirs might reveal someone else's.
+
+**Respecting their ownership.** It's their story. They get to decide what happens to it—forever, not just while they're your client.
+
+---
+
+## The Content Creator's Dilemma
+
+If you create content about healing—writing, speaking, social media, courses—you face a specific challenge:
+
+**Your content is better when it's specific.** Abstract wisdom is less impactful than real examples.
+
+**Your examples come from real people.** Even if you've done your own work, you're now surrounded by stories that aren't yours.
+
+**The temptation is real.** To use that client's breakthrough. To tell that story you heard in group. To make your content land using material you've been entrusted with.
+
+This is one of the most common ethical failures in healing content—and one of the least discussed.
+
+---
+
+## The Ethics of Using Others' Stories
+
+### Never Without Permission
+
+If you want to use a specific client's story, you need:
+
+1. **Explicit permission.** Not assumed, not implied—explicitly asked.
+2. **Full disclosure.** Show them exactly what you plan to share.
+3. **Right to refuse.** Make it genuinely optional, with no consequence for declining.
+4. **Right to revoke.** They can change their mind, even after saying yes.
+5. **Compensation consideration.** If you're profiting from their story, consider whether they should benefit.
+
+### The "Changed Enough" Illusion
+
+Many content creators believe: "I changed the details enough that no one would recognize them."
+
+**But:**
+- They might recognize themselves
+- People who know them might recognize them
+- The details you think are irrelevant might be the identifying ones
+- "Changed enough" is a judgment you're not qualified to make
+
+If you're using someone's story, even "anonymized," you're taking a risk with their trust—not yours.
+
+### The Composite Approach
+
+One ethical alternative: composite examples.
+
+A composite combines elements from multiple people—or from your imagination—into a fictional example that illustrates a real pattern.
+
+**Best practices for composites:**
+- Draw from multiple sources, not one with details changed
+- Make clear it's illustrative, not a specific person
+- Don't include unique, identifying details from any one person
+- Be honest with yourself—is this really a composite, or one person with a wig?
+
+### The Personal Disclosure Approach
+
+The cleanest approach: use your own material.
+
+Your healing journey. Your patterns. Your breakthroughs. Your struggles.
+
+This is yours to share. No one else's consent required. No confidentiality concerns.
+
+**The limit:** You can't write forever from only your experience. And some topics aren't yours to teach from.
+
+---
+
+## Field Note: The Permission That Protected Everyone
+
+She wanted to share a client's story. It was powerful—exactly the kind of transformation she helped people achieve. It would help others to hear it.
+
+So she asked.
+
+"I'm working on a piece about [topic], and I think your story could really help people. Would you be open to me sharing it? I can show you exactly what I'd write, change any details you want, and you can say no with absolutely no weirdness between us."
+
+The client read the draft. Asked for three changes. Gave permission.
+
+The content landed. The client felt honored, not exposed. Trust was strengthened.
+
+*Permission doesn't ruin content. It sanctifies it.*
+
+---
+
+## Vicarious Disclosure: The Hidden Risk
+
+There's a form of disclosure that many helpers don't consider:
+
+**When you share your story, whose story are you also sharing?**
+
+If you talk about your narcissistic mother, you're talking about your mother.
+If you describe your abusive ex, you're describing your ex.
+If you discuss your childhood trauma, you're discussing your family.
+
+**Their story is embedded in yours.**
+
+### Considerations for Vicarious Disclosure
+
+**Can they be identified?** Even if you don't name them, could readers figure out who they are?
+
+**What's the impact?** If they read this, or hear about it, what happens?
+
+**Do they have a say?** Should they? Some would argue no—your story is yours. Others would argue yes—when stories are shared, so is the ownership.
+
+**What's your intention?** Processing for yourself? Helping others? Revenge dressed as healing?
+
+There is no universal rule here. But there should be universal consideration.
+
+---
+
+## The Informal Helper's Challenge
+
+If you're not a licensed professional, confidentiality gets murky.
+
+No one signed an intake form. No ethics board governs you. The friend who confides in you over coffee didn't formally consent to anything.
+
+**But the trust is just as real.**
+
+### Principles for Informal Confidentiality
+
+**1. Assume confidentiality unless told otherwise.**
+
+Default position: what they tell you stays with you. If they wanted it shared, they'd share it themselves.
+
+**2. Ask before sharing.**
+
+"Is it okay if I mention this to [person]?"
+
+"Would you be comfortable if I asked [person] for advice about this?"
+
+"How private do you want this to be?"
+
+**3. Be explicit about your limits.**
+
+"I can't keep this between us if someone's in danger."
+
+"I need to process this with my partner, but they won't know who you are."
+
+"I might talk about this with my therapist—is that okay?"
+
+**4. Don't use social settings for disclosure.**
+
+The conversation at the party isn't the place to reference what they told you privately. Keep contexts separate.
+
+**5. When in doubt, don't.**
+
+You can always ask permission later. You can never unsay what's been said.
+
+---
+
+## The Group Setting Challenge
+
+In group settings—support groups, workshops, group coaching—confidentiality becomes collective.
+
+### The Problem
+
+- You can maintain confidentiality for yourself
+- You cannot guarantee it from other group members
+- One person's breach affects everyone
+
+### Best Practices
+
+**Explicit agreements.** At the start of every group: "What's shared here stays here. This includes not only content but identity—you don't mention that someone was here without their permission."
+
+**Regular reminders.** Norms decay. Reinforce them.
+
+**Modeling.** Demonstrate confidentiality yourself. Don't share examples from previous groups without permission.
+
+**Addressing breaches.** When it happens (and it will), name it. Don't shame, but don't ignore. "I want to remind everyone that what we share here stays here."
+
+**Acknowledging limits.** "I maintain confidentiality myself, but I can't guarantee what others will do. Please share with that in mind."
+
+---
+
+## Digital Confidentiality
+
+Modern helping happens in digital spaces. New considerations arise.
+
+### Communication Security
+
+| Method | Confidentiality Level | Notes |
+|--------|----------------------|-------|
+| In-person | High | No digital trail |
+| Phone call | Medium | Can be recorded; carrier has access |
+| Video call | Medium | Platform has access; can be recorded |
+| Encrypted text (Signal) | High | End-to-end encrypted |
+| Regular text/SMS | Low | Carrier accessible; stored on devices |
+| Email | Low | Multiple servers; often stored indefinitely |
+| DMs on social platforms | Low | Platform accessible; terms of service vary |
+
+### Best Practices
+
+**Use encrypted communication for sensitive content** when possible.
+
+**Discuss communication preferences** at intake. "How do you want us to communicate between sessions? Here are the privacy implications of each option..."
+
+**Be careful with specifics in writing.** What's said disappears (mostly). What's written persists.
+
+**Secure your own devices.** Password protection, encryption, secure backup.
+
+**Consider what happens if you die.** Who has access to your notes, emails, files? This is morbid but necessary.
+
+---
+
+## Note-Taking and Record-Keeping
+
+If you keep notes on clients:
+
+**Security.** Are they encrypted? Password-protected? What happens if your laptop is stolen?
+
+**Retention.** How long do you keep them? When do you delete them?
+
+**Access.** Who else can see them? Partners? Staff? Hackers?
+
+**Content.** What do you record? The minimum necessary? Everything? Their interpretations or just facts?
+
+**Their access.** Do they have the right to see their notes? What's your policy?
+
+### The Minimalism Approach
+
+Some helpers keep minimal notes:
+- Dates of sessions
+- Brief topic summary
+- Any risk factors
+- Referrals made
+- Nothing that would be damaging if exposed
+
+The less you record, the less can be breached.
+
+### The Thorough Approach
+
+Some helpers keep detailed notes:
+- Full session summaries
+- Clinical impressions
+- Treatment plans
+- Progress tracking
+
+This supports continuity of care—but creates more to protect.
+
+Neither is universally right. But both require security.
+
+---
+
+## When Confidentiality Must Break
+
+Sometimes confidentiality yields to other obligations.
+
+### Legal Requirements
+
+If you're a mandated reporter (therapists, teachers, medical professionals, and others depending on jurisdiction), you may be required to report:
+- Child abuse or neglect
+- Elder abuse
+- Abuse of vulnerable adults
+- (Sometimes) threats of violence
+
+Know your requirements. Follow them. Document everything.
+
+### Safety Concerns
+
+If someone is an imminent threat to themselves or others, confidentiality can break to protect life.
+
+This is not a casual judgment. "Imminent" means immediate, specific, with intent and means.
+
+**Document why you broke confidentiality.** Your reasoning should be clear and defensible.
+
+**Break minimally.** Share only what's necessary for safety. Not the whole history—just what's needed.
+
+### With Permission
+
+They can consent to disclosure. Get it in writing when possible.
+
+"I give [helper] permission to discuss my care with [person] for the purposes of [specific purpose]."
+
+---
+
+## Field Note: The Break That Was Necessary
+
+He revealed, in session, that he was planning to hurt someone. Not abstractly—specifically. A person, a time, a method.
+
+The therapist's stomach dropped. This was the moment every helper dreads.
+
+She stayed calm. Assessed further. Confirmed the intent was serious.
+
+"I hear how much pain is underneath this. And I have to be honest with you—what you're describing means I need to break confidentiality. I'm required to take steps to prevent harm. I'd rather do this with you than to you. Can we figure out together how to keep everyone safe?"
+
+He was angry. Then scared. Then relieved—somewhere under the anger.
+
+They called together. The crisis was managed. The relationship was strained but survived.
+
+Later, he said: "I hated you for that. But I knew you were doing what you had to. And honestly... I think I told you because I wanted someone to stop me."
+
+*Sometimes the break is the care.*
+
+---
+
+## Story Fatigue: What Happens to the Holder
+
+This chapter has focused on protecting their stories. But there's another aspect: what happens to you.
+
+When you hold many stories—especially traumatic ones—the weight accumulates.
+
+**Signs of story fatigue:**
+
+- Feeling burdened by what you know
+- Dreaming about clients' material
+- Difficulty separating their stories from your life
+- Feeling like you're carrying too many secrets
+- Wanting to share things you shouldn't
+- Cynicism about humanity after too many hard stories
+
+This connects to Chapter 5: Vicarious Trauma & Compassion Fatigue. The stories you carry are part of the weight.
+
+**What helps:**
+
+- Consultation where you can share (confidentially) what you're holding
+- Therapy for yourself where you can process
+- Rituals for releasing what's not yours (see Chapter 15: Energy Hygiene)
+- Boundaries on how many hard stories you take at once
+- Remembering that you don't have to hold everything
+
+---
+
+## A Practice: The Story Audit
+
+For each story you've considered sharing:
+
+1. **Whose story is this?** (Yours? A client's? A composite? Someone else's embedded in yours?)
+
+2. **Do I have permission?** (Explicit, current, revocable?)
+
+3. **Could they be identified?** (By themselves or others?)
+
+4. **What's my intention?** (Service? Processing? Content needs? Recognition?)
+
+5. **What's the risk if this goes wrong?** (To them? To the relationship? To your reputation?)
+
+6. **Is there a safer alternative?** (Your own story? A true composite? A hypothetical?)
+
+---
+
+## A Practice: The Confidentiality Check-In
+
+Periodically review:
+
+**1. What have I shared that I shouldn't have?**
+Be honest. We all slip. What matters is noticing and correcting.
+
+**2. What am I tempted to share?**
+The temptation is information. What's pulling you to disclose?
+
+**3. Where are my records vulnerable?**
+Security gaps? Outdated practices?
+
+**4. Who might have access to confidential information?**
+Partners who see your screen? Staff? Cloud services?
+
+**5. What would happen if my most sensitive material was exposed?**
+This isn't paranoia—it's planning.
+
+---
+
+## A Practice: The Consent Conversation
+
+Before using anyone's story, practice this conversation:
+
+"I'm working on [content type] about [topic]. I think your experience could really help others who are going through similar things. Would you be open to me sharing some of what we discussed? Here's what I'm thinking of including [share specifics]. You can say no with absolutely no impact on our relationship. You can also say yes and change your mind anytime. What comes up for you?"
+
+Practice until it's natural. Then use it.
+
+---
+
+## The Integration
+
+When someone tells you their story, you receive a sacred trust.
+
+Not sacred in a mystical sense—sacred in the sense that it matters, deeply, to them. They gave you something they could not get back. They trusted you with their vulnerability.
+
+What you do with that trust defines you as a helper.
+
+Will you protect it fiercely? Will you honor their ownership of their own story? Will you hold it with the reverence it deserves?
+
+Or will you treat it as material—content to be mined, examples to be deployed, color for your own narrative?
+
+**The choice is yours, repeatedly, every day.**
+
+And your clients—and your own integrity—will be shaped by what you choose.
+
+---
+
+## Integration Line
+
+> *"Their story passed through me. It does not belong to me."*
+
+---
+
+## One-Line Anchor
+
+> *"I hold what I've been told as if it were my own—because to them, it was even more."*
+
+---
+
+**[Continue to Chapter 13: Boundaried Presence →](./13-boundaried-presence.md)**


### PR DESCRIPTION
Add four comprehensive chapters covering the ethical framework for helpers:

- Chapter 9: The Ethics of Lived Experience - navigating when and how
  to share your own trauma story in service to others
- Chapter 10: Referral - When to Pass the Baton - recognizing scope
  limits and connecting people to appropriate care
- Chapter 11: Dual Relationships & Boundary Complexity - managing
  multiple relationships with the same person
- Chapter 12: Confidentiality & Story Stewardship - protecting the
  sacred trust of being told someone's story