### PR TITLE
📚 Add Volume 6 Part I & II (Chapters 1-4): The Guide

### DIFF
--- a/book/vol-6-guide/00-front-matter.md
+++ b/book/vol-6-guide/00-front-matter.md
@@ -6,39 +6,199 @@
 
 ---
 
-## About This Book
+You are holding the sixth volume in the Sovereignty Series.
 
-*To be written*
+This book assumes a journey completed—and a new calling emerging:
+
+**Volume 1** taught you to see the patterns—manipulation tactics, control dynamics, the architecture of narcissistic relationships.
+
+**Volume 2** taught you to cross the bridge—separating from what harmed you, understanding attachment, beginning the repair.
+
+**Volume 3** taught you to stand—installing internal authority, holding your own field, making choices without urgency.
+
+**Volume 4** taught you to live—embodying your sovereignty, reclaiming your energy, leading through presence.
+
+**Volume 5** taught you to give—parenting while healing, breaking generational chains, passing on what you never received.
+
+**Volume 6** is about serving—helping others on this path without losing yourself to the work.
 
 ---
 
-## Who This Book Is For
+## What This Book Is
 
-*To be written*
+This is a book about sustainable service.
+
+If you've done the work across these volumes, something may be stirring: the desire to help others who are where you once were. To guide. To teach. To hold space. To serve.
+
+Maybe you're becoming a therapist, coach, or healer. Maybe you're creating content about recovery. Maybe you've simply become the person everyone comes to—the friend who sees, the family member who understands, the colleague who holds space.
+
+This book is for you.
+
+It will teach you to:
+
+- Help without hiding in the helping
+- Give without depleting yourself
+- Hold space without absorbing what isn't yours
+- Serve without needing the service to define you
+- Guide without creating dependency
+- Maintain boundaries without building walls
+
+**The core insight:** *"You cannot give what you don't have. Your healing is your offering."*
+
+---
+
+## What This Book Is Not
+
+This book is not permission to start helping before you're ready.
+
+It is not a certification. It is not a replacement for proper training in therapeutic modalities if that's your path.
+
+It is not a manual for building a healing business—though it addresses the ethics of monetizing lived experience.
+
+And it is not for those still in acute crisis. If you're still in the active stage of your own healing, this book will wait for you. It's not going anywhere.
+
+**This book is for those ready to serve from overflow—not from emptiness.**
 
 ---
 
 ## How to Use This Book
 
-*To be written*
+### Read in Order or By Need
+
+The chapters build progressively, but different readers may need different paths:
+
+- **Shadow work focus:** Start with Part II (The Shadow of the Guide)
+- **Ethics focus:** Start with Part III (Ethical Foundations)
+- **Sustainability focus:** Start with Part IV (Sustainable Practice)
+- **Content creators:** Start with Part V (The Path of the Guide)
+- **Complete journey:** Read front to back
+
+### Use the Self-Assessment Tools
+
+This book includes checklists and self-assessment tools in the appendices. Use them honestly. They're designed to help you see what you might not want to see.
+
+### Return to the Field Notes
+
+The Field Notes throughout anchor these concepts in lived experience. They show what the shadow looks like, what clean helping feels like, what the journey from one to the other requires.
+
+### Work with Support
+
+If you're in a helping profession or training for one, this book is a companion to supervision—not a replacement. Bring what arises here to your own support systems.
 
 ---
 
-## A Note Before You Begin
+## A Note on "Helper"
 
-> *You feel called to help.*
->
-> *Maybe it's because you know what it's like to be in the dark. Maybe it's because someone helped you, and you want to pass that forward. Maybe people just show up at your door with their pain, and you've never known how to turn them away.*
->
-> *This book is not here to tell you to stop helping.*
->
-> *It's here to teach you how to help without disappearing.*
->
-> *Because the world needs guides who are grounded, boundaried, and sustainable. Not martyrs who burn out. Not rescuers who need to be needed. Not wounded healers hiding in the role.*
->
-> *Your healing is your credential. Your boundaries are your offering.*
+Throughout this book, we use "helper" broadly.
+
+You might be:
+- A licensed therapist or counselor
+- A coach (life, executive, recovery, trauma-informed)
+- A healer (bodyworker, energy worker, somatic practitioner)
+- A content creator (podcaster, author, course creator, social media educator)
+- A mentor or sponsor in recovery programs
+- A teacher or educator
+- The friend everyone comes to
+- The family member who holds it all together
+- A pastor, rabbi, spiritual director, or faith leader
+
+**If people bring their pain to you and you feel called to help—this book is for you.**
+
+The principles apply across contexts. The shadow shows up everywhere. The need for sustainability is universal.
 
 ---
 
-**Status:** Placeholder — Content Not Yet Written
+## A Note on Chapter 12 of Volume 4
 
+If you've read Volume 4, you encountered "The Shadow of the Healer."
+
+That chapter introduced something important: the shadow side of healing work. The ways that helping can become hiding. The ways that wisdom can become identity. The ways that service can become a stage.
+
+**This entire volume is an expansion of that chapter.**
+
+What was seeded there—in a single chapter within a book about embodiment—now grows into a complete guide for those called to help.
+
+If that chapter activated something in you, this book meets that activation directly.
+
+---
+
+## Prerequisites
+
+This book is written for those who have:
+
+- Named the patterns (Volume 1)
+- Crossed the bridge (Volume 2)
+- Installed sovereignty (Volume 3)
+- Begun embodiment (Volume 4)
+
+Volume 5 (parenting) is not a prerequisite—that path is parallel, not sequential.
+
+**Critical prerequisite:** You have done—and are continuing to do—your own healing work. This is not a book for those who want to help instead of heal. It's for those who have healed enough to help from overflow.
+
+If you're not sure whether you're ready, read Part II (The Shadow of the Guide) first. It will help you discern.
+
+---
+
+## A Note on Shadow
+
+This book spends significant time on shadow.
+
+Not to shame you. Not to convince you that you shouldn't help.
+
+**Shadow work is how we stay clean.**
+
+Every gift casts a shadow. The gift of perception casts the shadow of arrogance. The gift of empathy casts the shadow of absorption. The gift of healing casts the shadow of needing to be needed.
+
+Illuminating shadow doesn't diminish the gift. It allows the gift to flow clearly.
+
+The helpers who cause harm are usually the ones who never looked at their shadow. The ones who stay clean are the ones who look regularly.
+
+This book asks you to look.
+
+---
+
+## A Note on Monetization
+
+This book addresses—in Part V—the ethics of monetizing lived experience.
+
+This is complex terrain. Some believe healing should never be commodified. Others recognize that sustainable service requires sustainable economics.
+
+We don't resolve this debate. But we name the tensions, identify the shadow traps, and offer frameworks for navigating this honestly.
+
+**If you're uncomfortable with money and helping in the same sentence, that discomfort is worth exploring.**
+
+---
+
+## Content Notice
+
+This book addresses:
+
+- The shadow sides of helping professions
+- Vicarious trauma and compassion fatigue
+- Ethical violations in helping relationships
+- The ways helping can mask unhealed wounds
+- Complex dynamics in therapeutic and coaching relationships
+
+These topics are addressed with care, but they may activate your own material—especially if you're already in a helping role.
+
+**If you find yourself defensive while reading:**
+
+That defensiveness is data. Not an indictment—an invitation. What you resist examining is often what most needs your attention.
+
+Take breaks. Ground yourself. Process with your own support system. This book will wait.
+
+---
+
+## Dedication
+
+*For everyone who helps others walk this path—*
+
+*may you walk it yourself, first and always.*
+
+*Your healing is your credential.*
+
+*Your boundaries are your offering.*
+
+---
+
+**[Continue to Chapter 1: The Guide's Manifesto →](./chapters/01-guides-manifesto.md)**

--- a/book/vol-6-guide/README.md
+++ b/book/vol-6-guide/README.md
@@ -6,6 +6,67 @@
 
 ---
 
+## ⚡ Quick Navigation
+
+### Part I — Orientation
+| Chapter | Title | Description |
+|---------|-------|-------------|
+| [Front Matter](./00-front-matter.md) | *About This Book* | Who this book is for and how to use it |
+| [Chapter 1](./chapters/01-guides-manifesto.md) | The Guide's Manifesto | Your healing is your credential |
+| [Chapter 2](./chapters/02-why-survivors-become-helpers.md) | Why Trauma Survivors Become Helpers | The seven drivers behind the calling |
+
+### Part II — The Shadow of the Guide
+| Chapter | Title | Description |
+|---------|-------|-------------|
+| [Chapter 3](./chapters/03-when-helping-is-hiding.md) | When Helping Is Hiding | The disguise that looks like generosity |
+| [Chapter 4](./chapters/04-rescuers-trap.md) | The Rescuer's Trap | When saving others keeps everyone stuck |
+| Chapter 5 | Vicarious Trauma & Compassion Fatigue | *Coming soon* |
+| Chapter 6 | When Clients Trigger Your Material | *Coming soon* |
+| Chapter 7 | The Need to Be Needed | *Coming soon* |
+
+### Part III — Ethical Foundations
+| Chapter | Title | Description |
+|---------|-------|-------------|
+| Chapter 8 | Scope of Practice: Know Your Lane | *Coming soon* |
+| Chapter 9 | The Ethics of Lived Experience | *Coming soon* |
+| Chapter 10 | Referral: When to Pass the Baton | *Coming soon* |
+| Chapter 11 | Dual Relationships & Boundary Complexity | *Coming soon* |
+| Chapter 12 | Confidentiality & Story Stewardship | *Coming soon* |
+
+### Part IV — Sustainable Practice
+| Chapter | Title | Description |
+|---------|-------|-------------|
+| Chapter 13 | Boundaried Presence | *Coming soon* |
+| Chapter 14 | The Container: Session Structure That Protects | *Coming soon* |
+| Chapter 15 | Energy Hygiene for Helpers | *Coming soon* |
+| Chapter 16 | Caseload, Capacity & Saying No | *Coming soon* |
+| Chapter 17 | Supervision & Support Systems | *Coming soon* |
+
+### Part V — The Path of the Guide
+| Chapter | Title | Description |
+|---------|-------|-------------|
+| Chapter 18 | Teaching Without Converting | *Coming soon* |
+| Chapter 19 | Content Creation as Service | *Coming soon* |
+| Chapter 20 | Building Community, Not Dependency | *Coming soon* |
+| Chapter 21 | The Business of Helping (Without Selling Out) | *Coming soon* |
+| Chapter 22 | When You Outgrow Your Audience | *Coming soon* |
+
+### Part VI — Closing
+| Chapter | Title | Description |
+|---------|-------|-------------|
+| Chapter 23 | Epilogue: The Guide's Blessing | *Coming soon* |
+
+### Appendices
+| Appendix | Title | Description |
+|----------|-------|-------------|
+| Appendix A | Session Hygiene Checklist | *Coming soon* |
+| Appendix B | Red Flags in Client Relationships | *Coming soon* |
+| Appendix C | Self-Assessment: Am I Helping or Hiding? | *Coming soon* |
+| Appendix D | Referral Resources & Scripts | *Coming soon* |
+| Appendix E | Decoder Cards for Guides | *Coming soon* |
+
+---
+
 ## ⚡ The Vision
 
 This volume is for those who've done the work and now feel called to help others. Whether you're becoming a therapist, coach, content creator, or simply the person everyone comes to — this book teaches you to hold space without losing yourself.
@@ -31,58 +92,58 @@ This book is written for those who:
 
 ---
 
-## 📚 Proposed Structure
+## 📚 Book Structure
 
 ```
 PART I: ORIENTATION
-├── Front Matter .......... How to use this book
-├── Chapter 1 ............. The Guide's Manifesto
-└── Chapter 2 ............. Why Trauma Survivors Become Helpers
+├── Front Matter .......... How to use this book ✅
+├── Chapter 1 ............. The Guide's Manifesto ✅
+└── Chapter 2 ............. Why Trauma Survivors Become Helpers ✅
 
 PART II: THE SHADOW OF THE GUIDE
-├── Chapter 3 ............. When Helping Is Hiding
-├── Chapter 4 ............. The Rescuer's Trap
-├── Chapter 5 ............. Vicarious Trauma & Compassion Fatigue
-├── Chapter 6 ............. When Clients Trigger Your Material
-└── Chapter 7 ............. The Need to Be Needed
+├── Chapter 3 ............. When Helping Is Hiding ✅
+├── Chapter 4 ............. The Rescuer's Trap ✅
+├── Chapter 5 ............. Vicarious Trauma & Compassion Fatigue 🚧
+├── Chapter 6 ............. When Clients Trigger Your Material 🚧
+└── Chapter 7 ............. The Need to Be Needed 🚧
 
 PART III: ETHICAL FOUNDATIONS
-├── Chapter 8 ............. Scope of Practice: Know Your Lane
-├── Chapter 9 ............. The Ethics of Lived Experience
-├── Chapter 10 ............ Referral: When to Pass the Baton
-├── Chapter 11 ............ Dual Relationships & Boundary Complexity
-└── Chapter 12 ............ Confidentiality & Story Stewardship
+├── Chapter 8 ............. Scope of Practice: Know Your Lane 🚧
+├── Chapter 9 ............. The Ethics of Lived Experience 🚧
+├── Chapter 10 ............ Referral: When to Pass the Baton 🚧
+├── Chapter 11 ............ Dual Relationships & Boundary Complexity 🚧
+└── Chapter 12 ............ Confidentiality & Story Stewardship 🚧
 
 PART IV: SUSTAINABLE PRACTICE
-├── Chapter 13 ............ Boundaried Presence
-├── Chapter 14 ............ The Container: Session Structure That Protects
-├── Chapter 15 ............ Energy Hygiene for Helpers
-├── Chapter 16 ............ Caseload, Capacity & Saying No
-└── Chapter 17 ............ Supervision & Support Systems
+├── Chapter 13 ............ Boundaried Presence 🚧
+├── Chapter 14 ............ The Container: Session Structure That Protects 🚧
+├── Chapter 15 ............ Energy Hygiene for Helpers 🚧
+├── Chapter 16 ............ Caseload, Capacity & Saying No 🚧
+└── Chapter 17 ............ Supervision & Support Systems 🚧
 
 PART V: THE PATH OF THE GUIDE
-├── Chapter 18 ............ Teaching Without Converting
-├── Chapter 19 ............ Content Creation as Service
-├── Chapter 20 ............ Building Community, Not Dependency
-├── Chapter 21 ............ The Business of Helping (Without Selling Out)
-└── Chapter 22 ............ When You Outgrow Your Audience
+├── Chapter 18 ............ Teaching Without Converting 🚧
+├── Chapter 19 ............ Content Creation as Service 🚧
+├── Chapter 20 ............ Building Community, Not Dependency 🚧
+├── Chapter 21 ............ The Business of Helping (Without Selling Out) 🚧
+└── Chapter 22 ............ When You Outgrow Your Audience 🚧
 
 PART VI: CLOSING
-└── Chapter 23 ............ Epilogue: The Guide's Blessing
+└── Chapter 23 ............ Epilogue: The Guide's Blessing 🚧
 
 APPENDICES
-├── Appendix A ............ Session Hygiene Checklist
-├── Appendix B ............ Red Flags in Client Relationships
-├── Appendix C ............ Self-Assessment: Am I Helping or Hiding?
-├── Appendix D ............ Referral Resources & Scripts
-└── Appendix E ............ Decoder Cards for Guides
+├── Appendix A ............ Session Hygiene Checklist 🚧
+├── Appendix B ............ Red Flags in Client Relationships 🚧
+├── Appendix C ............ Self-Assessment: Am I Helping or Hiding? 🚧
+├── Appendix D ............ Referral Resources & Scripts 🚧
+└── Appendix E ............ Decoder Cards for Guides 🚧
 ```
 
 ---
 
 ## 🧠 Neuroscience Foundation
 
-Each chapter should include:
+Each chapter includes:
 - Mirror neurons and emotional contagion in helping relationships
 - The neuroscience of compassion fatigue
 - Co-regulation vs. over-giving
@@ -173,7 +234,8 @@ This is not for those still in acute healing. It's for those ready to serve from
 
 ---
 
-**Status:** Framework Only — Chapters Not Yet Written
+**Status:** Part I and Part II (Chapters 1-4) Complete — Remaining Chapters In Development
 
 *"Your healing is your credential. Your boundaries are your offering."*
 
+**[Begin Reading →](./00-front-matter.md)**

--- a/book/vol-6-guide/chapters/01-guides-manifesto.md
+++ b/book/vol-6-guide/chapters/01-guides-manifesto.md
@@ -1,0 +1,439 @@
+# Chapter 1: The Guide's Manifesto
+
+## Your Healing Is Your Credential
+
+---
+
+You feel called to help.
+
+Maybe it's because you know what it's like to be lost in the dark—and someone held a lantern for you. Maybe it's because you've walked a path so difficult that you can't bear to watch others stumble through it alone. Maybe it's because people show up at your door with their pain, drawn by something they can't name, and you've never learned how to turn them away.
+
+Whatever brought you here, the pull is real.
+
+**But the pull is not permission.**
+
+This book is not about whether to help. It's about how to help without losing yourself. How to serve without depleting. How to hold space without absorbing. How to guide without creating dependency.
+
+The difference between a healer who helps and a healer who harms often comes down to one thing:
+
+**Whether they did their own work first.**
+
+---
+
+## Field Note (Before): The Healer Who Couldn't Stop
+
+She was the one everyone called.
+
+Breakups, job losses, family crises, addiction spirals—if someone was in trouble, her number was first on the list. She'd drop everything. Cancel her own plans. Show up at 2 AM. Give until there was nothing left.
+
+She called it generosity. Her friends called her a saint.
+
+Her therapist called it something else.
+
+"When's the last time you focused on yourself?" the therapist asked.
+
+She laughed. "I don't have that luxury."
+
+But she knew. She'd been running from her own pain for years. Every time she sat still, it caught up. Every time she was alone, the memories surfaced.
+
+Other people's crises were a relief. In their emergencies, she could forget her own.
+
+She was hiding in plain sight—behind the halo of helpfulness.
+
+---
+
+## Field Note (After): The Guide Who Helps and Stays Whole
+
+She still helps. But differently.
+
+When the phone rings at 2 AM, she can assess: Is this an emergency that requires me, or a pattern that requires boundaries?
+
+When friends come to her in crisis, she can hold space without absorbing their pain. She can listen without fixing. She can care without carrying.
+
+Some people stopped calling. The ones who needed her martyrdom, not her presence—they drifted away.
+
+But others came closer. They trusted her more now. Because she wasn't leaking desperation. She wasn't needing their crisis.
+
+She was present. Grounded. Available—but not endless.
+
+"What changed?" someone asked her.
+
+"I stopped helping instead of healing. Now I help because I've healed."
+
+---
+
+## The Fundamental Distinction
+
+There are two kinds of helpers in the world:
+
+**Those who help from fullness.**
+They've done their work. They've faced their own wounds. They've learned to regulate their own nervous systems. They help because they have something to offer—not because they need to offer something.
+
+**Those who help from emptiness.**
+They're still running from their own pain. They help to feel valuable. They help to distract from their own unprocessed material. They help because without helping, they don't know who they are.
+
+The first creates sustainable change.
+The second creates dependency—and burnout.
+
+**This book is about becoming the first kind.**
+
+Not because the second kind is bad. But because the second kind is unsustainable—and often, without knowing it, harmful.
+
+---
+
+## The Wounded Healer Archetype
+
+Carl Jung gave us a powerful concept: the wounded healer.
+
+The idea is simple: those who have been wounded can become healers precisely because of their wounds. Having walked through suffering, they understand it from the inside. They don't theorize about pain—they've lived it.
+
+This is true. And it's powerful.
+
+**But it's incomplete.**
+
+Because there's a difference between a wound that has been tended and a wound that is still bleeding.
+
+A surgeon who has survived cancer can bring profound empathy to oncology patients. But a surgeon who is actively bleeding cannot operate. Their wounds would contaminate the patient.
+
+The same is true of psychological and emotional helping.
+
+Your wounds are part of your qualification. But only if they've been tended. Only if they've scarred over. Only if you can touch them without flooding.
+
+**The question is not: Were you wounded?**
+
+**The question is: Have you healed enough to help?**
+
+---
+
+## What "Healed Enough" Actually Means
+
+Let's be specific.
+
+"Healed enough" does not mean:
+- You have no more work to do
+- You never get triggered
+- Your past no longer affects you
+- You've achieved enlightenment
+- You've figured it all out
+
+**"Healed enough" means:**
+
+- You can tolerate your own distress without needing to discharge it onto others
+- You can hear someone else's story without flooding into your own
+- You can sit with uncertainty without rushing to fix
+- You can be triggered and return to regulation in a reasonable timeframe
+- You can let someone else have their experience without making it about you
+- You can acknowledge the limits of your competence
+- You can receive feedback without crumbling or defending
+- You can fail without your identity collapsing
+- You can rest
+
+If these feel solid—mostly stable, with occasional wobbles—you may be ready.
+
+If several of these feel aspirational rather than actual—you may need more time in your own work before taking on others'.
+
+**This is not a judgment. It's a kindness.**
+
+Rushing to help before you're ready harms both you and those you're trying to help.
+
+---
+
+## The Cost of Helping Too Soon
+
+When helpers step into their role before they're ready, predictable patterns emerge:
+
+**They absorb instead of witness.**
+Without solid boundaries, other people's pain floods into their system. They leave sessions exhausted, carrying material that isn't theirs.
+
+**They fix instead of hold.**
+Unable to tolerate distress (theirs or others'), they rush toward solutions. They give advice when presence is what's needed. They cut short the descent because they can't handle being in the darkness.
+
+**They need the role too much.**
+The helper role becomes identity. Without clients/friends/people who need them, they feel purposeless. This need bleeds into the relationship, creating subtle pressure for the person they're helping to stay sick enough to keep needing them.
+
+**They project their story onto others.**
+They see their own wounds everywhere. They interpret through the lens of what happened to them. They can't perceive the person in front of them—only the echo of themselves.
+
+**They burn out.**
+Operating from emptiness, they drain themselves to zero, then drain themselves past zero. They become depleted, resentful, sick. And then they can't help anyone—including themselves.
+
+---
+
+## Field Note: The Coach Who Couldn't Stop Seeing Her Mother
+
+She was good at pattern recognition. Too good.
+
+Every time a client described a controlling dynamic, she saw her mother. Every time someone mentioned emotional manipulation, she felt the familiar heat in her chest.
+
+She thought she was using her experience. She was actually projecting it.
+
+Her supervisor noticed first: "You keep interpreting control where the client hasn't named it. What if you're ahead of them?"
+
+She bristled. Then she reflected. Then she realized:
+
+She wasn't helping clients see their patterns. She was helping herself re-process hers—using their sessions.
+
+It wasn't malicious. It was unconscious. But it was still a problem.
+
+She took three months off. Deepened her own therapy. Learned to notice when she was in her story versus in theirs.
+
+When she came back, she could see more clearly. Because she wasn't looking through her own wound anymore.
+
+---
+
+## Neuroscience Lens: The Helper's Brain
+
+The impulse to help has neurobiological roots—and neurobiological risks.
+
+**Mirror Neurons:**
+When we witness someone in distress, mirror neurons in our brain fire as if we were experiencing the distress ourselves. This is the basis of empathy—we literally feel what others feel.
+
+For helpers, this means: you're not imagining that you pick up other people's emotions. You're actually, neurologically, absorbing them.
+
+Without training, this becomes overwhelming. With training, it becomes a tool.
+
+**Dopamine and the Helper's High:**
+Helping others triggers dopamine release. It feels good. This is adaptive—it reinforces prosocial behavior.
+
+But it can also become addictive. The helper's high can become a substitute for addressing your own pain. You get a hit of dopamine from helping, which temporarily masks your own distress. Then the distress returns, and you need another hit.
+
+This is how helping becomes compulsive.
+
+**Cortisol and Vicarious Stress:**
+When you absorb others' distress repeatedly, your stress hormones stay elevated. Your body doesn't fully distinguish between your stress and theirs. Over time, this creates the same physiological effects as chronic stress: compromised immune function, sleep disruption, anxiety, depression.
+
+This is the mechanism of compassion fatigue. It's not a character flaw—it's physiology.
+
+**The Vagal Balance:**
+Your vagus nerve regulates your stress response. High vagal tone allows you to flexibly move between activation and rest. It allows you to feel distress without being overwhelmed by it.
+
+Helpers with low vagal tone will struggle to hold space without flooding. Building vagal tone—through the practices in this book—is essential for sustainable helping.
+
+**Translation:** Your nervous system is the instrument of your work. If it's not well-maintained, your work will suffer.
+
+---
+
+## The Permission You've Been Waiting For
+
+If you're reading this and realizing you may not be ready—that's not failure. It's wisdom.
+
+**Permission:** You are allowed to continue your own healing before becoming a guide for others.
+
+There is no rush. The work will wait.
+
+The people who need you will still need you when you're ready.
+
+And when you are ready—when you've done enough of your own work to serve from overflow—you'll be far more effective than if you started before you were ready.
+
+**Taking time to heal is not selfish. It's responsible.**
+
+It's the most important thing you can do for the people you will eventually help.
+
+---
+
+## The Permission You Didn't Know You Needed
+
+And if you're reading this and realizing you ARE ready—but you've been doubting yourself:
+
+**Permission:** You are allowed to step into this work.
+
+Your wounds don't disqualify you. Your past doesn't disqualify you. Your lack of credentials doesn't disqualify you (depending on what you're offering).
+
+What qualifies you is:
+- That you've done the work
+- That you continue to do the work
+- That you're honest about what you don't know
+- That you're committed to sustainability
+- That you're willing to look at your shadow
+
+If those are true, you may be more ready than you realize.
+
+---
+
+## The Guide vs. The Guru
+
+This book is about becoming a guide—not a guru.
+
+**The Guru:**
+- Claims special knowledge
+- Needs followers
+- Resists questioning
+- Creates dependence
+- Positions above
+- Seeks recognition
+- Identity is tied to the role
+
+**The Guide:**
+- Shares what they've learned
+- Wants people to find their own way
+- Welcomes questions
+- Builds capacity
+- Walks alongside
+- Serves without needing credit
+- Is bigger than the role
+
+The guru needs you to need them.
+The guide works to make themselves unnecessary.
+
+**This book teaches the path of the guide.**
+
+---
+
+## What Sustainable Helping Looks Like
+
+Sustainable helping has observable characteristics:
+
+**You give from overflow, not deficit.**
+You have more than enough for yourself. What you offer others is the excess, not the core.
+
+**You can refuse without guilt.**
+When you don't have capacity, you can say no. You don't carry requests beyond your ability.
+
+**You're not attached to outcomes.**
+You do the work; they do the changing. You're not responsible for their transformation. You offer the invitation; they decide whether to accept.
+
+**You can celebrate their independence.**
+When they no longer need you, you're glad. Their growth doesn't threaten your identity.
+
+**You maintain your own practices.**
+You don't abandon your own healing to focus on others. You continue therapy, supervision, self-care—whatever keeps you whole.
+
+**You have boundaries that are visible to others.**
+People know what you offer and what you don't. Your limits are clear, not discovered through burnout.
+
+**You can receive.**
+You're not only a giver. You can be held, witnessed, cared for. The flow moves both ways.
+
+---
+
+## The Manifesto
+
+Here is what this book stands for:
+
+**Your healing is your credential.**
+Not certificates. Not titles. Not years of experience. What qualifies you to help is that you've done—and are doing—your own work.
+
+**Your boundaries are your offering.**
+Clean boundaries don't make you less helpful. They make you sustainable. They model what you're teaching. They protect both you and the people you serve.
+
+**Helping from emptiness harms.**
+It may look like generosity. It's actually self-abandonment. And it creates dependency in those you're trying to free.
+
+**The goal is to become unnecessary.**
+Not indispensable. A guide who creates dependency has failed. A guide who empowers others to find their own way has succeeded.
+
+**Shadow work is not optional.**
+Every gift casts a shadow. The helpers who cause harm are the ones who never look at theirs. Looking at your shadow is not self-indulgence—it's professional responsibility.
+
+**Sustainability is not selfishness.**
+Taking care of yourself is how you take care of your work. Burnout serves no one. Rest is part of the practice.
+
+**You cannot give what you don't have.**
+This is the core truth. All the techniques, all the training, all the good intentions—none of it matters if you're running on empty. Fill yourself first. Then offer from the overflow.
+
+---
+
+## The Question This Book Answers
+
+How do I help others without losing myself?
+
+That's the question underneath every chapter that follows.
+
+The chapters on shadow will show you where your helping might be hiding old wounds.
+
+The chapters on ethics will show you how to navigate the complex boundaries of this work.
+
+The chapters on sustainability will show you how to protect your capacity over the long term.
+
+The chapters on path will show you how to offer your gifts—through whatever medium calls you—without compromising your integrity.
+
+All of it serves this one inquiry: **How do I help without harm—to them or to me?**
+
+---
+
+## A Practice: The Readiness Inventory
+
+Before you continue, take stock.
+
+Answer honestly:
+
+1. **Am I currently in acute crisis?** If yes, this is not the time to focus on helping others. Get stable first.
+
+2. **Do I have my own support system?** Therapist, supervisor, trusted peers, practices that hold me?
+
+3. **Can I tolerate distress without needing to fix it immediately?** Can I sit with discomfort—mine or others'—without rushing toward resolution?
+
+4. **When I imagine someone no longer needing me, how do I feel?** Relieved? Glad? Or threatened? Purposeless?
+
+5. **What do I get from helping?** Be honest. Is it service? Meaning? Identity? Distraction from my own pain?
+
+6. **How do I respond to feedback about my helping?** Can I receive it? Do I defend? Crumble? Dismiss?
+
+7. **What happens when I'm not helping?** Do I feel at peace? Or do I feel restless, empty, unsure who I am?
+
+There's no scoring system. Just notice what arises. What you notice is information.
+
+---
+
+## A Practice: The Overflow Check
+
+Use this before helping interactions (sessions, calls, support conversations):
+
+1. **Check your reservoir.** On a scale of 1-10, how full is your internal tank? If it's below 6, proceed with extra caution—or reschedule.
+
+2. **Clarify your capacity.** What do you actually have to give right now? Time? Energy? Attention? Be honest.
+
+3. **Set your boundary in advance.** How long will this go? What will you not take on? Decide before you begin.
+
+4. **Name what you need after.** What will refill you? Time alone? Movement? Nature? Plan your recovery.
+
+This takes two minutes. It prevents hours of depletion.
+
+---
+
+## Reader Reflection
+
+- What draws me to helping work? What's the honest answer—not the noble one?
+- Am I helping from overflow or emptiness? If I'm honest?
+- What am I afraid would happen if I stopped helping?
+- What does my helping give me that I'm not getting elsewhere?
+- Am I running from my own pain by focusing on others' pain?
+- What does "healed enough" mean to me? Am I there?
+
+**Body cue to notice:** The compulsion to help, the relief when someone needs you, the discomfort when you're not needed
+
+**Practice:** Overflow Check (before helping interactions)
+
+---
+
+## Integration Line
+
+> *"Your healing is your credential. Your boundaries are your offering."*
+
+---
+
+## Closing Note for This Chapter
+
+If you're reading this book, you probably already help.
+
+The question is not whether you'll help—it's whether you'll help sustainably. Whether you'll help cleanly. Whether you'll help in a way that serves rather than depletes.
+
+The impulse to help is beautiful. It's one of the best things about being human.
+
+But the impulse is not enough. It needs to be trained. Contained. Integrated with shadow work and boundary work and self-awareness.
+
+**This book is that training.**
+
+Not to make you less helpful. To make you helpful for the long term. To make your helping sustainable, clean, and truly effective.
+
+You can help others walk this path.
+
+But first, you have to walk it yourself.
+
+That's the manifesto: **Your healing is your credential. Your boundaries are your offering.**
+
+Let's begin.
+
+---
+
+**[Continue to Chapter 2: Why Trauma Survivors Become Helpers →](./02-why-survivors-become-helpers.md)**

--- a/book/vol-6-guide/chapters/02-why-survivors-become-helpers.md
+++ b/book/vol-6-guide/chapters/02-why-survivors-become-helpers.md
@@ -1,0 +1,401 @@
+# Chapter 2: Why Trauma Survivors Become Helpers
+
+## The Pull Is Not Random
+
+---
+
+It's not a coincidence that you're drawn to this work.
+
+Look around any therapy training program, any coaching certification, any healing arts community. You'll find a striking pattern: many—perhaps most—of the people there have experienced significant trauma.
+
+This isn't random. It's not coincidence. It's not even primarily about empathy, though that's part of it.
+
+**There are specific, identifiable reasons why those who have been wounded become those who heal.**
+
+Understanding these reasons matters. Not to pathologize your calling—but to ensure your calling doesn't become another form of survival.
+
+---
+
+## Field Note: The Therapist in Training
+
+In her cohort of fifteen student therapists, she counted:
+
+- Four adult children of alcoholics
+- Three survivors of childhood sexual abuse
+- Five who had experienced narcissistic parents
+- Two with chronic illness backgrounds
+- One who had escaped a cult
+
+When she mentioned this to her supervisor, he wasn't surprised.
+
+"Most therapists are wounded healers," he said. "The question is whether they've done enough work on their wounds to not bleed on their clients."
+
+She thought about her own history. The reason she'd entered the field. The need to understand what had happened to her—and to make sure it didn't happen to others.
+
+Was that a calling? Or was it still survival?
+
+Maybe both. The work would be to sort one from the other.
+
+---
+
+## The Seven Drivers
+
+Through research, clinical observation, and the accounts of countless helpers, we can identify seven primary reasons trauma survivors are drawn to helping roles:
+
+### 1. Pattern Recognition
+
+When you've lived inside dysfunction, you learn to read its signals.
+
+As a child in an unpredictable home, your survival depended on reading the room. Noticing the slight tension in a parent's shoulders. Catching the microsecond before the storm.
+
+This hypervigilance—exhausting and often painful—also trains perception.
+
+**You learned to see what others miss.**
+
+The subtle manipulation. The covert control. The masked emotion. The unspoken need.
+
+These perceptual skills, forged in survival, transfer directly to helping work. You can sense what clients haven't said. You can notice what friends are hiding. You can read between the lines of any story.
+
+The gift is real. But it has shadow.
+
+**The shadow:** Your perception may be calibrated to threat. You might see danger everywhere, including where it isn't. You might project your patterns onto others, mistaking your past for their present.
+
+---
+
+### 2. The Compulsion to Prevent
+
+Many helpers are driven by a deep need to prevent others from experiencing what they experienced.
+
+*If I can just stop this from happening to someone else...*
+
+*If I can reach them before it's too late...*
+
+*If I can give them what I never had...*
+
+This is understandable. Beautiful, even. But it contains a trap.
+
+**You cannot go back and save yourself.**
+
+No matter how many people you help, you cannot retroactively fix your own childhood. You cannot undo what was done to you by undoing what's being done to them.
+
+When prevention becomes compulsion, helpers over-function. They take on too much responsibility. They insert themselves into situations that aren't theirs to fix. They burn out trying to solve the unsolvable.
+
+**The work:** Grieve what you couldn't prevent in your own life. Let that grief be separate from the help you offer now.
+
+---
+
+### 3. The Search for Meaning
+
+Trauma often shatters meaning. It asks: *Why did this happen? What was the point? Why me?*
+
+These questions can haunt for decades.
+
+One way survivors answer them is by creating meaning: *This happened so I could help others.*
+
+**The wound becomes the gift. The suffering becomes the credential.**
+
+This is not wrong. Viktor Frankl's entire logotherapy is built on the human need to find meaning in suffering. Meaning aids survival.
+
+But there's a shadow here too.
+
+If your suffering only has meaning because you help others, then stopping helping means losing meaning. Your identity becomes welded to the role. You cannot rest without feeling purposeless.
+
+**The work:** Find multiple sources of meaning. Let your helping be meaningful without being your only source of meaning.
+
+---
+
+### 4. The Mastery Attempt
+
+Psychologically, we're drawn to re-experience our wounds in contexts where we might master them.
+
+This is called **repetition compulsion**, and it's both adaptive and risky.
+
+The child who felt helpless in chaos may become the adult who enters chaotic situations—but this time as the one in control. The one who can fix things. The one with power.
+
+This isn't always conscious. It often isn't.
+
+But look at what you're drawn to help with. Is it exactly what you experienced? Are you drawn to the same wounds, the same patterns, the same dynamics?
+
+**That's not coincidence. That's your psyche seeking mastery.**
+
+The danger: you may be using others' situations to re-process your own. You may be seeking resolution you never got—through their stories, not yours.
+
+**The work:** Do your direct work. Face your own material in your own therapy, with your own support. Don't outsource your healing to the helping relationship.
+
+---
+
+### 5. The Safety of the Helper Role
+
+In many dysfunctional families, the helper role is one of the safer positions.
+
+The identified patient gets attacked. The rebel gets punished. The invisible child gets ignored.
+
+But the helper—the one who soothes, mediates, caretakes—often gets approval. Or at least, less punishment.
+
+**Helping may have been your survival strategy.**
+
+If being useful protected you as a child, you may have learned: *My value comes from what I provide. I am safe when I am needed.*
+
+This can drive adult helping behavior powerfully. Not as a calling—as a continuation of survival patterns.
+
+**The shadow:** You may have difficulty receiving. Difficulty resting. Difficulty letting others help you. Because deep down, being helped feels like being useless—and being useless feels unsafe.
+
+**The work:** Practice receiving. Practice rest. Practice allowing yourself to be cared for, even when you have nothing to offer in return.
+
+---
+
+### 6. The Empathy Expansion
+
+Trauma can freeze empathy—or it can expand it.
+
+Many survivors report that their suffering opened them to the suffering of others in ways that weren't available before. They can feel what others feel. They can meet pain without flinching (to a point).
+
+**This expanded empathy is real.** It's one of the genuine gifts of the wounded healer archetype.
+
+But it has shadows.
+
+Empathy without boundaries becomes absorption. You don't just feel with them—you feel as them. You don't just understand their pain—you carry it.
+
+And expanded empathy, when paired with a need to help, can become codependency. You're so attuned to their experience that you lose track of your own.
+
+**The work:** Train the boundary between empathy and absorption. Learn to witness without merging. Care without carrying.
+
+---
+
+### 7. The Unfinished Grief
+
+Sometimes, the pull toward helping is really the pull toward mourning.
+
+In helping others heal what you couldn't heal, you touch your own wounds indirectly. In witnessing their suffering, you witness yours. In guiding their grief, you process your own.
+
+This can be healing—if it's conscious.
+
+It becomes problematic when it's unconscious. When you're using others' processes to avoid your own. When you're metabolizing your grief through their work instead of through your own.
+
+**The shadow:** You might not notice when their process ends and yours begins. You might need them to keep grieving so you can keep processing.
+
+**The work:** Have your own dedicated space for grief. Don't confuse witness with processing.
+
+---
+
+## Neuroscience Lens: The Helper's Nervous System
+
+The seven drivers aren't just psychological—they're neurobiological.
+
+**Hypervigilance and Perception:**
+Trauma trains the amygdala to be highly reactive to threat cues. This is exhausting, but it also creates heightened perception. You literally notice more, especially social and emotional cues. This is why survivors often make excellent readers of people.
+
+**The Caregiving System:**
+The brain has a distinct neural system for caregiving, involving oxytocin and the ventral vagal complex. For some trauma survivors—especially those who had parentified roles in childhood—this system is highly developed. Caregiving feels natural, even essential.
+
+But overdevelopment of the caregiving system often correlates with underdevelopment of the receiving system. You know how to give; you struggle to take.
+
+**Dopamine and Helper's High:**
+As noted in Chapter 1, helping triggers dopamine release. For survivors who may have dysregulated reward systems due to trauma, this dopamine hit can become particularly important. Helping doesn't just feel good—it may feel like one of the few reliable sources of feeling good.
+
+This can create a pattern: distress → helping → dopamine → temporary relief → distress returns → more helping.
+
+The cycle can look like dedication. It's actually dependency.
+
+**Attachment and the Helper Role:**
+For those with anxious attachment, helping can be an attachment strategy: *If I make myself indispensable, they can't leave me.*
+
+For those with avoidant attachment, helping can be a way to connect from a safe distance: *I can be close to you through the helping role, without true vulnerability.*
+
+Both of these are relationship strategies wearing the mask of generosity.
+
+**Translation:** Your nervous system may be wired for helping in ways that aren't entirely chosen. Understanding this wiring helps you work with it consciously.
+
+---
+
+## The Reparenting Fantasy
+
+One specific driver deserves its own examination: **the reparenting fantasy**.
+
+Many survivors unconsciously enter helping roles hoping to receive what they never got.
+
+The logic is subtle:
+
+*If I become the helper I needed, maybe someone will help me.*
+
+*If I create the safe space I longed for, maybe I'll finally feel safe.*
+
+*If I give others the attunement I missed, maybe someone will attune to me.*
+
+This rarely works. Here's why:
+
+**The people you help are not positioned to help you.** There's an inherent asymmetry in helping relationships. They're coming to you for care—they're not in a position to provide it. Expecting reciprocity from clients, coaching relationships, or even friends you're helping creates impossible dynamics.
+
+**The past cannot be retroactively healed through the present.** What you needed as a child cannot be fully met now. It can be grieved. It can be tended. It can be partially addressed through therapy and healthy adult relationships. But the child part of you that needed attunement at six cannot be satisfied by clients who need you at forty.
+
+**The fantasy keeps you seeking in the wrong places.** As long as you unconsciously hope that helping will get you helped, you'll be perpetually disappointed. And you may not invest in the relationships that could actually meet your needs—because you're focused on the ones that can't.
+
+**The work:** Name the fantasy. Grieve its impossibility. Then find appropriate places to receive—therapy, peer relationships, intimate partnerships, friendships. Let helping be about them, not about finally getting what you need.
+
+---
+
+## Field Note: The Fantasy She Didn't Know She Had
+
+She'd been a coach for eight years when she finally saw it.
+
+She was in her own supervision session, processing frustration with a client who had terminated abruptly. "I gave her so much," she said. "I saw her so clearly. And then she just left."
+
+Her supervisor was quiet. Then: "What did you want from her?"
+
+The question startled her. She wasn't supposed to want anything from clients. That's not how it worked.
+
+But she sat with it. And slowly, the truth emerged.
+
+She had wanted the client to see her. To thank her. To recognize the quality of the attention she was providing. To give back.
+
+She had wanted to be met.
+
+Not sexually, not romantically—but genuinely met. Seen. Valued.
+
+The client's leaving felt like abandonment because something in her had hoped this relationship would finally give her what she'd never received.
+
+She wept in supervision that day. Not for the client. For herself. For the child who had given and given and was still waiting to receive.
+
+That grief changed her work. She stopped unconsciously seeking from clients what they couldn't give. She strengthened her own support system. She became cleaner in the role.
+
+---
+
+## The Gifts and Their Shadows
+
+Let's name this clearly:
+
+| Driver | Gift | Shadow |
+|--------|------|--------|
+| Pattern Recognition | Deep perception, ability to see dynamics | May project patterns, see threat everywhere |
+| Prevention Compulsion | Passion to protect | Cannot save yourself by saving others |
+| Search for Meaning | Purpose, motivation | If helping = only meaning, can't stop |
+| Mastery Attempt | Desire to understand and transform | Using others' material to process yours |
+| Safety of Helper Role | Skill in care, comfort with giving | Difficulty receiving, identity tied to usefulness |
+| Empathy Expansion | Deep ability to feel with others | Absorption, boundary confusion |
+| Unfinished Grief | Access to emotional depth | May need others to stay wounded |
+
+**Every driver is both.**
+
+This book is not about eliminating these drivers. It's about becoming conscious of them—so the gift can flow and the shadow can be monitored.
+
+---
+
+## The Question That Sorts Clean from Shadow
+
+When examining your pull toward helping, one question clarifies:
+
+**Am I doing this for them, or for myself?**
+
+Now—this question is tricky. Because:
+
+- It's okay to get something from helping. Meaning, connection, income—these are legitimate.
+- Pure altruism may not exist. Almost all helping has some self-interest.
+- The issue isn't whether you benefit. It's whether your benefit comes at their cost.
+
+**Clean helping:** You benefit AND they benefit. Your needs are met through appropriate channels (income, meaning, connection), and their growth is the primary aim.
+
+**Shadow helping:** You benefit at their expense. Your needs are met in ways that compromise their process—through dependency, projection, or needing them to stay stuck.
+
+---
+
+## A Practice: The Driver Inventory
+
+Take time with this reflection.
+
+For each of the seven drivers, rate on a scale of 1-5 how strongly it applies to you:
+
+1. **Pattern Recognition** — How much does "I see what others miss" drive my helping?
+
+2. **Prevention Compulsion** — How much is "stopping this from happening to others" my motivation?
+
+3. **Search for Meaning** — How much does my suffering only make sense if I help?
+
+4. **Mastery Attempt** — Am I drawn to help the exact wounds I carry?
+
+5. **Safety of Helper Role** — Did helping keep me safe as a child? Does it still?
+
+6. **Empathy Expansion** — Do I feel others' pain as strongly as my own?
+
+7. **Unfinished Grief** — Am I processing my losses through others' processes?
+
+There's no right answer. This is mapping territory, not judging it.
+
+Notice which drivers are strongest. Ask: **What work do I need to do to keep this gift and tend this shadow?**
+
+---
+
+## A Practice: The Reparenting Fantasy Inquiry
+
+Complete these sentences honestly:
+
+1. "When I help others, I hope they will..."
+2. "If I could get from my clients/friends/people I help what I never got as a child, it would be..."
+3. "The feeling I'm secretly seeking through helping is..."
+4. "If I stop helping, I'm afraid I'll never..."
+
+Read your answers. Notice what arises. This is not for judgment—it's for clarity.
+
+Then ask: **Where can I actually get what I need?** Make a list of relationships and contexts where receiving is appropriate.
+
+---
+
+## A Practice: Separating Story from Story
+
+Use this when you notice you're very activated by someone's material:
+
+1. **Pause.** Notice the intensity of your reaction.
+
+2. **Ask:** Is this about them, or is this about me?
+
+3. **Check for echoes.** Does their story remind you of your story? Are you responding to what they're describing, or to your own memory?
+
+4. **Ground.** Feel your feet. Notice your breath. Remember: you are here, now—not there, then.
+
+5. **Proceed from presence.** If you're clear this is about them, continue. If you're not clear, slow down. You don't have to sort it all out now—but you do have to notice.
+
+---
+
+## Reader Reflection
+
+- Which of the seven drivers resonates most strongly for me?
+- What am I secretly hoping helping will give me?
+- How did the helper role function in my family of origin?
+- What wound am I most drawn to help others with? Is it my wound?
+- Where do I actually get care? Is it enough?
+- What would I feel if I couldn't help for a year?
+
+**Body cue to notice:** The pull toward helping, the urgency to intervene, the relief when needed
+
+**Practice:** Driver Inventory (quarterly check-in)
+
+---
+
+## Integration Line
+
+> *"The pull toward helping is real. The question is what else it's carrying."*
+
+---
+
+## Closing Note for This Chapter
+
+You're not broken for being drawn to helping.
+
+The pull comes from real experiences. Real perception. Real empathy. Real desire to prevent suffering.
+
+**These are not problems. They're features.**
+
+But features can malfunction. The same pattern recognition that makes you perceptive can make you project. The same empathy that lets you feel with can collapse you into absorption. The same drive to prevent can become compulsion.
+
+This chapter isn't about pathologizing your calling. It's about understanding it fully—including the parts you might not have looked at.
+
+Because understanding is what allows transformation.
+
+When you know why you help—all the reasons, not just the noble ones—you can help cleanly. You can tend the shadows before they take over. You can receive where receiving is appropriate and give where giving serves.
+
+**The pull toward helping is valid.**
+
+**The work is to ensure it serves life—including your own.**
+
+---
+
+**[Continue to Chapter 3: When Helping Is Hiding →](./03-when-helping-is-hiding.md)**

--- a/book/vol-6-guide/chapters/03-when-helping-is-hiding.md
+++ b/book/vol-6-guide/chapters/03-when-helping-is-hiding.md
@@ -1,0 +1,443 @@
+# Chapter 3: When Helping Is Hiding
+
+## The Disguise That Looks Like Generosity
+
+---
+
+This is the chapter you might resist.
+
+It asks a question that threatens the helper's identity:
+
+**What if the helping isn't about them—it's about avoiding yourself?**
+
+What if all the time, energy, and attention you pour into others is a sophisticated strategy for not looking at your own material?
+
+What if your generosity is a disguise?
+
+This is uncomfortable. But it's also necessary.
+
+Because helping that hides is not actually helping. It's self-abandonment wearing the mask of service.
+
+---
+
+## Field Note (Before): The Selfless One
+
+She was known for having no needs.
+
+Always available. Never complaining. The first to volunteer and the last to ask for anything in return.
+
+"She's so selfless," people would say, with admiration.
+
+But her therapist saw something different.
+
+"When's the last time you attended to your own needs?" the therapist asked.
+
+She paused. Then: "I don't really have needs. I mean, not like other people."
+
+The therapist waited.
+
+"Okay," she admitted. "I guess I don't let myself have needs. It's easier to focus on everyone else."
+
+"Easier how?"
+
+She felt the familiar tightness in her chest. The thing she didn't want to look at. The darkness she had been orbiting for years, never quite entering.
+
+"If I stop focusing on everyone else, I'll have to focus on me. And I don't want to look at what's there."
+
+The selflessness wasn't generosity. It was avoidance with a halo.
+
+---
+
+## Field Note (After): The Woman Who Finally Sat Still
+
+Three years later, same woman.
+
+She still helps. But less. And differently.
+
+When the urge to help arises, she pauses. Asks: *Is this mine to do? Or am I using this to not be with myself?*
+
+Sometimes the answer is clear—this is genuine service, and she has capacity. She gives freely.
+
+Sometimes the answer is uncomfortable—this is avoidance in disguise. She recognizes the pull toward escape and chooses differently. She sits still. She feels what's there.
+
+The people around her are confused at first. Some are disappointed—they'd grown accustomed to her endless availability.
+
+But she's more present now. When she helps, it's cleaner. And when she's alone with herself, she can finally bear it.
+
+The darkness she'd been avoiding? She found grief in there. And underneath the grief, rest.
+
+---
+
+## The Anatomy of Hiding in Helping
+
+Hiding in helping has a recognizable structure:
+
+**Step 1: The discomfort arises.**
+You feel something you don't want to feel. Emptiness. Grief. Fear. Shame. Old memories surfacing. Uncomfortable truths about your life.
+
+**Step 2: The helper impulse activates.**
+Instead of staying with the discomfort, you pivot outward. *Who needs me? What can I do? Where is there a problem I can solve?*
+
+**Step 3: The focus shifts.**
+Your attention leaves your own experience and locks onto someone else's. Now their problem is the problem. Their pain is what needs tending. Your discomfort fades to background noise.
+
+**Step 4: The temporary relief.**
+It works—sort of. The helping creates a sense of purpose, connection, and distraction. You feel better. You feel useful. You feel like yourself again.
+
+**Step 5: The discomfort returns.**
+Because it was never actually processed. It was just displaced. So it comes back. And you need to help again. And again. And again.
+
+This is the cycle of hiding in helping.
+
+---
+
+## What You Might Be Hiding From
+
+The content varies, but common themes emerge:
+
+**Your own grief.**
+Loss you haven't fully mourned. Relationships that ended. Dreams that didn't come true. Parts of yourself you had to abandon. Helping others grieve is easier than grieving yourself.
+
+**Your own wounds.**
+Trauma you haven't fully processed. Abuse you've named but not metabolized. Patterns you understand intellectually but haven't felt through. Helping others heal their wounds is easier than healing yours.
+
+**Your own emptiness.**
+The void that opens when you're not useful. The question of who you are when you're not needed. The fear that without a function, you might be nothing. Helping fills the emptiness—temporarily.
+
+**Your own needs.**
+Needs you've learned to suppress. Needs that weren't met in childhood. Needs that feel shameful or dangerous to acknowledge. Helping others with their needs is easier than facing your own.
+
+**Your own powerlessness.**
+The fundamental helplessness of the human condition. The things you can't control. The suffering you can't prevent. Helping creates an illusion of control—if you can save them, maybe you're not so helpless after all.
+
+**Your own dissatisfaction.**
+With your relationship, your career, your life. Rather than face what isn't working and make difficult changes, you focus on others. Their lives become more interesting than yours—because yours is too painful to examine.
+
+**Your own mortality.**
+At the deepest level, some helping is an attempt to outrun death. To create meaning. To leave a legacy. To matter. To not disappear. Facing mortality directly is harder than staying busy serving.
+
+---
+
+## The Twelve Signs
+
+How do you know if your helping is hiding?
+
+Watch for these indicators:
+
+**1. You can't stop.**
+You say you want to cut back, but you don't. You recognize you're overextended, but you keep saying yes. The compulsion is stronger than your stated intention.
+
+**2. Sitting still feels unbearable.**
+When you're not helping, you feel restless, anxious, or depressed. Stillness brings up content you don't want to face. You'd rather be busy.
+
+**3. Your own life is neglected.**
+Your house, your health, your relationships, your creative projects—they're on hold while you attend to others. Your life is always deprioritized for someone else's emergency.
+
+**4. You feel resentful—but won't stop.**
+Part of you is angry about how much you give. But you don't reduce the giving. You just carry the resentment alongside it.
+
+**5. Being needed feels better than being loved.**
+You're more comfortable being useful than being wanted for yourself. The helper role feels safer than vulnerability.
+
+**6. You don't know who you are when you're not helping.**
+Your identity is fused with the helper function. Without someone to help, you feel purposeless. "Helper" isn't something you do—it's who you are.
+
+**7. You get anxious when they don't need you.**
+Their independence threatens you. If they're okay, what's your role? You might find yourself subtly undermining their progress—or feeling relieved when they struggle again.
+
+**8. You avoid people who would challenge you.**
+You surround yourself with people who need you, not people who see you. Those who would push you to grow are kept at a distance.
+
+**9. You rarely receive.**
+The flow only goes one way—out. When people try to give to you, you deflect, minimize, or redirect to their needs. You don't know how to take in.
+
+**10. Your helping has urgency.**
+It doesn't feel like a choice—it feels like a compulsion. There's a driven quality, a sense that you have to help now. This urgency is often sourced in your material, not theirs.
+
+**11. You choose helpers who need help over helpers who don't.**
+In your own relationships, you pick fixer-uppers. Not because you're drawn to their essence—because you're drawn to their brokenness. It gives you something to do.
+
+**12. Underneath the helping, there's exhaustion.**
+Not physical tiredness—soul tiredness. A deep weariness that rest doesn't touch. Because you've been running for so long.
+
+---
+
+## Neuroscience Lens: The Avoidance Circuit
+
+Your brain has well-established circuits for avoidance—and they can hijack helping behavior.
+
+**The Amygdala and Threat Detection:**
+When painful material approaches consciousness, your amygdala registers it as threat. It triggers the same circuits that would activate if you encountered a physical danger.
+
+For trauma survivors, this threat response is often heightened. Internal experience—your own emotions, memories, sensations—can feel genuinely dangerous. The brain treats inner material the same way it would treat an external predator.
+
+**The Pivoting Response:**
+When threatened, the brain looks for escape routes. If physical escape isn't available, it pivots to other strategies: distraction, suppression, action.
+
+Helping is a particularly elegant pivot. It redirects attention outward. It creates a sense of purpose. It triggers dopamine (reward). And it's socially praised—no one questions the person who's "always there for others."
+
+**The Numbing of Self-Awareness:**
+Chronic other-focus can actually reduce activity in the brain regions associated with self-awareness. You don't just distract from yourself—you gradually lose the capacity for self-reflection.
+
+This is why long-term helper-hiders often have difficulty answering basic questions about their own feelings, needs, or desires. The circuits for self-awareness have atrophied.
+
+**The Freeze Response:**
+Interestingly, some hiding in helping is actually a freeze response in disguise. Rather than fight or flight, the person freezes—but it looks like action because they're so busy with others. The inner freezing (emotional deadness, disconnection from self) is masked by outer activity.
+
+**Translation:** Your nervous system may have learned that helping is safer than feeling. Unlearning this requires patient, repeated practice of staying with internal experience.
+
+---
+
+## Field Note: The Coach Who Filled Her Calendar
+
+She noticed it first in her scheduling.
+
+Her calendar was always full. Not with clients—she wasn't that busy with paid work. But with friends who needed support. Family members in crisis. Volunteer commitments. Anyone who needed anything.
+
+The moment a slot opened, she'd fill it.
+
+Her coach asked: "What would happen if you left a day empty?"
+
+She felt the panic immediately. "I don't know. I'd probably just... sit there."
+
+"And what would happen then?"
+
+"I'd feel useless. Or I'd have to think about my life. My marriage isn't great. My own goals are stalled. If I stop helping everyone, I'll have to face all of that."
+
+She recognized it then. The busy calendar wasn't generosity. It was a defensive structure against her own life.
+
+That recognition changed everything—not immediately, but gradually. She started leaving gaps. Sitting with the discomfort. Facing what was there.
+
+Her marriage eventually ended. But it needed to. She'd been using helping to avoid that truth for years.
+
+---
+
+## The Self-Abandonment Structure
+
+Hiding in helping is a form of self-abandonment.
+
+You leave yourself—your needs, your pain, your life—to attend to others.
+
+This mirrors what may have happened in your family of origin:
+
+- If your parents' needs always came first, you learned that your needs don't matter.
+- If you were only valued for what you provided, you learned that your worth is in your function.
+- If attending to yourself was called selfish, you learned to feel guilty about your own needs.
+- If no one was there for you, you learned not to expect care—and to provide it instead.
+
+**Hiding in helping is the perpetuation of childhood patterns into adulthood.**
+
+You're doing to yourself what was done to you: abandoning your inner experience to focus on others.
+
+The difference is that now, you're the one doing the abandoning. Which means you're also the one who can stop.
+
+---
+
+## Field Note: The Sponsor Who Couldn't Sit with Himself
+
+He'd been sober for fifteen years. A respected sponsor in his recovery community.
+
+He had five sponsees. Took calls at any hour. Never missed a meeting. Was known for his availability.
+
+But his own sponsor noticed something.
+
+"When's the last time you did your own step work?" the old-timer asked.
+
+He deflected. "I've done the steps."
+
+"Have you done them recently? Is there something you're avoiding?"
+
+He bristled. Then softened. The old-timer knew him too well.
+
+"There's grief I haven't touched," he admitted. "About my father. He died while I was still using, and I never really... I just haven't gone there."
+
+"And the sponsoring? Does it help you not go there?"
+
+The question landed. Of course it did. Every time the grief approached, there was a sponsee in crisis. Every time he was alone, his phone rang. It wasn't coincidence—he'd built a life where he never had to be with himself.
+
+"I think I need to take a break," he said.
+
+It took six months. Six months of sitting with the grief he'd been running from for fifteen years. It was the hardest work he'd done since getting sober.
+
+When he came back to sponsoring, it was different. Cleaner. Because he wasn't using their recovery to avoid his own.
+
+---
+
+## What Clean Helping Looks Like
+
+For contrast, here's what helping looks like when it's not hiding:
+
+**You can choose not to help.**
+There's no compulsion. You can say no, and you don't feel like you're abandoning your identity. You help because you want to, not because you have to.
+
+**You can sit still.**
+When you're alone, you can be with yourself. Stillness doesn't trigger panic or frantic activity. You're okay being unneeded.
+
+**Your own life is tended.**
+Your health, relationships, home, and personal goals get attention. You're not sacrificing your life for others—you're living your life, and helping is part of it.
+
+**You feel satisfied, not resentful.**
+Helping feels good—and complete. You're not accumulating a ledger of unreturned favors. You give freely and release.
+
+**You can receive.**
+When people offer you care, you can take it in. You don't have to deflect, minimize, or quickly redirect to their needs.
+
+**You know who you are beyond helping.**
+The role is something you do, not something you are. You have other sources of identity, meaning, and purpose.
+
+**You're happy when they don't need you.**
+Their growth and independence is the goal. When they no longer need you, you feel accomplished, not abandoned.
+
+---
+
+## Key Distinctions
+
+| Hiding in Helping | Clean Helping |
+|-------------------|---------------|
+| Compulsive | Chosen |
+| Avoids your own material | Coexists with your own work |
+| Creates dependency | Builds independence |
+| Cannot be refused | Can say no freely |
+| Driven by inner emptiness | Flows from inner fullness |
+| Identity-fused | Role-contained |
+| Resentful underneath | Satisfying |
+| Depleting | Sustainable |
+| Rarely receives | Gives and takes |
+| Threatened by their growth | Celebrates their growth |
+
+---
+
+## The Invitation Underneath
+
+Hiding in helping often contains a secret invitation:
+
+**Come find me.**
+
+Buried underneath all the other-focus is a longing to be found. To be sought after for who you are, not what you provide. To have someone pursue you instead of the other way around.
+
+But the hiding makes this impossible. The more you hide in helping, the more invisible you become. People see the helper function, not the person underneath. And so the longing goes unmet—which drives more hiding—which creates more invisibility.
+
+**The way out is counterintuitive:**
+
+You have to stop hiding to be found. You have to show yourself—your needs, your vulnerabilities, your non-helper self—to be truly seen.
+
+This requires letting the helper mask drop. Allowing people to meet you in your human messiness. Risking that without the function, you might be less valued—but discovering that the right people will value you more.
+
+---
+
+## A Practice: The Avoidance Audit
+
+Use this when you notice the urge to help:
+
+**Step 1: Pause before acting.**
+When the helper impulse arises, don't act immediately. Take three breaths.
+
+**Step 2: Check your interior.**
+What's happening inside you right now? What feeling or experience was present before the impulse arose?
+
+**Step 3: Ask the question.**
+"Am I moving toward something—or away from something?"
+
+If toward: What am I genuinely called to give here?
+If away: What am I avoiding by focusing on this?
+
+**Step 4: Name what you're running from.**
+If this is avoidance, name it specifically. "I'm running from the conversation I need to have with my partner." "I'm avoiding the grief about my mother." "I'm hiding from the emptiness."
+
+**Step 5: Decide consciously.**
+You might still choose to help—but now it's a choice, not an automatic escape. And you know what you'll need to come back to later.
+
+---
+
+## A Practice: The Stillness Challenge
+
+For one week:
+
+1. **Build in gaps.** Schedule at least two hours each day where you have nothing planned and no one to help.
+
+2. **Notice the pull.** When the urge to fill the gaps arises (text someone, check on someone, offer something), don't act on it. Just notice.
+
+3. **Stay with what's there.** Whatever comes up in the stillness—sit with it. You don't have to fix it. Just experience it.
+
+4. **Journal the content.** What thoughts, feelings, or sensations appeared when you stopped helping? What were you avoiding?
+
+5. **Reflect.** At the end of the week, what did you learn about what hiding underneath your helping?
+
+This practice is harder than it sounds. The pull toward activity can be powerful. Treat the discomfort as information.
+
+---
+
+## A Practice: The Return to Self
+
+Use this after helping interactions where you may have over-given:
+
+**Step 1: Physical return.**
+Feel your body. Notice your feet on the ground. Your breath in your chest. The weight of your body in the chair.
+
+**Step 2: Energetic return.**
+Imagine calling back any attention or energy you left with the other person. Not coldly—just clearly. What's theirs is theirs. What's yours returns to you.
+
+**Step 3: Self-inquiry.**
+Ask: "What do I need right now?" Listen for the answer. It might be rest, food, movement, solitude, or connection with someone who can hold you.
+
+**Step 4: Meet the need.**
+Don't skip to the next helping task. Tend to yourself first. Even if briefly.
+
+This trains the pattern of returning—instead of perpetually giving outward without coming back.
+
+---
+
+## Reader Reflection
+
+- When I'm alone with nothing to do, what comes up?
+- What am I using helping to avoid?
+- Who would I be if I weren't the helper?
+- What grief, fear, or truth am I running from?
+- What would I have to face if I stopped focusing on everyone else?
+- Can I tolerate being still? For how long?
+- What is the invitation underneath my hiding?
+
+**Body cue to notice:** The relief when someone needs you, the panic when you're not needed, the restlessness in stillness
+
+**Practice:** Avoidance Audit (before helping interactions), Stillness Challenge (weekly)
+
+---
+
+## Integration Line
+
+> *"Hiding in helping is self-abandonment dressed as generosity."*
+
+---
+
+## Closing Note for This Chapter
+
+If you recognized yourself in these pages, that's not an indictment.
+
+Many of the world's best helpers started here—hiding in service, avoiding themselves through other-focus.
+
+**The recognition is the beginning of change.**
+
+You can't stop hiding until you see that you're hiding. And now you see.
+
+This doesn't mean you should stop helping. It means you should clean your helping. Ensure it's not contaminated with avoidance. Ensure you're serving from fullness, not fleeing from emptiness.
+
+The work ahead involves:
+- Facing what you've been avoiding
+- Tolerating stillness and its contents
+- Building an identity beyond the helper role
+- Learning to receive, not just give
+- Letting yourself be found
+
+This is harder than helping others. It's also more important.
+
+Because until you stop hiding in helping, your helping will always be compromised—by desperation, dependency, and the unconscious need to stay busy.
+
+**The goal isn't to stop helping. It's to help freely—as a choice, not an escape.**
+
+That requires facing yourself. All of yourself.
+
+Even the parts you've been running from.
+
+---
+
+**[Continue to Chapter 4: The Rescuer's Trap →](./04-rescuers-trap.md)**

--- a/book/vol-6-guide/chapters/04-rescuers-trap.md
+++ b/book/vol-6-guide/chapters/04-rescuers-trap.md
@@ -1,0 +1,517 @@
+# Chapter 4: The Rescuer's Trap
+
+## When Saving Others Keeps Everyone Stuck
+
+---
+
+The rescuer doesn't just help.
+
+The rescuer saves.
+
+Swoops in. Takes over. Fixes the problem. Solves the crisis. Carries the weight that isn't theirs to carry.
+
+And in doing so, the rescuer creates a trap—for the person they're rescuing, and for themselves.
+
+If you've spent time in the helping world, you've probably encountered the Drama Triangle: Victim, Persecutor, Rescuer. But the rescuer position deserves its own examination, because it's the one most helpers fall into without realizing it.
+
+**The rescuer's trap looks like compassion. It feels like service. And it keeps everyone stuck.**
+
+---
+
+## Field Note (Before): The Hero
+
+He was the one who fixed things.
+
+When his sister relapsed, he drove through the night to find her. When his coworker was drowning in a project, he stayed late to finish it for them. When his partner couldn't handle the finances, he took over.
+
+He told himself he was helping. Being responsible. Being good.
+
+But there was a pattern underneath.
+
+Every rescue created dependency. His sister expected him to bail her out. His coworker kept underperforming. His partner never learned to manage money.
+
+And he was exhausted. Running from crisis to crisis. Never caught up. Never at rest.
+
+He was the hero. But the story never ended.
+
+---
+
+## Field Note (After): The Person Who Stood Back
+
+Three years later.
+
+His sister relapsed again. He did something different: he told her where the treatment centers were and that he loved her. And then he didn't drive through the night.
+
+She was furious. Accused him of abandonment. Called him every name she could think of.
+
+He felt terrible—for about a week. Then something shifted.
+
+She checked herself into treatment. Without him forcing it. Without him managing it. It was her choice. Her recovery.
+
+When he saw her six months later, she said something that stayed with him: "I never thought I could do it myself. I needed you to stop rescuing me so I could find out."
+
+He learned: **the rescue was the obstacle.**
+
+---
+
+## The Drama Triangle
+
+Before we go further, let's establish the framework.
+
+In the 1960s, psychiatrist Stephen Karpman identified a social model of human interaction he called the Drama Triangle. It has three positions:
+
+**Victim:** "I can't handle this. I'm helpless. Someone save me."
+The victim feels powerless, unable to solve their own problems. They look outward for rescue.
+
+**Persecutor:** "This is your fault. You're the problem. You deserve what's happening."
+The persecutor blames, criticizes, and attacks. They hold others responsible and often feel justified in their aggression.
+
+**Rescuer:** "Let me save you. I'll fix this. You need me."
+The rescuer swoops in to solve problems, take over, and provide relief—often without being asked.
+
+**The critical insight:** These are not fixed identities. They're positions people cycle through. The rescuer who is rebuffed becomes the victim ("After all I've done!") or the persecutor ("You're so ungrateful!"). The victim who gets no rescue becomes the persecutor. And so on.
+
+**The triangle is a trap.** Once you're in it, you cycle between positions without resolution. Real change only happens when someone steps off the triangle entirely.
+
+---
+
+## Why Rescuers Are Not Helpers
+
+Here's the distinction that matters:
+
+**Helpers empower. Rescuers enable.**
+
+A helper supports someone in doing something for themselves.
+A rescuer does it for them.
+
+A helper trusts the other person's capacity.
+A rescuer assumes the other person is incapable.
+
+A helper lets them struggle productively.
+A rescuer eliminates all struggle.
+
+A helper celebrates their independence.
+A rescuer is threatened by their independence.
+
+**The rescuer needs to be needed.** This isn't service—it's attachment to a role that provides identity, purpose, and often a sense of superiority.
+
+---
+
+## The Anatomy of a Rescue
+
+Rescuing has a recognizable pattern:
+
+**Step 1: Someone expresses distress.**
+They're struggling. Something is wrong. They feel overwhelmed.
+
+**Step 2: The rescuer feels the activation.**
+A familiar pull—toward action, toward solving, toward making it better. This feels like compassion. It's often something more complex.
+
+**Step 3: The rescuer takes over.**
+Instead of supporting them in solving their own problem, the rescuer solves it for them. Takes on their task. Makes the calls they should make. Does the work they should do.
+
+**Step 4: Temporary relief (for both).**
+The person in distress feels relieved—the pressure is off. The rescuer feels valuable—they made a difference.
+
+**Step 5: Dependency deepens.**
+The person in distress learns they don't have to solve their own problems. The rescuer learns their value comes from being needed. The dynamic calcifies.
+
+**Step 6: The next crisis arrives.**
+Because nothing was actually resolved. The person never developed capacity. They need rescuing again. And the rescuer, predictably, answers the call.
+
+---
+
+## What Rescuers Get From Rescuing
+
+Rescuing isn't purely altruistic. It provides significant psychological payoffs:
+
+**A sense of superiority.**
+The rescuer is the capable one. The competent one. The one who has it together. Rescuing others reinforces this self-image.
+
+**Avoidance of own material.**
+(As discussed in Chapter 3) Focusing on others' crises means you don't have to focus on your own unresolved issues.
+
+**Identity and purpose.**
+Without someone to rescue, who are you? The rescuer role provides a stable sense of identity in an uncertain world.
+
+**Control.**
+Rescuing creates a dynamic where you have power. The victim needs you. This can feel safer than vulnerability or equality.
+
+**Protection from own vulnerability.**
+If you're always the strong one, you never have to show weakness. Rescuing keeps you in a position where your own struggles don't have to be seen.
+
+**Guaranteed connection.**
+If they need you, they won't leave. Rescuing creates bonds—codependent ones, but bonds nonetheless.
+
+**The dopamine hit.**
+Rescuing feels good. The gratitude, the relief on their face, the sense of being valuable—all trigger neurochemical reward.
+
+None of these are bad in themselves. But when they become the drivers of helping behavior, the helping is compromised.
+
+---
+
+## Field Note: The Therapist Who Couldn't Let Them Struggle
+
+She was a good therapist. Skilled. Caring. Clients loved her.
+
+But her supervisor noticed a pattern.
+
+"You move to comfort very quickly," the supervisor observed. "The moment a client feels distress, you're there with a reframe, a technique, a solution."
+
+She defended: "I don't want them to suffer unnecessarily."
+
+"And what do they learn when you always rescue them from discomfort?"
+
+She considered this. The answer was uncomfortable.
+
+They learned that discomfort was intolerable. That they couldn't handle it themselves. That she would always be there to make it better.
+
+They weren't building capacity—they were building dependency on her.
+
+The next session, she tried something different. A client was in distress, and instead of moving to fix, she simply witnessed. "This is hard," she said. "What do you notice in your body?"
+
+The client sat with it. Found their own resources. Came to their own insight.
+
+It was slower. Messier. More uncomfortable for both of them.
+
+And far more therapeutic.
+
+---
+
+## Neuroscience Lens: The Rescue Response
+
+Your brain has wiring that supports rescuing—and wiring that's compromised by it.
+
+**The Urgency Circuit:**
+When you perceive someone in distress, your sympathetic nervous system can activate as if you're in danger. This creates urgency—a felt sense that something must be done now.
+
+For those with trauma histories, this urgency circuit may be hypersensitive. You feel their distress as an emergency, even when it isn't. This drives hasty rescuing that's more about relieving your discomfort than serving them.
+
+**Mirror Neurons and Over-Identification:**
+As discussed in Chapter 2, mirror neurons fire when we observe others in emotional states. If your boundaries are porous, you don't just perceive their distress—you feel it as your own.
+
+Rescuing can become a strategy to relieve your own distress. You're not just helping them—you're making yourself feel better by eliminating the stimulus (their pain) that's activating you.
+
+**The Caretaking System:**
+The brain's caregiving circuitry evolved to care for infants who genuinely cannot survive alone. When this system is chronically activated toward adults, you're treating capable humans as if they were helpless infants.
+
+This is neurologically confusing for both parties. You feel compelled to protect; they feel infantilized. Neither of you can see the other clearly.
+
+**Dopamine and the Rescue High:**
+Successfully rescuing someone triggers dopamine release. Like any dopamine-driven behavior, it can become addictive. You may find yourself unconsciously seeking opportunities for rescue—not to serve others, but to get the hit.
+
+**Cortisol and the Crash:**
+After the rescue high comes the crash. The person didn't change. The crisis repeated. You're exhausted. This cortisol crash can drive you to seek another rescue, creating a cycle of activation and depletion.
+
+**Translation:** Your nervous system may be wired to perceive emergency where there isn't one, and to feel relief through rescuing. Rewiring requires practicing different responses.
+
+---
+
+## The Paradox of Rescue
+
+Here's what rescuers don't see:
+
+**The rescue prevents the growth.**
+
+Every time you solve someone's problem for them, you deprive them of the opportunity to develop their own capacity. You send an implicit message: *You can't handle this. You need me.*
+
+Over time, this becomes a self-fulfilling prophecy. They stop trying because they've learned you'll take over. Their capacity atrophies. And they become more dependent, not less.
+
+**The rescue that feels like love is often the opposite.**
+
+Real love trusts. Real love says: "I believe you can handle this. I'm here if you need support—but I won't do it for you."
+
+Rescue says: "I don't trust you to handle this. Let me take over."
+
+Which message actually serves their growth?
+
+---
+
+## Field Note: The Mother Who Couldn't Stop
+
+She'd done everything for her adult son.
+
+Paid his rent when he overspent. Made his appointments when he forgot. Apologized to his employers when he messed up.
+
+"I'm just helping," she told her friend.
+
+"Is he getting more capable?" her friend asked.
+
+The question landed hard.
+
+He wasn't. At thirty-two, he was less capable than at twenty-two. Because she'd never let him fail. Never let him experience the consequences of his choices. Never trusted him to figure it out.
+
+She'd rescued him into helplessness.
+
+The conversation that followed was one of the hardest of her life. She told him she was stepping back. That she believed he could handle his own life. That she loved him—and that was exactly why she was going to let him struggle.
+
+He called her cruel. Said she was abandoning him.
+
+She cried for weeks. Doubted herself. Wondered if she was doing the right thing.
+
+Two years later, he was holding down a job, managing his own finances, and had a relationship built on mutual respect instead of dependency.
+
+"I hated you for stepping back," he told her. "And I needed you to."
+
+---
+
+## The Rescuer's Trap Is Self-Perpetuating
+
+One of the most insidious aspects of rescuing: it creates the conditions for more rescuing.
+
+When you rescue someone:
+- They don't develop capacity
+- So they face the next crisis unable to handle it
+- So they need rescuing again
+- So you rescue again
+- And the cycle continues
+
+**The rescuer is creating their own job security.**
+
+Not consciously. Not maliciously. But effectively.
+
+If you want to keep being needed, keep rescuing. If you want them to become capable and independent, stop.
+
+---
+
+## What Rescuers Fear
+
+Under the compulsion to rescue, there are usually fears:
+
+**Fear of their suffering.**
+"If I don't rescue, they'll suffer." Yes—possibly. Struggle is often necessary for growth. Suffering avoided is sometimes just suffering postponed.
+
+**Fear of their failure.**
+"If I don't rescue, they'll fail." Maybe. And maybe failure is what they need to learn. Your rescue deprives them of that teacher.
+
+**Fear of being unnecessary.**
+"If they don't need me, what's my role?" This is a question worth sitting with. Who are you beyond the rescuer function?
+
+**Fear of being seen as cold.**
+"If I don't rescue, they'll think I don't care." You might have to tolerate being misunderstood. Care that builds capacity doesn't always look warm.
+
+**Fear of their anger.**
+"If I don't rescue, they'll be furious." Possibly. Particularly if they're used to being rescued. Can you tolerate their disappointment?
+
+**Fear of abandoning them.**
+"If I don't rescue, I'm abandoning them." This conflates rescuing with connection. You can stay connected without taking over. You can be present without fixing.
+
+---
+
+## Helping vs. Rescuing: The Distinctions
+
+| Rescuing | Helping |
+|----------|---------|
+| Does for them | Supports them in doing |
+| Assumes incapacity | Trusts capacity |
+| Creates dependency | Builds independence |
+| Feels urgent | Feels patient |
+| Eliminates all struggle | Allows productive struggle |
+| Threatened by their growth | Celebrates their growth |
+| Needs them to need you | Wants them to not need you |
+| Relief-focused (short-term) | Growth-focused (long-term) |
+| About the rescuer's needs | About the other person's growth |
+| Involves taking over | Involves standing alongside |
+
+---
+
+## The Empowerment Alternative
+
+If rescuing doesn't serve, what does?
+
+**The empowerment model:**
+
+1. **Witness their struggle.**
+   Instead of rushing to fix, just see. "This is hard. I see you struggling."
+
+2. **Express confidence.**
+   "I believe you can handle this." This simple statement can be transformative.
+
+3. **Ask before offering.**
+   "Would you like support with this?" Let them say yes or no.
+
+4. **Support, don't take over.**
+   If they want help, offer assistance that keeps them in the driver's seat. "What would be most helpful?" "What have you already tried?"
+
+5. **Tolerate their discomfort.**
+   Don't rush to relieve. Their discomfort is often the catalyst for their growth.
+
+6. **Tolerate your own discomfort.**
+   Your urge to fix is often about your activation, not their need. Sit with it.
+
+7. **Celebrate their capability.**
+   When they solve it themselves, acknowledge it. "You handled that."
+
+This is slower. Less dramatic. Less immediately gratifying.
+
+And far more effective.
+
+---
+
+## Field Note: The Sponsor Who Sat Back
+
+She'd been sponsoring women in recovery for twelve years.
+
+Early on, she'd rescued constantly. Drove sponsees to meetings. Loaned them money. Let them stay at her house. Fixed their problems.
+
+Most of them relapsed.
+
+Slowly, she learned a different approach.
+
+A new sponsee called, panicked. Lost her job. Behind on rent. Couldn't make ends meet.
+
+Old her would have offered money, a place to stay, a ride to job interviews.
+
+New her took a breath. "That sounds really hard. What are you thinking about doing?"
+
+"I don't know," the sponsee said. "I was hoping you'd tell me."
+
+"I trust you to figure this out. You have more resources than you think. What's one thing you could do today?"
+
+The sponsee was frustrated. She wanted to be saved.
+
+But she wasn't saved. Instead, she was seen as capable. And over the next month, she figured it out. Got a new job. Made payment arrangements. Stayed sober.
+
+When they talked about it later, the sponsee said: "I was so mad at you for not rescuing me. But if you had, I would have learned nothing. I would have just waited for the next rescue."
+
+---
+
+## The Exit From the Triangle
+
+The Drama Triangle only breaks when someone steps off.
+
+For rescuers, stepping off means:
+
+**Recognizing the trap.**
+Seeing that rescue keeps everyone stuck. That your help isn't helping.
+
+**Tolerating the discomfort.**
+Both theirs and yours. Letting them struggle. Letting yourself feel the pull to save and not acting on it.
+
+**Trusting their capacity.**
+Even—especially—when they don't trust it themselves. Sometimes your belief in them is what they need more than your rescue.
+
+**Finding your worth elsewhere.**
+If being needed is your primary source of value, stepping back feels like death. You need other sources of self-worth before you can stop rescuing.
+
+**Accepting the anger.**
+They will be angry. The victim who loses their rescuer often becomes the persecutor. "How dare you not save me?" This anger is part of the process. It's not a sign you're wrong.
+
+**Staying connected without fixing.**
+The alternative to rescuing isn't abandonment. It's a different kind of presence. "I'm here. I care. And I trust you to handle this."
+
+---
+
+## A Practice: The Rescue Pause
+
+When you feel the urge to rescue:
+
+**Step 1: Notice the urgency.**
+Feel the pull to act. The compulsion to fix. The sense that something must be done right now.
+
+**Step 2: Pause.**
+Don't act immediately. Take three breaths. Let the urgency peak and begin to fade.
+
+**Step 3: Check whose emergency this is.**
+Is this genuinely urgent? Or does it feel urgent because of your activation?
+
+**Step 4: Ask empowering questions.**
+Instead of taking over:
+- "What do you think you should do?"
+- "What resources do you have?"
+- "What have you tried?"
+- "What would help you feel more capable?"
+
+**Step 5: Offer support, not solution.**
+"I'm happy to help brainstorm. I'll support you in handling this. But it's yours to handle."
+
+**Step 6: Tolerate their disappointment.**
+They might want to be rescued. Your not-rescuing might frustrate them. That's okay. Their frustration is not evidence that you should rescue.
+
+---
+
+## A Practice: The Capability Acknowledgment
+
+After interactions where you successfully didn't rescue:
+
+**Step 1: Notice what happened.**
+Did they handle it? Even imperfectly?
+
+**Step 2: Name their capability.**
+To them: "You figured that out."
+To yourself: "They're more capable than my rescuing suggested."
+
+**Step 3: Reinforce the pattern.**
+The more you acknowledge capability, the more you'll trust it. The more they hear it, the more they'll develop it.
+
+---
+
+## A Practice: The Identity Inventory
+
+Explore what rescuing gives you:
+
+**Question 1:** "What do I get from being the rescuer?"
+List everything—status, purpose, identity, control, avoidance.
+
+**Question 2:** "Who am I if no one needs rescuing?"
+Sit with this question. Don't rush to answer. Let it be uncomfortable.
+
+**Question 3:** "What else could give me what rescuing gives me?"
+What other sources of meaning, purpose, or identity could you develop?
+
+**Question 4:** "What am I afraid will happen if I stop rescuing?"
+Name the fears specifically. Then reality-test them.
+
+---
+
+## Reader Reflection
+
+- When have I rescued someone who could have handled it themselves?
+- What did I get from the rescue?
+- How did my rescuing affect their capability over time?
+- What am I afraid would happen if I stopped rescuing?
+- Who would I be if no one needed saving?
+- Can I tolerate someone's struggle without fixing it?
+- Can I tolerate their anger if I don't rescue?
+
+**Body cue to notice:** The urgency to fix, the discomfort when they struggle, the satisfaction when they need you
+
+**Practice:** Rescue Pause (before intervening), Capability Acknowledgment (after they handle it)
+
+---
+
+## Integration Line
+
+> *"The rescue that feels like love is often the obstacle to their growth."*
+
+---
+
+## Closing Note for This Chapter
+
+If you've been a rescuer, this chapter may sting.
+
+You've been trying to help. You've been trying to do good. And here's a framework that says your help might have been the problem.
+
+**Please hear this:**
+
+The impulse to rescue comes from care. From empathy. From a genuine desire to reduce suffering. These are not bad things.
+
+But care without wisdom can cause harm. Empathy without boundaries can create dependency. The desire to reduce suffering can prevent the productive struggle that builds strength.
+
+**The goal isn't to stop caring.**
+
+It's to care in ways that serve growth, not dependency. To help in ways that empower, not enable. To be present without taking over.
+
+This is harder than rescuing. It requires tolerating discomfort—theirs and yours. It requires trusting capability that may not be evident. It requires letting go of the identity that comes from being needed.
+
+**But it's the only path to real help.**
+
+The rescue that keeps them stuck is not help. The step back that lets them grow is.
+
+Trust their capacity. Even when they don't. Especially when they don't.
+
+That's how the trap releases.
+
+---
+
+**[Continue to Chapter 5: Vicarious Trauma & Compassion Fatigue →](./05-vicarious-trauma-compassion-fatigue.md)**


### PR DESCRIPTION
Expand Volume 6 with complete front matter and first four chapters:

Part I: Orientation
- Front Matter: Complete introduction for helpers and guides
- Chapter 1: The Guide's Manifesto - Your healing is your credential
- Chapter 2: Why Trauma Survivors Become Helpers - The seven drivers

Part II: The Shadow of the Guide
- Chapter 3: When Helping Is Hiding - Self-abandonment disguised as generosity
- Chapter 4: The Rescuer's Trap - When saving others keeps everyone stuck

Each chapter includes field notes, neuroscience lens sections, key distinctions,
practices, and reader reflections following the established series format.