### PR TITLE
📚 Add Volume 6 chapters 17-21: The Path of the Guide

### DIFF
--- a/book/vol-6-guide/chapters/17-supervision-support-systems.md
+++ b/book/vol-6-guide/chapters/17-supervision-support-systems.md
@@ -1,0 +1,558 @@
+# Chapter 17: Supervision & Support Systems
+
+## You Cannot Hold Others If No One Is Holding You
+
+---
+
+This chapter is about the thing most guides forget:
+
+**You need support too.**
+
+Not as a nice-to-have. Not as self-care window dressing. As a structural necessity for sustainable practice.
+
+The wounded healer archetype is romantic. The lone practitioner who has walked through fire and now guides others through theirs. But the archetype doesn't tell you about the burnout, the secondary trauma, the slow erosion of self that happens when you hold others' pain without someone holding yours.
+
+**You cannot pour from an empty cup. But more than that—you cannot hold a container if you are not contained.**
+
+---
+
+## Field Note: The Helper Who Stopped Asking for Help
+
+She had been seeing clients for three years.
+
+Her practice was full. Her reviews were glowing. People described sessions with her as transformative.
+
+But something was shifting. She dreaded Mondays. She felt irritated by client stories she used to find moving. She caught herself checking the clock mid-session.
+
+One night, she realized she hadn't talked to anyone about her own life in months. When friends asked how she was, she pivoted to "fine" and then asked about them. When her partner wanted to process something, she went into therapist mode.
+
+She had become the designated holder for everyone. And no one was holding her.
+
+It took a panic attack in her car after a difficult session to finally reach out to her old supervisor. The first words she said were: "I think I forgot I was allowed to need things."
+
+*The guide who cannot receive will eventually have nothing left to give.*
+
+---
+
+## Why Support Systems Matter
+
+You might think you don't need formal support because:
+- You've done your own therapy
+- You understand the dynamics intellectually
+- You're "mostly healed"
+- Your clients' issues don't affect you anymore
+- You have friends you can talk to
+
+**Here's what experience teaches:**
+
+### 1. You Are Not Done Healing
+
+No one is. The work is lifelong. And when you're in the helping role, your material gets activated in specific ways. A client's story mirrors your mother. A group dynamic reminds you of your family. An angry client triggers your fear of abandonment.
+
+Without support, you have two options:
+- Process it alone (which has limits)
+- Don't process it at all (which creates blind spots)
+
+Neither is sustainable.
+
+### 2. Transference and Countertransference Are Real
+
+When you work closely with people in pain, things get projected onto you. Clients may see you as the parent they never had, the lover who abandoned them, the authority figure who failed them.
+
+And you project back. You may need to be the rescuer. You may get activated by their resistance. You may become attached to their progress.
+
+Without supervision, these dynamics operate invisibly—influencing your work in ways you cannot see.
+
+### 3. Vicarious Trauma Is Cumulative
+
+Hearing stories of pain changes you. This is not weakness—it's mirror neuron biology. You feel what they feel. That's what makes you good at this work. But it's also what makes this work dangerous.
+
+Vicarious trauma doesn't announce itself. It accumulates slowly:
+- Increased cynicism
+- Emotional numbness
+- Sleep disruption
+- Hypervigilance in daily life
+- Intrusive thoughts about client stories
+- Difficulty feeling joy
+
+Without structured support, you may not notice the accumulation until you're already depleted.
+
+### 4. Isolation Is a Professional Hazard
+
+Helping work is isolating by nature:
+- You can't talk about specifics due to confidentiality
+- You're the one holding space, not receiving it
+- Your role is to focus on others' needs
+- Success means clients leave; you stay
+
+This isolation can feel noble. It can also slowly destroy you.
+
+---
+
+## Neuroscience Lens: The Cost of Constant Holding
+
+When you hold space for others, your nervous system is working.
+
+**What's happening physiologically:**
+
+- Mirror neurons fire constantly, creating resonance with client states
+- Your prefrontal cortex is online, managing the session
+- Your vagal brake is engaged, maintaining your own regulation while tracking theirs
+- Stress hormones are released and (hopefully) metabolized
+
+**After the session:**
+- Your system needs to discharge and reset
+- Emotional residue needs processing
+- Your nervous system needs to return to its own rhythms, not the client's
+
+**Without support:**
+- Residue accumulates
+- Your baseline shifts toward dysregulation
+- You lose access to your own emotional signals
+- You become hypervigilant or numb—often both
+
+The science is clear: **social support is the primary regulator of the nervous system.** You cannot skip this step and remain effective.
+
+---
+
+## The Supervision Relationship
+
+Supervision is not:
+- Someone telling you what to do
+- Being evaluated or judged
+- Proving you're competent
+- A required box to check
+
+Supervision is:
+- A space where you can be seen in your work
+- A relationship where your blind spots can be illuminated
+- A container for processing what gets activated
+- Protection—for you and for those you serve
+
+### What Good Supervision Looks Like
+
+**Your supervisor:**
+- Has more experience and training than you do
+- Can hold complexity without collapsing into simplicity
+- Is not competitive with you
+- Can challenge you without shaming you
+- Understands the specific nature of your work
+- Has their own supervision and support
+- Is not perfect—but is honest
+
+**The relationship:**
+- Is consistent and boundaried
+- Has clear agreements about frequency and focus
+- Includes space for your emotional experience, not just case consultation
+- Addresses your growth edges, not just client issues
+- Feels like a place where you can bring difficulty
+
+**What you bring:**
+- Honest disclosure about what's challenging you
+- Willingness to be seen in your not-knowing
+- The cases that confuse you—not just the victories
+- Your own reactions and countertransference
+- The question underneath the question
+
+---
+
+## Field Note: What He Didn't Want to Admit
+
+He brought a case to supervision. A client who kept canceling. Who wasn't progressing.
+
+His supervisor listened. Then asked: "What do you feel when she cancels?"
+
+Relief. He felt relief.
+
+He hadn't wanted to admit it. But this client triggered something in him—some version of his mother's chaos, her constant crises, her inability to be helped.
+
+He had been unconsciously creating distance. His slight impatience was showing. She was picking up on it and protecting herself by not showing up.
+
+Without supervision, he would have concluded the client wasn't ready for the work. With supervision, he saw his own part in the dynamic.
+
+*The thing you most don't want to bring to supervision is usually the thing most important to bring.*
+
+---
+
+## Beyond Supervision: Your Larger Support System
+
+Supervision is essential. But it's not enough.
+
+You also need:
+
+### Peer Support
+
+Colleagues who understand the work. Who can normalize the challenges. Who laugh at the absurdities and hold the difficulties.
+
+This is different from supervision:
+- It's peer-to-peer, not hierarchical
+- It's mutual—you hold them and they hold you
+- It's often more about processing and less about direction
+- It can include the parts of you that aren't "the practitioner"
+
+**Forms peer support can take:**
+- Consultation groups (regular meetings with others in your field)
+- Peer dyads (one-on-one mutual support)
+- Informal networks (colleagues you call when things are hard)
+- Professional communities (gatherings, trainings, conferences)
+
+### Personal Therapy
+
+If you're a guide for others, you need your own guide.
+
+This is non-negotiable if:
+- Your own material is getting activated regularly
+- You came to this work through your own wounding
+- You're carrying unprocessed trauma
+- You find yourself over-giving or under-giving
+- You notice your work is affecting your personal life
+- You're considering increasing your capacity
+
+Your therapist should:
+- Not be in your professional network
+- Not be someone you might supervise later
+- Not be invested in your role as a healer
+- See you as a whole person, not just a practitioner
+
+### Personal Relationships
+
+You need people who don't see you as The Healer.
+
+People who:
+- Know you outside your professional role
+- Don't come to you for guidance
+- Let you be messy, uncertain, and just human
+- Don't need you to be the wise one
+- Remind you that you're not that special
+
+**The risk:** As you develop in this work, you may find yourself becoming the default healer in every relationship. Friends start treating you as their therapist. Family sees you as the one who explains dynamics.
+
+**The boundary:** You need relationships where you are not the guide. Where you can receive without giving. Where you can be held without holding.
+
+### Your Own Practices
+
+What fills you back up?
+
+- Movement that isn't about performance
+- Creativity that isn't about output
+- Rest that isn't about productivity
+- Play that isn't about purpose
+- Silence that isn't about insight
+- Nature that isn't about metaphor
+
+These aren't luxuries. They're infrastructure.
+
+---
+
+## The Support System Assessment
+
+Honestly evaluate your current support:
+
+### Supervision
+- Do you have regular supervision?
+- Is your supervisor equipped for the work you're doing?
+- Are you honest in supervision, or performing competence?
+- When was the last time supervision challenged you?
+
+### Peer Support
+- Do you have colleagues you can be real with?
+- Is there mutual support, or are you always the giver?
+- Do you have space to process difficult sessions?
+- Are you connected to a professional community?
+
+### Personal Therapy
+- Are you in your own therapy?
+- If not, what's your reasoning—and is it actually valid?
+- Does your therapist see the whole you?
+- When was the last time you brought something difficult?
+
+### Personal Relationships
+- Do you have relationships where you're not the helper?
+- Can you receive in your personal life?
+- Are there people who see you outside your role?
+- Who holds you when you're struggling?
+
+### Self-Care Practices
+- What actually restores you?
+- Are you doing it, or just knowing you should?
+- Is your self-care genuine nourishment or performance?
+- When was the last time you rested without guilt?
+
+---
+
+## Field Note: The Inventory She Did
+
+She printed out the questions and answered them honestly.
+
+The results were uncomfortable:
+
+Supervision: Hadn't gone in four months. "Too busy."
+Peer support: Used to have a consultation group. Let it slide.
+Personal therapy: Stopped when she "felt better."
+Personal relationships: Had become the holder in all of them.
+Self-care: Exercise was the only thing. And it had become compulsive.
+
+She saw the pattern. She had been slowly withdrawing from receiving while intensifying her giving.
+
+No wonder she was exhausted. No wonder she was starting to resent her work.
+
+The support system wasn't missing because she was busy. She was busy because she was avoiding being supported.
+
+*Sometimes "not having time" is protection against vulnerability.*
+
+---
+
+## Common Resistances to Getting Support
+
+### "I should be able to handle this by now."
+
+**The belief:** Real healers don't need help.
+
+**The truth:** The most effective healers are the most supported ones. Your ability to hold others is directly proportional to how well you are held.
+
+### "I don't have time."
+
+**The belief:** Support is a luxury I can't afford.
+
+**The truth:** You don't have time NOT to. The cost of unsupported practice is burnout, blind spots, and harm—to yourself and those you serve.
+
+### "I don't want to burden anyone."
+
+**The belief:** My needs are too much. I should only give.
+
+**The truth:** This is often childhood material disguised as virtue. Your needs are not a burden. Receiving is as important as giving.
+
+### "I've done enough therapy."
+
+**The belief:** I've processed my past. I'm done.
+
+**The truth:** The work is never done—only the acute phase. And being in a helping role activates material in ways that regular life doesn't.
+
+### "I can process on my own."
+
+**The belief:** Self-reflection is sufficient.
+
+**The truth:** Self-reflection has limits. Your blind spots are called blind spots because you can't see them. You need external perspective.
+
+### "Supervision feels like being evaluated."
+
+**The belief:** Someone watching my work will find me inadequate.
+
+**The truth:** Good supervision isn't about proving competence. It's about growing in the places you can't grow alone.
+
+---
+
+## Building Your Support System
+
+### Step 1: Assess What's Missing
+
+Use the questions above. Be honest. Where are the gaps?
+
+### Step 2: Identify the Resistance
+
+What's the story you tell yourself about why you don't have support in that area?
+
+What would change if you didn't believe that story?
+
+### Step 3: Take One Step
+
+- If supervision is missing: Research supervisors in your area or modality
+- If peer support is missing: Reach out to one colleague for coffee
+- If therapy is missing: Book a consultation with a therapist
+- If personal relationships are missing: Invest in one non-helper relationship
+- If self-care is missing: Block one hour this week for genuine restoration
+
+### Step 4: Make It Structural
+
+Support that depends on your mood won't last. Build it into your schedule:
+- Supervision: Same time, every two weeks, non-negotiable
+- Peer consultation: Monthly meeting, calendar invite sent
+- Therapy: Regular appointment, paid in advance
+- Self-care: Protected time, treated as sacred as client sessions
+
+### Step 5: Notice the Resistance When It Arises
+
+You will want to skip. Cancel. "Just this once."
+
+Notice what arises when support is scheduled. That's material.
+
+---
+
+## A Practice: The Weekly Support Check
+
+Every week, ask yourself:
+
+**1. Have I been held this week?**
+- By whom?
+- In what way?
+- Was it sufficient?
+
+**2. Have I processed what I've been carrying?**
+- What's still with me from sessions?
+- What needs to be spoken to someone else?
+- What needs more attention?
+
+**3. Have I received?**
+- Not just given—received
+- Care, presence, attention, support
+- From humans, not just activities
+
+**4. What do I need this week?**
+- What kind of support?
+- From whom?
+- What's stopping me from getting it?
+
+---
+
+## A Practice: Asking for Help
+
+If asking for help is difficult, practice:
+
+**The script:**
+"I'm noticing I need some support right now. Would you have capacity to [listen/hold space/give me feedback]?"
+
+**Then:**
+- Let them respond honestly
+- If they can't, that's okay—find someone else
+- If they can, receive without minimizing
+- Resist the urge to turn it back to them
+
+**Afterward:**
+- Notice what it felt like to ask
+- Notice what it felt like to receive
+- Notice the stories that arose
+
+---
+
+## Supervision Agreements
+
+If you're establishing or re-establishing supervision, clarify:
+
+**Frequency:** How often will you meet? (Weekly, biweekly, monthly)
+
+**Focus:** What's the balance between case consultation and personal process?
+
+**Confidentiality:** What are the agreements about what's shared?
+
+**Emergencies:** What happens if something arises between sessions?
+
+**Feedback:** How will your supervisor give you feedback? How will you receive it?
+
+**Evaluation:** If there's any evaluative component, how is it handled?
+
+**Boundaries:** What's the relationship outside of supervision?
+
+---
+
+## Field Note: The Agreement That Saved Her
+
+When she started with her new supervisor, they made explicit agreements.
+
+One was: "I want you to tell me when you see my shadow. Even if it's uncomfortable."
+
+Months later, her supervisor said: "I'm noticing you're rescuing this client. You're working harder than they are."
+
+It stung. But she had asked for it. She sat with it. And she saw it was true.
+
+Without the agreement, she might have defended. With the agreement, she could receive.
+
+*The container of good supervision is built on explicit agreement.*
+
+---
+
+## When Support Isn't Enough
+
+Sometimes, no amount of supervision, therapy, or peer support will be sufficient.
+
+**Signs you may need to pause practice:**
+
+- You're having intrusive thoughts about client material
+- You're unable to leave work at work
+- Your own symptoms are returning or intensifying
+- You're dreading sessions more than looking forward to them
+- You're crossing boundaries you wouldn't have before
+- You're using substances to cope with the work
+- Your physical health is deteriorating
+- Your personal relationships are suffering significantly
+
+**If you recognize these signs:**
+
+This is not failure. This is information.
+
+You may need:
+- A reduced caseload
+- A leave of absence
+- A return to more intensive personal therapy
+- A shift in the type of clients you see
+- A different kind of work entirely
+
+There is no shame in recognizing limits. There is wisdom in it.
+
+---
+
+## The Gift You Give by Receiving
+
+When you receive support, you're not just taking care of yourself.
+
+**You're modeling something essential for those you serve:**
+
+- That needing help is human
+- That receiving is as important as giving
+- That the helper can be helped
+- That vulnerability is not weakness
+- That sustainable practice requires support
+
+If you want your clients to learn to receive, you must learn to receive.
+
+If you want them to ask for help, you must ask for help.
+
+If you want them to build support systems, you must have one yourself.
+
+**Your willingness to be supported is part of your offering.**
+
+---
+
+## Reader Reflection
+
+- What's my current support system? Is it sufficient?
+- Where do I resist receiving support? What's the story underneath?
+- When was the last time I was truly held—not holding?
+- What would change in my practice if I was better supported?
+- What's one step I can take this week to strengthen my support system?
+- What am I afraid would happen if I asked for more help?
+
+**Body cue to notice:** The relief when someone finally holds you. The resistance before you let them.
+
+**Practice:** Weekly support check
+
+---
+
+## Integration Line
+
+> *"The container that holds others must itself be contained. Your support system is not self-indulgence—it is infrastructure."*
+
+---
+
+## A Final Field Note: The Holding That Heals
+
+She sits across from her supervisor now with the same regularity she once sat with clients.
+
+She brings the hard things. The clients who confuse her. The parts of herself that get activated. The fears she hasn't shared with anyone else.
+
+And she is held. Not fixed—held.
+
+When she returns to her own practice, she's different. Not because she has more answers. Because she has been received. Because someone has seen her struggle and not looked away.
+
+She understands now what she's offering her clients.
+
+Not expertise. Not technique. Not insight alone.
+
+A willingness to be in the difficulty with them. A steady presence that doesn't need them to be different.
+
+She can only offer that because someone offers it to her.
+
+*You cannot give what you don't have. Your receiving is your offering.*
+
+---
+
+**[Continue to Chapter 18: Teaching Without Converting →](./18-teaching-without-converting.md)**

--- a/book/vol-6-guide/chapters/18-teaching-without-converting.md
+++ b/book/vol-6-guide/chapters/18-teaching-without-converting.md
@@ -1,0 +1,492 @@
+# Chapter 18: Teaching Without Converting
+
+## Offering Truth Without Needing Them to Take It
+
+---
+
+You have learned something valuable.
+
+Something that changed your life. That rewired your understanding. That showed you what was hidden before.
+
+Naturally, you want to share it.
+
+You want others to see what you've seen. To know what you know. To be freed the way you were freed.
+
+This is a beautiful impulse. And it carries a shadow.
+
+**The shadow of the teacher is the need to convert.**
+
+---
+
+## Field Note: The Conversation That Went Wrong
+
+She was having dinner with an old friend.
+
+The friend was complaining about her mother again. The same pattern. The enmeshment. The guilt trips. The inability to set boundaries.
+
+She saw it so clearly now. The narcissistic dynamic. The trauma bond. The fawning response.
+
+She wanted to help. So she started explaining.
+
+The drama triangle. The concept of narcissistic supply. How her friend was repeating childhood patterns.
+
+Her friend's face changed. First confusion. Then something like hurt. Then a kind of shutdown.
+
+"I just wanted you to listen," her friend said finally. "I wasn't asking for a diagnosis."
+
+She drove home confused. She was right about the dynamics. She was only trying to help.
+
+Later, she recognized it: She had converted a friendship into a teaching moment. Her friend hadn't signed up for that.
+
+*Being right is not the same as being helpful.*
+
+---
+
+## The Difference Between Teaching and Converting
+
+**Teaching:**
+- Offers frameworks when asked
+- Respects the learner's autonomy
+- Allows disagreement and alternative paths
+- Is curious about what they already know
+- Empowers their own discovery
+- Doesn't need them to agree to feel successful
+- Meets them where they are
+
+**Converting:**
+- Offers frameworks whether asked or not
+- Subtly (or not subtly) pressures agreement
+- Has difficulty with alternative perspectives
+- Assumes they don't know
+- Creates dependence on your framework
+- Needs validation that your view is correct
+- Tries to move them from where they are
+
+**One-Line Decoder:** *Teaching opens doors. Converting pushes people through them.*
+
+---
+
+## Why We Want to Convert
+
+The urge to convert isn't malicious. It often comes from:
+
+### 1. Genuine Care
+
+You suffered before you learned this. You don't want them to suffer the same way. The urgency comes from caring.
+
+**The shadow:** Care can become pressure. What feels like love to you may feel like imposition to them.
+
+### 2. Validation of Your Own Journey
+
+If they see it your way, it confirms your way is right. Their agreement stabilizes your worldview.
+
+**The shadow:** You may need their conversion more than they need your teaching.
+
+### 3. Unprocessed Evangelist Trauma
+
+Many who come to healing work escaped rigid ideological systems—religious, political, familial. The pattern of converting is still in your nervous system.
+
+**The shadow:** You may be doing the same thing, just with new content. Same urgency, different gospel.
+
+### 4. The High of Being Right
+
+There's a dopamine hit when someone has the breakthrough you predicted. When your framework explains their life better than they could.
+
+**The shadow:** You may be attached to being the one with insight. (See Chapter 12: The Shadow of the Healer in Volume 4.)
+
+### 5. Fear
+
+If they don't get it, maybe you're wrong. If your framework doesn't land, maybe it was never true. Their resistance threatens your certainty.
+
+**The shadow:** You may be converting to protect yourself from doubt.
+
+---
+
+## Neuroscience Lens: Why Conversion Backfires
+
+The brain doesn't learn well under pressure.
+
+**When someone feels pushed:**
+
+- The sympathetic nervous system activates
+- The prefrontal cortex goes partially offline
+- Defensive processing takes over
+- New information is filtered through threat detection
+- Emotional walls go up
+- The very insight you're offering becomes associated with discomfort
+
+**This is why people:**
+- Agree in the moment to stop the conversation
+- Forget what you said within hours
+- Avoid topics where you've pushed
+- Feel resistance without knowing why
+- Dig into their existing position
+
+**The paradox:** The harder you push, the less they can receive.
+
+Receptivity requires safety. Safety requires autonomy. Autonomy requires you to release your grip on the outcome.
+
+---
+
+## Field Note: The Workshop Participant
+
+He was facilitating a workshop on boundaries.
+
+One participant pushed back hard. "This all sounds like selfishness. What about sacrifice? What about putting others first?"
+
+He felt his body tighten. His old self would have argued. Would have explained why she was wrong. Would have doubled down with more evidence.
+
+Instead, he breathed. And said:
+
+"That's a valid concern. There are real wisdom traditions that emphasize selflessness. I'm not asking you to abandon that. I'm just offering another lens. You get to decide if it's useful for you."
+
+Something in her softened. Not because he convinced her. Because he didn't need to.
+
+She stayed engaged for the rest of the workshop. At the end, she said: "I'm still not sure I agree with all of it. But I'll think about it."
+
+*That's the win. Not conversion—engagement.*
+
+---
+
+## The Consent of Teaching
+
+In Volume 4, we explored consent in intimacy. The same principles apply to teaching:
+
+**Consent must be:**
+- Freely given (not pressured or extracted)
+- Informed (they know what they're agreeing to)
+- Reversible (they can opt out at any time)
+- Specific (yes to one thing doesn't mean yes to everything)
+- Enthusiastic (not just tolerating—actually wanting)
+
+**In teaching, this means:**
+
+**1. Asking before offering frameworks**
+
+"Would it be helpful if I shared a way of looking at this?"
+"Do you want some input, or do you just need to vent?"
+"I have some thoughts—interested?"
+
+**2. Checking in during**
+
+"Is this landing?"
+"Does this feel relevant to what you're dealing with?"
+"Should I keep going, or is this enough?"
+
+**3. Respecting "no"**
+
+When they say no—explicitly or implicitly—stop.
+No resistance to their resistance.
+No subtle continuation disguised as "just one more thing."
+
+**4. Offering, not imposing**
+
+"Here's one way to see it."
+"This is what worked for me—might not apply to you."
+"Take what's useful, leave what isn't."
+
+---
+
+## Signs You're Converting, Not Teaching
+
+### In the Moment
+
+- You're talking more than listening
+- You feel urgent, like you need to convince them
+- Their resistance makes you double down
+- You're frustrated they don't "get it"
+- You're thinking about what to say next while they're talking
+- Their body language is closing and you're not adjusting
+- You're speaking faster, leaning in, getting more insistent
+
+### In the Pattern
+
+- The same topics keep coming up with the same people
+- People seem to avoid certain subjects around you
+- You get feedback that you're "a lot" or "intense"
+- You notice people agreeing just to end conversations
+- You're known as the one who always has the answer
+- You feel disappointed when your insights aren't valued
+- You catch yourself diagnosing people who didn't ask
+
+### In the Aftermath
+
+- You feel drained after "helping" conversations
+- You replay conversations, wishing they had understood
+- You feel angry or dismissed when they don't apply your advice
+- You distance from people who don't share your framework
+- Your relationships increasingly include only people who agree with you
+
+---
+
+## The Art of Holding Truth Lightly
+
+You can believe something is true—deeply, completely true—and still hold it lightly.
+
+**Holding truth lightly means:**
+
+- I know what I know, and I don't need you to know it too
+- My certainty doesn't require your agreement
+- I can offer without attachment
+- I can be wrong, and that doesn't threaten my foundation
+- Your path may be different from mine
+- The framework that saved me may not be the one that saves you
+- Truth is larger than my understanding of it
+
+**This is different from:**
+
+- Pretending you don't know what you know
+- Abandoning your convictions to avoid conflict
+- Being wishy-washy about your perspective
+- Never offering your view
+- Hiding your wisdom to be "nice"
+
+You can be clear and unattached. You can be honest and non-coercive. You can speak truth and respect autonomy.
+
+---
+
+## Field Note: The Couple
+
+They came to her for relationship coaching.
+
+She saw the pattern within minutes. Classic pursuer-distancer dynamic. His avoidant attachment triggering her anxious attachment, escalating in a predictable dance.
+
+But she didn't say that.
+
+Instead, she asked questions. About their experience. About what they noticed. About what they'd tried.
+
+Slowly, they began to see it themselves. The pattern emerged in their own words. She offered language occasionally—"Some people call that 'pursuing'"—but she never told them what was happening.
+
+At the end of the session, he said: "I think I'm the one who pulls away. I never saw it before."
+
+She hadn't told him that. He had discovered it. And because he discovered it, it was his.
+
+*Teaching that leaves ownership with the learner is more durable than teaching that impresses.*
+
+---
+
+## The Different Contexts
+
+### With Clients
+
+If someone is paying for your guidance, there's implicit consent to teach. But even here:
+
+- Check before introducing frameworks
+- Offer, don't impose
+- Leave room for their "no"
+- Let insights emerge when possible rather than delivering them
+- Notice when you're working harder than they are
+- Your job is to help them fish, not to fish for them
+
+### With Friends
+
+Friendship is not therapy. Your friends did not hire you.
+
+- Unless explicitly asked, don't analyze their dynamics
+- Ask: "Do you want support or solutions?"
+- Accept that most of the time, they just want to be heard
+- Your frameworks are not more valid than their lived experience
+- If you find yourself in teacher mode constantly, you may be avoiding intimacy
+
+### With Family
+
+Family dynamics are especially loaded. Your insight about the family system does not give you authority over it.
+
+- Tread carefully with unsolicited analysis
+- Your perception of your parents is not necessarily your siblings' job to validate
+- You may see dynamics others aren't ready to see—that doesn't make you superior
+- Sometimes the most healing thing is to not explain and just be present
+
+### With Strangers
+
+The person on the plane, at the party, in the grocery store—they didn't ask.
+
+- Not everyone with a problem needs your framework
+- Practice tolerating the discomfort of not helping
+- Your restraint is also a gift
+- Not every conversation is a teaching opportunity
+
+### Online
+
+This is where conversion culture thrives. Consider:
+
+- Are you offering or pushing?
+- Are you speaking to be helpful or to be seen as wise?
+- Is your content invitational or pressuring?
+- Do you leave room for disagreement, or do you position disagreement as ignorance?
+
+---
+
+## A Practice: The Pause Before Teaching
+
+Before offering a framework, insight, or perspective:
+
+**Pause.**
+
+**Ask yourself:**
+1. Did they ask for this?
+2. Am I certain this will serve them, or do I just want to share it?
+3. What would happen if I didn't offer this?
+4. Is my urgency about them or about me?
+5. Can I offer this with zero attachment to whether they take it?
+
+**If you proceed:**
+- Offer, don't tell
+- Use invitational language
+- Watch their response
+- Stop before you're done
+
+**If you don't proceed:**
+- That's a complete response
+- Listening without solving is enough
+- Your restraint is a practice
+
+---
+
+## A Practice: Teaching by Asking
+
+Instead of telling, try asking:
+
+**Instead of:** "What you're describing is a trauma bond."
+**Try:** "What do you notice keeps you connected to them, even when it hurts?"
+
+**Instead of:** "Your mother is clearly narcissistic."
+**Try:** "How does it feel when she responds that way? What happens in your body?"
+
+**Instead of:** "You need to set boundaries."
+**Try:** "What would it look like if you only did what genuinely works for you?"
+
+**The principle:** Lead them to their own insight. It takes longer. It lands deeper.
+
+---
+
+## When Conversion Is Actually Called For
+
+There are times when stronger advocacy is appropriate:
+
+**Immediate safety concerns:** If someone is in danger, you may need to be more direct. "I'm worried about your safety" is not conversion—it's care.
+
+**Professional contexts where they've consented:** If you're their coach, therapist, or teacher, you've been invited to offer direction.
+
+**When explicitly asked:** "Please just tell me what you think I should do." Even then, you can offer without coercing.
+
+**Systemic injustice:** There are times to take a stand. But even here, notice the difference between advocacy and coercion, between truth-telling and needing agreement.
+
+Even in these contexts:
+- Respect autonomy as much as possible
+- Don't weaponize urgency
+- Stay connected even if they disagree
+- Their "no" is still valid
+
+---
+
+## The Teacher's Paradox
+
+The more you know, the less you need to prove it.
+
+The deepest teachers often speak least. They ask more than tell. They trust the process more than the content. They're not threatened by disagreement.
+
+**Signs of a mature teacher:**
+- Can hold silence
+- Delights in student's own insights
+- Not competitive with other teachers
+- Okay with being forgotten if the lesson lands
+- Doesn't need credit
+- Can say "I don't know"
+- Doesn't defend their framework—just offers it
+
+**Signs of an immature teacher:**
+- Fills silence with more content
+- Needs to be the source of insight
+- Competes with or dismisses other approaches
+- Wants to be remembered
+- Needs acknowledgment
+- Claims certainty on everything
+- Defends their framework against all critique
+
+---
+
+## Field Note: The Teacher She Learned From
+
+The teacher she most respected rarely gave answers.
+
+When students asked questions, she would often respond: "What do you think?"
+
+At first, this frustrated students. They had paid for wisdom. They wanted to be told.
+
+But over time, something happened. Students began trusting their own knowing. Began discovering insights that were genuinely theirs. Began needing her less.
+
+She wasn't withholding. She was trusting. Trusting that wisdom was already present in the room—and her job was to help it surface, not to provide it.
+
+That trust was more transformative than any lecture.
+
+*The greatest teaching often looks like nothing.*
+
+---
+
+## Releasing Outcomes
+
+Here is the hardest truth:
+
+**They might not get it.**
+
+Not because you failed. Not because they're dense. But because:
+
+- It's not their time
+- Their path is different
+- They need to learn through experience, not explanation
+- What healed you may not heal them
+- They have their own wisdom to follow
+- Some lessons can only be learned the hard way
+- It's simply not yours to give them
+
+Your job is to offer clearly, hold lightly, and release completely.
+
+Their journey is theirs.
+
+---
+
+## Reader Reflection
+
+- Where do I cross the line from teaching to converting?
+- What's the urgency underneath my desire to help others see?
+- Can I tolerate someone not getting what I know?
+- Where am I still carrying the evangelist pattern?
+- What would change if I trusted people to find their own path?
+- Who in my life do I subtly pressure to share my worldview?
+
+**Body cue to notice:** The tension that arises when someone disagrees. The relief when they "get it."
+
+**Practice:** The Pause Before Teaching
+
+---
+
+## Integration Line
+
+> *"The truth doesn't need your defense. It just needs your offering—open-handed, freely given, and easy to refuse."*
+
+---
+
+## A Final Field Note: The Dinner, Revisited
+
+She had dinner with that friend again, months later.
+
+The same patterns were present. The same complaints about her mother.
+
+This time, she listened. Asked questions. Held space.
+
+Her friend cried. Laughed. Said things she'd never said before.
+
+At the end, her friend said: "You always make me feel like I can figure things out myself."
+
+She hadn't taught anything.
+She hadn't explained the drama triangle.
+She hadn't offered the narcissism framework.
+
+She had just been present. And in that presence, her friend found her own way.
+
+*Sometimes the best teaching is not teaching at all.*
+
+---
+
+**[Continue to Chapter 19: Content Creation as Service →](./19-content-creation-as-service.md)**

--- a/book/vol-6-guide/chapters/19-content-creation-as-service.md
+++ b/book/vol-6-guide/chapters/19-content-creation-as-service.md
@@ -1,0 +1,612 @@
+# Chapter 19: Content Creation as Service
+
+## Sharing Your Healing Without Performing It
+
+---
+
+There has never been a time when more people are sharing their healing journeys publicly.
+
+Podcasts. Instagram posts. TikTok videos. Substack essays. YouTube channels. Online courses. E-books. Communities.
+
+The barriers to sharing have collapsed. Anyone with a story can tell it. Anyone with insight can teach it. Anyone with lived experience can offer it.
+
+This is remarkable. The gatekeepers who once controlled who could speak about healing have lost their monopoly. Wisdom is being democratized.
+
+And like all democratizations, it creates new challenges.
+
+**Content creation about healing is a minefield of shadow dynamics, ethical complexity, and nervous system activation—for both creator and audience.**
+
+This chapter is for those creating content about trauma, healing, and personal growth. Whether you have an audience of thousands or you're just starting to share.
+
+---
+
+## Field Note: The First Video
+
+She posted her first video about her healing journey on a Tuesday night.
+
+Nothing fancy. Just her, a phone, some words about recognizing narcissistic abuse that she wished someone had told her years ago.
+
+By morning, it had two hundred views. Comments. Shares. DMs from strangers saying: "This is exactly what I needed to hear. How did you know?"
+
+Something in her lit up. Dopamine. Recognition. Purpose.
+
+She made another video. And another.
+
+By month three, she had fifty thousand followers. Brand deals. Speaking requests. A publisher interested in a book.
+
+By month six, she was exhausted. Anxious before posting. Defensive about criticism. Performing emotions she'd already processed. Checking her phone every hour.
+
+She had started creating to serve. Somewhere along the way, she had started creating to be seen.
+
+*The algorithm rewards performance. What the soul requires is authenticity.*
+
+---
+
+## Why We Create Content About Healing
+
+There are many valid reasons to share your healing publicly:
+
+**1. The Lighthouse Impulse**
+
+You suffered in isolation. Now you want to be the light you needed then. You want others to find what took you so long to find.
+
+This is genuine service. It matters.
+
+**2. Processing Through Expression**
+
+Writing and speaking about your experience helps you integrate it. Creation is a form of processing. The audience becomes witness to your ongoing work.
+
+**3. Building Connection**
+
+Isolation was part of your wounding. Public sharing builds bridges. It creates community. It combats the aloneness that trauma instills.
+
+**4. Economic Reality**
+
+You have insights. There's a market for them. Content creation can become livelihood. There's nothing inherently wrong with this.
+
+**5. Making Meaning**
+
+If your suffering had no purpose, it's unbearable. Creating content transforms pain into offering. Meaning-making is survival.
+
+---
+
+## The Shadow Reasons
+
+These can coexist with the genuine ones:
+
+**1. External Validation**
+
+Likes, shares, and followers can become substitutes for internal security. Your sense of worth becomes tied to engagement metrics.
+
+**2. Identity Attachment**
+
+Your role as "healer" or "survivor" becomes how you know yourself. You need to keep producing content to maintain the identity.
+
+**3. Trauma Bonding with an Audience**
+
+The intensity of shared pain creates attachment. You become bound to your audience through the wound, not through health.
+
+**4. Avoiding Further Growth**
+
+If you're always teaching the basics, you don't have to confront the advanced work. Content creation can be a way of staying in the known.
+
+**5. Control**
+
+When you control the narrative, you control how you're seen. Public sharing can be a defense against the vulnerability of private relating.
+
+---
+
+## Neuroscience Lens: The Creator's Nervous System
+
+Content creation about emotional topics activates specific neural circuitry:
+
+**When you share your story:**
+- Memory networks activate, sometimes retraumatizing
+- Mirror neurons fire as you imagine your audience receiving
+- The social engagement system is online, reading responses as relational cues
+- Dopamine surges with positive feedback
+- Cortisol surges with negative feedback
+- The narrative brain constructs and reconstructs your story for coherence
+
+**When you post and wait:**
+- Anticipatory anxiety activates the amygdala
+- Checking for responses mimics addictive patterns
+- Validation becomes a regulatory strategy
+- Criticism can land as attack, triggering survival responses
+- The nervous system learns to seek the hit of engagement
+
+**The risk:** Your nervous system can become calibrated to external response rather than internal knowing. You can lose access to your own baseline because you're constantly checking against audience reaction.
+
+---
+
+## Field Note: The Comment Section
+
+He wrote a long essay about his father. About the abuse. About the silence. About what it took to leave and rebuild.
+
+It was the truest thing he'd ever written.
+
+Ninety percent of the comments were supportive. Grateful. Moving.
+
+But there were a few—just a few—that gutted him. "This sounds like you're blaming everyone else." "Where's the accountability for your own choices?" "Seems like you just want attention."
+
+He read those three comments more times than the hundred others combined.
+
+That night, he couldn't sleep. He drafted replies. Deleted them. Drafted new ones.
+
+His girlfriend said: "You're letting three strangers determine your worth."
+
+She was right. But his nervous system didn't know that.
+
+*The brain is wired to scan for threat. Three negative comments can hijack a hundred positive ones.*
+
+---
+
+## The Audience Relationship
+
+Your audience is not neutral. It's a relationship—with all the complexity that implies.
+
+**What audiences often want:**
+- To feel seen in their own pain
+- To learn from your experience
+- To not be alone
+- To find hope
+- To get practical tools
+- Entertainment, connection, inspiration
+
+**What audiences sometimes want (shadow):**
+- To project onto you
+- To make you their savior
+- To be told they're right and everyone else is wrong
+- To have their victim identity confirmed
+- To consume your emotional labor without doing their own work
+- To build parasocial connection instead of real relationships
+
+**What you're responsible for:**
+- Offering honest, boundaried content
+- Not exploiting vulnerability for engagement
+- Maintaining your own wellbeing
+- Being clear about what you are and aren't offering
+- Not manufacturing intimacy you can't sustain
+
+**What you're not responsible for:**
+- How they interpret your content
+- Whether they do the work
+- Their healing
+- Their projections
+- Fixing everyone who reaches out
+
+---
+
+## The Performance Trap
+
+There's a difference between:
+
+**Sharing authentically:**
+- Content emerges from genuine experience
+- You post because you have something to offer
+- You can take breaks without identity crisis
+- The content serves your growth, not just theirs
+- You're in contact with yourself while creating
+
+**Performing healing:**
+- Content emerges from what will engage
+- You post because you need the response
+- Breaks feel threatening to your identity
+- The content consumes your growth
+- You're performing a version of yourself
+
+**Signs you've moved from sharing to performing:**
+
+- You exaggerate emotional states for impact
+- You manufacture breakthroughs you haven't had
+- You revisit old trauma not to process but to produce
+- You feel pressure to be more healed than you are
+- You avoid sharing struggles because it would contradict your brand
+- Your content life feels different from your real life
+- You're exhausted by your own story
+
+---
+
+## Field Note: The Curated Self
+
+She looked at her Instagram and saw a woman she barely recognized.
+
+Inspirational quotes over sunrise photos. Polished videos about self-love. Posts about being "fully healed."
+
+She was none of those things.
+
+In private, she was still struggling. Still anxious. Still triggered by her mother's calls. Still unsure about her worth.
+
+But online, she had become a character—the Healed Woman. And that character had expectations.
+
+When she tried to post about a bad day, her engagement dropped. When she shared genuine uncertainty, followers unfollowed. The algorithm punished her authenticity.
+
+So she kept performing. And the gap between her public self and private self grew until she didn't know which one was real.
+
+*When performance becomes identity, you lose access to the truth that made your content valuable in the first place.*
+
+---
+
+## What Service-Oriented Content Looks Like
+
+### Honest Range
+
+You share your growth AND your struggle. Not just polished wisdom—but the ongoing mess of being human.
+
+"I teach about boundaries. I'm also still learning them."
+"This is what I've figured out. Here's where I'm still confused."
+"I've come far. I'm not done."
+
+### Boundaries Around Exposure
+
+Not everything needs to be shared. You can serve without stripping.
+
+- You can reference difficult experiences without detailed accounts
+- You can offer wisdom without the full trauma narrative
+- You can have private healing that isn't content
+- Your current struggles don't need to be monetized
+
+### Non-Dependency
+
+Your content points people toward their own work, not toward endless consumption of your content.
+
+"Here's something to try—then go do it."
+"This video is enough. You don't need the course."
+"Take this and make it yours."
+
+### Sustainable Rhythm
+
+You post when you have something to offer. Not because the algorithm requires daily content. Not because you need the dopamine.
+
+- Breaks are acceptable
+- Silence is not failure
+- Your rhythm is your rhythm
+
+### Non-Exploitation
+
+You don't exploit your own trauma for engagement. You don't exploit your audience's trauma for profit.
+
+- Not sensationalizing
+- Not manufacturing crisis
+- Not trauma-baiting
+- Not using engagement metrics to determine what's true
+
+---
+
+## A Practice: The Content Intention Check
+
+Before creating, ask:
+
+**1. Why am I creating this?**
+- Genuine service?
+- Processing for myself?
+- Need for validation?
+- Obligation to the algorithm?
+- Something I need to say regardless of response?
+
+**2. Am I in a state to create?**
+- Regulated enough to share publicly?
+- Not in acute crisis?
+- Not creating from desperation?
+- Not using content as a substitute for support?
+
+**3. What's the cost?**
+- What will this take from me to share?
+- What might it trigger?
+- Is this exposure appropriate right now?
+
+**4. What do I want them to take away?**
+- A feeling?
+- An action?
+- A shift in perspective?
+- Connection?
+
+**5. Am I attached to the response?**
+- Can I post this and not check for 24 hours?
+- Will I be okay if no one engages?
+- Does my worth depend on this landing?
+
+---
+
+## A Practice: Post-Creation Regulation
+
+After creating or posting emotional content:
+
+**1. Ground immediately**
+- Feet on floor
+- Breath into belly
+- Feel the edges of your body
+- Return to physical present
+
+**2. Delay checking responses**
+- Decide in advance: when will you look?
+- Block the first few hours
+- Notice what comes up in the delay
+
+**3. Limit exposure to comments**
+- Set a timer
+- Don't scroll endlessly
+- Respond from regulation, not reaction
+- It's okay not to read them all
+
+**4. Have embodied activity after**
+- Walk, exercise, cook
+- Something physical
+- Something that isn't online
+- Return to your body
+
+**5. Connect with someone real**
+- Not a follower—a person who knows you
+- Someone who sees you offline
+- Let yourself be seen as human, not creator
+
+---
+
+## The Boundary of Specificity
+
+A key tension: How much detail serves?
+
+**Arguments for specificity:**
+- Detail helps people recognize their own experience
+- Specifics create connection
+- Vagueness can feel inauthentic
+
+**Arguments against over-specificity:**
+- Detailed trauma narratives can retraumatize both you and your audience
+- Specifics can be used against you
+- Some details are for you and your support system, not public consumption
+- Over-exposure can create inappropriate intimacy
+
+**The guideline:** Share what's processed. Hold what's still raw.
+
+If you're still activated by a story, you probably shouldn't be sharing it publicly. Content should emerge from integration, not be a substitute for it.
+
+---
+
+## Field Note: What She Didn't Share
+
+The assault was not content.
+
+She knew other creators who detailed everything. The clicks. The engagement. The "brave" comments.
+
+But for her, that story was for her therapist. For her partner. For her own journal.
+
+What she shared publicly was the aftermath—the patterns she developed, the healing practices that helped, the insights that emerged. Not the specific horror.
+
+Some people pushed. "But don't we need to hear the full story to understand?"
+
+Her answer was no. You needed to understand the pattern, not witness her pain. Her healing didn't require your witnessing.
+
+She protected the story because the story was sacred.
+
+*Not everything that happened to you belongs to the public.*
+
+---
+
+## Navigating Platform Dynamics
+
+Each platform has its own economics, and those economics shape what gets rewarded:
+
+**Short-form video (TikTok, Reels):**
+- Rewards sensationalism, hot takes, high emotion
+- Punishes nuance, slowness, complexity
+- Creates pressure for fast, reactive content
+- Easy to optimize for clicks at the expense of depth
+
+**Long-form video (YouTube):**
+- Allows more depth
+- Still rewards hooks and drama
+- Watch time matters more than wisdom
+- Thumbnail economy can pressure sensationalism
+
+**Written (Substack, blogs):**
+- Allows complexity
+- Self-selecting audience (readers who read)
+- Less instant dopamine, potentially more sustainable
+- Still subject to vanity metrics
+
+**Social (Instagram, Twitter):**
+- Public and commentable
+- Hot take culture
+- Engagement rewards controversy
+- Algorithm-driven visibility
+
+**Your job:** Know the platform you're using. Understand its pressures. Choose consciously what you're willing to do and not do.
+
+You can use platforms without being used by them—but it requires awareness.
+
+---
+
+## Audience Size and Responsibility
+
+As audience grows, responsibility changes:
+
+**Small audience:**
+- More intimate
+- You can engage meaningfully with most feedback
+- Lower stakes for missteps
+- Room to experiment
+
+**Medium audience:**
+- Less ability to respond to everyone
+- Some parasocial dynamics emerging
+- Criticism has more volume
+- Starting to need boundaries
+
+**Large audience:**
+- You cannot possibly engage with everyone
+- Strong parasocial dynamics
+- Public criticism can be intense
+- Power differential matters
+- Missteps have wider impact
+
+**The principle:** The larger your platform, the more responsibility you carry—and the more protection you need.
+
+Large audiences require:
+- Team support (if possible)
+- Clear content boundaries
+- Reduced parasocial intimacy
+- Greater care with what you share
+- Protection of your private life
+
+---
+
+## The Parasocial Problem
+
+**Parasocial relationship:** A one-sided relationship where one person (the audience) invests emotional energy in another person (the creator) who doesn't know them.
+
+**This is normal.** Humans form attachments to figures they follow. It's how our social brains work.
+
+**It becomes problematic when:**
+- The creator encourages false intimacy they can't sustain
+- The audience believes the relationship is reciprocal
+- Boundaries become blurred about what the creator owes
+- The creator's wellbeing depends on the parasocial love
+- Neither party acknowledges the inherent asymmetry
+
+**Clean practice:**
+- Be warm but boundaried
+- Don't perform intimacy you can't deliver
+- Make the asymmetry clear without being cold
+- Remember: they know a version of you; you don't know them
+
+---
+
+## Field Note: The DMs
+
+She woke up to two hundred DMs.
+
+Some were kind. Some were needy. Some were demands disguised as questions. Some were pain she didn't know how to hold from a stranger.
+
+She used to try to respond to all of them. Used to feel responsible for each person who reached out. Used to carry their stories.
+
+Now, she responds to what she can. She doesn't open everything. She has canned responses for common questions. She points people to resources instead of trying to be the resource.
+
+Some days, she feels guilty. Most days, she knows: she can't be everyone's person. She was never meant to be.
+
+*Scaling your presence doesn't scale your capacity. You are still one nervous system.*
+
+---
+
+## When Content Replaces Healing
+
+A warning:
+
+Content creation can become a way to avoid the ongoing work.
+
+**Signs this is happening:**
+
+- You're teaching material you haven't integrated
+- Your public self is more "healed" than your private self
+- You're more comfortable sharing online than with people who know you
+- Creation has replaced therapy, journaling, or support
+- You're stuck at the level you started at because you keep teaching basics
+- Your audience has become your primary relationship
+
+**The antidote:**
+- Keep doing your own work
+- Maintain support systems offline
+- Let your content grow with you
+- Stay a student while you teach
+- Have parts of your life that aren't content
+
+---
+
+## A Framework: The Three Circles
+
+Imagine three concentric circles:
+
+**Inner Circle: Sacred**
+- Material that is yours alone
+- Experiences still being processed
+- Private healing not meant for public
+- Relationships that need protection
+
+**Middle Circle: Support System**
+- Material for close friends, therapist, trusted colleagues
+- Ongoing struggles that need holding
+- Works in progress
+- Vulnerabilities that need care
+
+**Outer Circle: Public**
+- Material that's processed and integrated
+- Wisdom that can serve
+- Stories that have landed
+- Vulnerabilities you can hold publicly without activation
+
+**The discipline:** Not everything moves outward. Some things stay inner. Some things stay middle. The outer circle is selective—not your full self, but what can serve.
+
+---
+
+## Integration Questions for Content Creators
+
+Ask yourself regularly:
+
+**Am I creating from overflow or from emptiness?**
+- Overflow: I have something to give
+- Emptiness: I need something from them
+
+**Is this serving the work or my ego?**
+- Serving: This helps people
+- Ego: This makes me look good
+
+**Am I processing through creation or substituting creation for processing?**
+- Processing: The creation supports my growth
+- Substituting: The creation replaces my growth
+
+**What's my relationship with the response?**
+- Healthy: I notice feedback and let it inform me
+- Unhealthy: My worth rises and falls with engagement
+
+**Can I stop?**
+- Yes: I choose to do this
+- No: I'm compelled to do this
+
+---
+
+## Reader Reflection
+
+- Why do I create content about healing (or why do I want to)?
+- Where are my shadow motivations?
+- Am I sharing from processing or from performance?
+- What would change in my content practice if I had no audience?
+- What parts of my story are sacred and need protection?
+- Can I tolerate creating something that doesn't "do well"?
+
+**Body cue to notice:** The hit of engagement. The crash of criticism. The urgency to check.
+
+**Practice:** Content Intention Check
+
+---
+
+## Integration Line
+
+> *"Your healing is not content. Your content is an offering from healing. These are not the same thing."*
+
+---
+
+## A Final Field Note: Why She Kept Going
+
+She thought about quitting many times.
+
+The algorithm was exhausting. The parasocial intensity was draining. The comments—even the positive ones—took something from her.
+
+But she kept going. Not for the likes. Not for the brand.
+
+Because every so often, she got a message like this:
+
+"I found your video at 3 AM when I was planning to kill myself. What you said about there being a way through—I didn't believe it, but I stayed to see if you were right. It's been six months. I'm still here. Thank you."
+
+That was why.
+
+Not the thousands. The one.
+
+Content creation as service meant remembering: it was never about the many. It was always about the one person who needed it most.
+
+And for that one person, she would keep offering.
+
+*Service doesn't require scale. It requires sincerity.*
+
+---
+
+**[Continue to Chapter 20: Building Community, Not Dependency →](./20-building-community-not-dependency.md)**

--- a/book/vol-6-guide/chapters/20-building-community-not-dependency.md
+++ b/book/vol-6-guide/chapters/20-building-community-not-dependency.md
@@ -1,0 +1,583 @@
+# Chapter 20: Building Community, Not Dependency
+
+## Creating Spaces That Empower Rather Than Attach
+
+---
+
+We heal in relationship.
+
+Isolation is part of the wound. Connection is part of the cure.
+
+So it makes sense that those who guide healing often build communities—gatherings of people on similar paths, supporting each other through the work.
+
+Communities can be transformative. They can also become traps.
+
+**The difference is whether the community empowers its members to grow—or whether it needs them to stay.**
+
+---
+
+## Field Note: The Community That Held Too Tight
+
+She built the group because she knew what loneliness felt like.
+
+When she was early in her healing, she would have given anything for a space like this—people who understood, who could witness, who got it.
+
+So she created one. Online at first. Then retreats. Then a membership program.
+
+The community grew. Hundreds of members. Deep bonds. Real support.
+
+And somewhere along the way, it shifted.
+
+Members stopped graduating. They stayed. Year after year.
+
+The language inside the community became its own dialect—terms and frameworks that made sense internally but isolated members from outside perspectives.
+
+When people did leave, it felt like betrayal. The group rallied. "She just wasn't ready." "He couldn't handle the growth."
+
+She noticed—with discomfort—that she needed them as much as they needed her.
+
+The community had become a family. And like the families many members came from, it had become hard to leave.
+
+*Community can replicate the dynamics it was meant to heal.*
+
+---
+
+## The Difference Between Community and Dependency
+
+**Healthy Community:**
+- Members come and go freely
+- Relationships exist outside the group
+- Diversity of perspectives is welcome
+- The leader is not the center
+- Graduation is celebrated
+- Outside resources are encouraged
+- Members are stronger for participating
+
+**Dependent Community:**
+- Leaving is difficult or discouraged
+- Relationships become insular
+- Dissent is uncomfortable
+- The leader is essential
+- Staying is the implicit goal
+- The community is positioned as the only or best resource
+- Members are dependent on belonging
+
+**One-Line Decoder:** *Healthy communities help people need them less. Dependent communities help people need them more.*
+
+---
+
+## Why Dependency Develops
+
+Dependency isn't always intentional. It often emerges from:
+
+### 1. The Leader's Need to Be Needed
+
+If you need the community for validation, income, or identity, you may unconsciously create structures that keep people attached.
+
+### 2. Members' Familiar Patterns
+
+Many people seeking healing come from enmeshed or controlling systems. They know how to be dependent. Healthy community is unfamiliar.
+
+### 3. The Intensity of Shared Experience
+
+When people share deep pain together, bonds form quickly. These bonds can become confused with requirement.
+
+### 4. Financial Structures
+
+If your income depends on members staying, you have a perverse incentive to create stickiness.
+
+### 5. Isolation from Outside Resources
+
+When the community positions itself as special, unique, or superior, members may discount outside support.
+
+### 6. Group Identity
+
+Strong group identity creates belonging—but also creates in-group/out-group dynamics that make leaving feel like loss of self.
+
+---
+
+## Neuroscience Lens: Why Groups Feel So Good (And So Hard to Leave)
+
+Humans are wired for group belonging. We evolved in tribes. Exclusion was death.
+
+**What happens neurologically in community:**
+
+- Oxytocin releases during connection, creating bonding
+- Mirror neurons synchronize group members' nervous systems
+- Shared language creates in-group recognition
+- The prefrontal cortex tracks social standing and group norms
+- The amygdala monitors for exclusion threats
+
+**Why leaving feels hard:**
+
+- Oxytocin withdrawal creates genuine discomfort
+- The nervous system reads departure as potential isolation
+- Identity confusion arises when group identity was strong
+- Fear of being "alone again" activates old survival responses
+- The group may interpret leaving as rejection (and communicate that)
+
+**This is normal biology.** The question is whether the community uses this biology to serve members—or to trap them.
+
+---
+
+## Signs of Dependency Dynamics
+
+### In the Community
+
+- Members stay for years without visible growth
+- Leaving is framed negatively (betrayal, not being ready, losing commitment)
+- The community's language becomes specialized and separate
+- Outside perspectives are dismissed or minimized
+- Members' primary relationships are within the community
+- The leader is positioned as uniquely wise
+- Criticism of the community or leader is unwelcome
+- There's pressure to participate in all offerings
+- Stories of "what happens to people who leave" circulate
+
+### In Members
+
+- Fear of leaving that seems disproportionate
+- Identity strongly tied to community membership
+- Most close relationships are within the group
+- Difficulty accessing growth resources outside the community
+- Spending beyond their means to participate
+- Defending the community aggressively against any critique
+- Can't imagine life outside the group
+- Increasing isolation from previous relationships
+
+### In the Leader
+
+- Anxiety when members consider leaving
+- Taking departure personally
+- Subtle discouragement of graduation
+- Positioning yourself as essential
+- Difficulty celebrating when members move on
+- Financial or identity dependence on the community's continuation
+- Defensiveness about community dynamics when questioned
+
+---
+
+## Field Note: The Leader Who Noticed
+
+He had built a successful coaching community. Two years. Strong engagement. Real results.
+
+But when he looked honestly, he saw something uncomfortable.
+
+His "most committed" members were also his most struggling. They had been there since the beginning. They renewed every time. They praised him constantly.
+
+And they hadn't actually changed that much.
+
+Meanwhile, the members who had really transformed—they left. They took what they learned and moved on. He barely heard from them.
+
+He realized: he had been measuring success by retention. But retention wasn't the metric. Transformation was.
+
+The ones who stayed were comfortable. The ones who left had actually grown.
+
+*Staying can look like commitment. Sometimes it's stagnation.*
+
+---
+
+## Building Community That Empowers
+
+### 1. Design for Graduation
+
+Make leaving a built-in, celebrated outcome.
+
+- Time-limited containers (cohorts that end)
+- Graduation ceremonies or acknowledgments
+- Clear markers for when someone might be "done"
+- Celebration of departures, not mourning
+- "Alumni" status that doesn't require ongoing membership
+
+### 2. Encourage Outside Resources
+
+Never position your community as the only path.
+
+- Recommend other teachers, books, approaches
+- Welcome members' other practices
+- Avoid "our way" language
+- When someone finds something better for them, celebrate it
+- Don't compete with their therapist, other communities, or support systems
+
+### 3. Decentralize Leadership
+
+Don't make yourself the hub.
+
+- Cultivate member-to-member connection
+- Train emerging leaders
+- Step back so others can step forward
+- Your absence shouldn't collapse the community
+- The community should function without you in the room
+
+### 4. Normalize Diversity of Paths
+
+Not everyone needs the same thing. Not everyone grows the same way.
+
+- Multiple entry and exit points
+- Varying levels of engagement without hierarchy
+- Permission to participate partially
+- Recognition that not everything is for everyone
+- "This might not be for you, and that's okay"
+
+### 5. Watch Financial Incentives
+
+If your income depends on people staying, build in counterweights.
+
+- Don't structure pricing to punish leaving
+- Offer one-time options alongside subscriptions
+- Be honest with yourself about your need for renewal
+- Celebrate members who cancel because they've grown
+- Question your own motivations regularly
+
+### 6. Make It Safe to Leave
+
+The ultimate test: can people leave without drama?
+
+- No guilt trips
+- No subtle punishment
+- No stories about them after they're gone
+- The door genuinely open for return
+- Relationship not contingent on membership
+
+---
+
+## A Practice: The Community Health Check
+
+Regularly assess your community (or a community you're in):
+
+**Departure Safety**
+- How do you feel when members leave?
+- What stories circulate about people who've left?
+- Is there any cost (social, emotional) to departure?
+- Are you honest about this?
+
+**Growth Orientation**
+- Are members actually transforming?
+- Do the longest-tenured members show the most growth?
+- Is graduation normalized or rare?
+- What would "success" look like for members?
+
+**Leader Centrality**
+- How much does the community depend on you?
+- What happens when you're absent?
+- Are other leaders emerging?
+- Is your ego in check?
+
+**Outside Connection**
+- Do members maintain outside relationships?
+- Are other resources encouraged?
+- Is there humility about what the community can and can't provide?
+- Is the community a supplement or a replacement?
+
+**Honest Assessment**
+- If a cult expert evaluated your community, what would they notice?
+- What would a critical observer see?
+- Where are your blind spots likely to be?
+- Who is willing to tell you the truth?
+
+---
+
+## Field Note: What He Changed
+
+After his realization, he made changes.
+
+He created explicit "graduation" points. At six months, one year, two years—conversations about whether continued participation was still serving growth.
+
+He started referring his most loyal members to other programs. "I think you're ready for something different." At first, it felt like pushing them away. Then he saw: he was freeing them.
+
+He reduced his own presence in the group. Trained other facilitators. Made member-to-member connection the focus instead of member-to-leader connection.
+
+His renewal rates dropped. His satisfaction increased.
+
+The community became healthier—and he became less needed.
+
+Which was the point all along.
+
+*The community that needs you least is the one you've built best.*
+
+---
+
+## The In-Group/Out-Group Trap
+
+Communities create belonging. Belonging requires an "us."
+
+The shadow: "us" often creates "them."
+
+**Signs of problematic in-group dynamics:**
+
+- Special language that marks insiders
+- Stories about "people who don't get it"
+- Superiority about the community's approach
+- Dismissal of outside perspectives
+- "We understand; they don't"
+- An increasingly closed worldview
+
+**Healthy in-group dynamics:**
+
+- Shared language as tool, not test
+- Curiosity about outside perspectives
+- Humility about limitations
+- Welcoming of fresh viewpoints
+- "This works for us; other things work for others"
+- Openness to being wrong
+
+**The test:** Does belonging require separation from others? Or can members fully belong while remaining connected to outside worlds?
+
+---
+
+## Trauma Bonding in Communities
+
+Healing communities often form around shared pain. This can be powerful—and risky.
+
+**Trauma bonding:** The intense connection formed through shared suffering.
+
+**In communities, this looks like:**
+- Identity rooted in victimhood
+- Bonding through storytelling about pain
+- Difficulty moving past the wound
+- New members validated primarily by their trauma
+- Healing itself threatening to the connection (if we heal, what holds us together?)
+
+**Healthy community acknowledges pain AND moves toward growth.**
+
+- Pain is witnessed, not worshipped
+- Identity shifts from survivor to thriver
+- Healing is celebrated, not threatened
+- Connection includes but doesn't depend on shared trauma
+- New members welcomed for who they're becoming, not just what they survived
+
+---
+
+## Field Note: When Healing Became Threatening
+
+The women's group had been together for three years.
+
+They had shared their deepest pain. Held each other. Witnessed each other.
+
+Then Sarah started getting better. Really better. New relationship. New career. New energy.
+
+At first, they celebrated. But as Sarah's happiness continued—as she talked more about joy than pain—something shifted.
+
+She noticed the eye rolls. The subtle digs. "Must be nice." The energy changed when she entered the room.
+
+Eventually, she left. Not because she didn't love them. But because her healing threatened the group's identity.
+
+The community had been built on shared pain. It didn't know how to hold shared joy.
+
+*A community that can only hold wound will struggle when members heal.*
+
+---
+
+## Curating for Growth
+
+Who you let into community matters. How you support them matters more.
+
+### Entry
+
+- Clear about who it's for (and who it's not for)
+- Not promising what you can't deliver
+- Some assessment of readiness
+- Honest about what participation requires
+- Not taking everyone who pays
+
+### Belonging
+
+- Regular check-ins about whether this still serves
+- Varying levels of involvement without judgment
+- Support for those who need to step back
+- Privacy about members' journeys
+
+### Departure
+
+- Proactive conversations about graduation
+- Celebration of leaving
+- Continued connection without membership requirement
+- No burning bridges
+
+### Return
+
+- Open door for those who need to come back
+- No shame about returning
+- Not dependent on why they left
+
+---
+
+## A Practice: The Annual Departure Conversation
+
+Once a year, initiate with every long-standing member:
+
+"I want to check in about whether this community is still serving your growth. It's okay if the answer is no—that might mean you've gotten what you needed. Let's look at where you are and whether continued participation makes sense."
+
+**The purpose:**
+- Normalize graduation
+- Break the assumption that staying is default
+- Give permission to leave
+- Get honest feedback
+- Show that you value their growth over their renewal
+
+**What to listen for:**
+- Staying from momentum vs. staying from intention
+- Growth happening vs. comfort maintained
+- This community as supplement vs. this community as replacement
+- Genuine enthusiasm vs. obligation
+
+---
+
+## When Members Are Stuck
+
+Not everyone who stays is stuck. But some are.
+
+**Signs a member may be stuck:**
+- Long tenure with limited visible growth
+- Chronic participation without integration
+- Using community as substitute for harder work
+- Same issues arising year after year
+- Resistance to resources outside the community
+- Over-identification with the group
+
+**What to do:**
+- Have an honest conversation
+- Name what you're observing without judgment
+- Explore what might be needed that this community can't provide
+- Recommend specific outside resources
+- Consider whether continued participation serves them
+- Be willing to suggest they leave
+
+**This is hard.** Stuck members are often loyal, paying, and appreciative. They may not want to leave. You may not want them to leave.
+
+But if your job is their growth, sometimes the growth is out.
+
+---
+
+## The Leader's Shadow in Community
+
+Your community will reflect your unhealed parts.
+
+**Common leader shadows in community building:**
+
+- **Need to be needed:** Creates dependency, discourages graduation
+- **Fear of abandonment:** Makes leaving difficult, interprets departure as betrayal
+- **Savior complex:** Positions yourself as essential, creates over-reliance
+- **Need for control:** Discourages autonomy, maintains hierarchy
+- **Financial anxiety:** Creates structures that prioritize retention over transformation
+- **Identity attachment:** Makes the community's success your worth
+
+**The antidote:** Your own ongoing work. Supervision. Honest feedback from trusted people. Willingness to see.
+
+---
+
+## Field Note: The Honest Question
+
+Her mentor asked: "If every member graduated tomorrow, would you be okay?"
+
+She sat with it.
+
+The honest answer was no. Not financially. Not emotionally. Not identity-wise.
+
+She needed them to stay. Which meant she couldn't fully encourage them to leave.
+
+That realization was painful. And clarifying.
+
+She began building other income streams. Began investing in relationships outside the community. Began separating her worth from her membership count.
+
+It took two years. But eventually, she could answer honestly: yes.
+
+She would be okay if they all left. Which meant she was finally free to help them leave.
+
+*You can only truly liberate them when you don't need them to stay.*
+
+---
+
+## Community Red Flags
+
+For those discerning whether to join a community:
+
+**Red flags:**
+- Leaving is discouraged or punished
+- The leader is positioned as uniquely wise
+- Outside resources are dismissed
+- Long-term members seem stuck
+- Special language creates insiders and outsiders
+- Criticism is not welcome
+- Financial structures punish departure
+- Members' primary relationships are all internal
+- "Us vs. them" dynamics
+- Pressure to participate in all offerings
+
+**Green flags:**
+- Graduation is celebrated
+- The leader models ongoing learning
+- Outside resources are encouraged
+- Long-term members show genuine growth
+- Language is accessible to newcomers
+- Critique is welcome
+- Pricing respects members' autonomy
+- Members maintain outside relationships
+- Humility about limitations
+- Varying levels of participation welcome
+
+---
+
+## The Highest Goal
+
+The best communities put themselves out of business—one member at a time.
+
+They're so effective at growth that people outgrow them.
+They're so oriented toward empowerment that members need them less.
+They're so honest about limitations that people find additional resources.
+
+**This is counter to every business instinct.** But it's the heart of service.
+
+A community built on growth creates conditions for growth.
+A community built on dependency creates conditions for dependency.
+
+Which are you building?
+
+---
+
+## Reader Reflection
+
+- If I lead community: What keeps members attached? Is it growth or dependency?
+- If I'm in community: What keeps me there? Would I be okay leaving?
+- What signs of dependency might I be missing in my community?
+- How do I feel when people leave my spaces?
+- What would change if I prioritized member growth over member retention?
+- Where might my own needs be shaping the community in unhealthy ways?
+
+**Body cue to notice:** The grip when someone considers leaving. The relief when they stay. What those tell you about your attachment.
+
+**Practice:** The Annual Departure Conversation
+
+---
+
+## Integration Line
+
+> *"The community that sets people free is stronger than the one that holds them tight. Liberation, not loyalty, is the measure of success."*
+
+---
+
+## A Final Field Note: The Gathering That Ended
+
+She decided to close the community.
+
+Not because it was failing—it was thriving. But it had served its purpose. The members who needed to grow had grown. Those who hadn't weren't going to, at least not there.
+
+She announced it six months in advance. Gave people time to adjust. Created a closing ceremony.
+
+The last gathering was grief and gratitude. What they'd shared. What they'd become. How they'd changed.
+
+And then—it was over. No more container. No more automatic belonging.
+
+At first, the absence ached.
+
+Then she noticed: many of them kept connecting. Not because a membership required it. But because they had become real to each other.
+
+The community lived on—not as structure, but as relationship.
+
+That was always the point.
+
+*The best communities become unnecessary. What remains is what was real.*
+
+---
+
+**[Continue to Chapter 21: The Business of Helping (Without Selling Out) →](./21-business-of-helping.md)**

--- a/book/vol-6-guide/chapters/21-business-of-helping.md
+++ b/book/vol-6-guide/chapters/21-business-of-helping.md
@@ -1,0 +1,597 @@
+# Chapter 21: The Business of Helping (Without Selling Out)
+
+## Money, Ethics, and Sustainability in Healing Work
+
+---
+
+Let's talk about the thing most healing spaces avoid:
+
+**Money.**
+
+You offer something valuable. Something that transforms lives. Something you may have paid dearly—in suffering, in work, in time—to learn.
+
+Should you charge for it? How much? Is it ethical to profit from pain? How do you build a sustainable practice without becoming a salesperson? How do you keep your integrity when rent is due?
+
+These questions haunt those who do this work.
+
+**The spiritual bypass says:** "Money corrupts. True healers don't charge. It should be about service, not income."
+
+**The capitalist bypass says:** "Your value determines your price. Charge what you're worth. Money is just energy."
+
+**Neither is complete.**
+
+This chapter is about building an ethical, sustainable business around helping—without losing your soul.
+
+---
+
+## Field Note: The Healer Who Was Broke
+
+She was good at this work. Really good.
+
+People came to her broken and left different. Her practice was full. Her reviews were glowing.
+
+And she was barely making rent.
+
+She charged what felt "fair"—which meant what she was comfortable asking. Which meant far less than what the work was worth.
+
+When someone couldn't pay, she said yes anyway. When someone needed extra time, she gave it. When she burned out, she pushed through.
+
+She was operating from a belief she'd never examined: that charging fully for healing work made her a fraud. That true service meant sacrifice.
+
+Meanwhile, her own survival anxiety leaked into sessions. Her resentment grew. Her capacity diminished.
+
+She was so committed to not being "about the money" that she was running on empty.
+
+*Martyrdom is not a business model.*
+
+---
+
+## Why Money Feels Complicated in Healing Work
+
+This isn't arbitrary discomfort. There are real reasons:
+
+### 1. Pain Shouldn't Be For Sale
+
+There's something that feels wrong about profiting from suffering. When people are vulnerable, charging them can feel exploitative.
+
+**The truth:** Everyone who helps for a living—doctors, therapists, teachers—charges. The question isn't whether to charge, but how to do it ethically.
+
+### 2. Our Own Wounds Around Money
+
+Many drawn to healing work grew up in scarcity, or in homes where money was dirty, or where worth was never tied to income.
+
+**The truth:** Your money wound is material for your own healing—not a guide for your business.
+
+### 3. The Spiritual Community's Money Shadow
+
+Many healing traditions have explicitly devalued money. The message: spiritual people don't care about material things.
+
+**The truth:** This often leads to underpaid helpers and burned-out healers. Sustainability requires resources.
+
+### 4. Comparison to Free Information
+
+In the internet age, so much is free. Why should someone pay you when they could learn from YouTube?
+
+**The truth:** Information is abundant. Transformation is rare. You're not selling information—you're offering presence, container, and personalized support.
+
+### 5. Fear of Being "Salesy"
+
+The wellness industry has a reputation for manipulation, upselling, and predatory marketing. You don't want to be that.
+
+**The truth:** There's a difference between ethical business and exploitation. You can sell without selling out.
+
+---
+
+## Neuroscience Lens: Money and the Nervous System
+
+Money activates the nervous system in specific ways:
+
+**Scarcity triggers survival responses.** When you're unsure how you'll pay bills, your prefrontal cortex goes offline. You can't think clearly. You can't show up fully for clients.
+
+**Charging activates social threat.** Asking for money can feel like risking rejection. The amygdala reads this as danger.
+
+**Receiving money can trigger unworthiness.** If you don't believe you deserve compensation, receiving it creates dissonance.
+
+**Financial stability creates capacity.** When you're resourced, you can be present. When you're not, you leak stress into every interaction.
+
+**The mechanism:** Your nervous system state affects your clients' nervous system states. If you're financially dysregulated, that will show up in your work—no matter how much you try to hide it.
+
+---
+
+## Field Note: When She Raised Her Rates
+
+She finally did it. Raised her rates to match her peers. To reflect the training she'd done. To make her practice sustainable.
+
+She lost some clients. That hurt.
+
+She also stopped resenting sessions. Stopped feeling drained by the work. Started showing up more present.
+
+The clients who stayed—or came at the new rate—were more committed. They did more homework. They showed up more fully.
+
+She realized: her low rates hadn't just been hurting her. They'd been attracting people who weren't serious about change.
+
+The price was a filter. And it was filtering for the right things.
+
+*What you charge shapes who comes—and how they engage.*
+
+---
+
+## The Ethics of Charging
+
+Charging for healing work is not inherently unethical. How you charge can be.
+
+### Ethical Charging
+
+**Is clear about what you're offering.** No bait-and-switch. No vague promises. No claims you can't support.
+
+**Is accessible in some form.** Sliding scale, scholarships, free resources—some way for those without means to access support.
+
+**Matches the value you're providing.** Not dramatically overcharging for what you're capable of delivering.
+
+**Doesn't exploit desperation.** Not using fear, urgency, or manufactured scarcity to pressure people into buying.
+
+**Respects autonomy.** They can say no without pressure. They're not punished for declining.
+
+**Is honest about what money gets them.** Paying doesn't guarantee results. You're offering a container, not a cure.
+
+### Unethical Charging
+
+**Promising outcomes you can't deliver.** "This program will heal your trauma." "Guaranteed transformation."
+
+**Exploiting vulnerability.** Targeting people in crisis with high-pressure tactics. Using their pain against them.
+
+**Creating artificial scarcity.** "Only 3 spots left!" when there aren't. "Price goes up at midnight!" when it doesn't.
+
+**Upselling unnecessarily.** Convincing someone they need your premium offer when the basic one would serve them.
+
+**Obscuring the cost.** Hidden fees. Payment structures that take advantage of confusion.
+
+**Confusing correlation with causation.** "She made $100K after my program"—without acknowledging all the other factors.
+
+---
+
+## Pricing as a Practice
+
+How you set prices should emerge from clarity, not anxiety.
+
+### Questions to Ask
+
+**What do I need to live?**
+- What's your actual cost of living?
+- What creates financial stability for you?
+- What would let you stop worrying about rent?
+
+**What does the market support?**
+- What do peers with similar training charge?
+- What is your audience able to pay?
+- Where are you positioned in the market?
+
+**What's the value of transformation?**
+- What's it worth to heal a relationship pattern?
+- To reduce anxiety by 50%?
+- To break a generational cycle?
+- Not to exploit—but to recognize real value.
+
+**What allows for sustainability?**
+- Can you see clients at this rate for years?
+- Does this rate create burnout or capacity?
+- Are you resentful at this price?
+
+**What's your capacity?**
+- How many clients can you genuinely see well?
+- What happens if you try to see more?
+- Can you raise rates instead of expanding capacity?
+
+---
+
+## A Practice: The Pricing Inventory
+
+Get clear on your numbers:
+
+**Monthly needs:**
+- Rent/mortgage
+- Utilities
+- Food
+- Transportation
+- Healthcare
+- Debt payments
+- Savings
+- Self-care (therapy, supervision, etc.)
+- Professional expenses
+- Buffer for unexpected costs
+
+**Total needed monthly:** $_____
+
+**Work capacity:**
+- Hours you can work per week sustainably: _____
+- Client hours per week (not total work hours): _____
+- Weeks you work per year (allowing for rest): _____
+
+**Rate calculation:**
+- Total needed annually ÷ billable hours annually = minimum rate
+- Add buffer for taxes (25-40% depending on location)
+- This is your floor—the minimum you can charge sustainably
+
+**Reality check:**
+- Is this rate realistic for your market?
+- If it's higher than market, what needs to change?
+- If it's lower, can you charge what the market will bear?
+
+---
+
+## The Sliding Scale Question
+
+Many healers offer sliding scale—reduced rates for those with less means.
+
+**The argument for:**
+- Increases access
+- Acknowledges economic inequality
+- Aligns with values of service
+- Allows work with populations who couldn't otherwise afford it
+
+**The argument against:**
+- Can leave you under-resourced
+- May attract those not serious about the work
+- Puts burden on you to assess who "deserves" lower rates
+- Can create resentment over time
+
+**A middle path:**
+
+**Structured sliding scale:**
+- Clear criteria for who qualifies
+- Set number of sliding-scale spots
+- Explicit that it's limited
+- Not "whatever you can pay"
+
+**Scholarship model:**
+- Full-rate clients fund scholarship spots
+- Limited spots available
+- Application process
+- Clarity that this is a gift, not an entitlement
+
+**Free resources:**
+- Content, groups, or introductory offerings that are free
+- Paid work for those who want deeper engagement
+- Not everything has to be paid; not everything has to be free
+
+**Pro bono:**
+- Set number of pro bono clients per month/year
+- Clear boundaries around it
+- Not indefinite
+
+---
+
+## Field Note: The Sliding Scale That Slid
+
+He offered sliding scale to everyone.
+
+"Pay what feels right," he said. "I trust you to know what you can afford."
+
+What he got: mostly people paying toward the bottom. Including some who could clearly afford more.
+
+He noticed resentment building. Noticed himself giving less to lower-paying clients. Noticed the energy wasn't clean.
+
+He changed his approach. Set three clear rates: standard, reduced (with simple income verification), and full scholarship (limited spots, application required).
+
+The clarity helped. He stopped resenting. The clients who paid full rate felt good about supporting access. The ones on scholarship felt held, not guilty.
+
+*Unclear generosity breeds resentment. Clear generosity sustains.*
+
+---
+
+## The Marketing Question
+
+You have something to offer. People need to know about it.
+
+But marketing in the healing space is fraught. So much manipulation. So much hype. So many promises.
+
+**Clean marketing:**
+
+**Is honest.** Accurately describes what you offer. Doesn't exaggerate results. Doesn't claim what you can't deliver.
+
+**Is invitational.** Offers without pressure. Lets people say no. Doesn't manufacture urgency.
+
+**Is human.** Sounds like you. Not like a marketing template. Not like everyone else in your space.
+
+**Is boundaried.** Doesn't overshare to create intimacy. Doesn't trauma-bait for attention. Doesn't exploit your own story for clicks.
+
+**Is sustainable.** You can do this for years without burning out. You're not performing.
+
+**Unclean marketing:**
+
+- Manufactured urgency and false scarcity
+- Promises of guaranteed results
+- Testimonials that imply everyone will have the same outcome
+- Pain-point exploitation ("Are you sick of...?")
+- Bait-and-switch tactics
+- Making people feel broken so you can sell the fix
+- Aspirational images that create inadequacy
+- Appeals to fear, shame, or envy
+
+---
+
+## A Practice: The Marketing Integrity Check
+
+Before any marketing message:
+
+**1. Is this true?**
+- Am I exaggerating?
+- Can I actually deliver this?
+- Are these results typical or exceptional?
+
+**2. Is this clean?**
+- Am I creating urgency artificially?
+- Am I exploiting vulnerability?
+- Would I say this to someone I love?
+
+**3. Is this me?**
+- Does this sound like my actual voice?
+- Am I copying tactics that don't fit me?
+- Would I be embarrassed if a respected colleague saw this?
+
+**4. Is this sustainable?**
+- Can I keep doing this?
+- Does this feel energizing or depleting?
+- Am I performing or sharing?
+
+---
+
+## Field Note: The Launch That Felt Wrong
+
+She copied the formula. The "best practices" from the marketing gurus.
+
+Pain points in the headline. Countdown timers. "Doors close tonight!" Testimonials with income claims. Bonuses for fast action.
+
+It worked. The course sold out.
+
+And she felt sick.
+
+She didn't want clients who came from fear. She didn't want to build a business on manufactured urgency. She didn't want to be the person who wrote those emails.
+
+The next launch, she did it differently. Clear, calm, honest. "Here's what I offer. Here's who it's for. Here's the price. Take your time."
+
+It sold less. She felt better.
+
+Over time, the people who came—the ones who came from genuine resonance instead of manufactured pressure—became her best clients.
+
+*The launch strategy that builds the list isn't always the one that builds the right relationship.*
+
+---
+
+## The Upsell Dilemma
+
+You have multiple offerings. How do you encourage people to go deeper without being manipulative?
+
+**Clean upselling:**
+
+- They've genuinely gotten value from the first thing
+- The next offering truly serves their evolution
+- They have room to say no without pressure
+- You don't need them to say yes
+- The transition is invitational, not automatic
+
+**Unclean upselling:**
+
+- The first thing was a loss-leader designed to convert
+- The next offering primarily serves your revenue
+- Pressure is applied through scarcity or shame
+- You're attached to their yes
+- They're enrolled before they've decided
+
+**The question:** Am I offering this because they need it, or because I need them to buy it?
+
+---
+
+## Business Models for Helpers
+
+There are many ways to structure helping work. Each has tradeoffs:
+
+### One-on-One Sessions
+
+**Pros:** Deepest work. Highest per-hour rate possible. Full attention.
+
+**Cons:** Limited by your time. High energy cost. Income ceiling.
+
+### Group Programs
+
+**Pros:** Leverage your time. Create community. More accessible price point.
+
+**Cons:** Less personalized. Requires facilitation skills. Some people need 1:1.
+
+### Courses/Products
+
+**Pros:** Income while you sleep. Scalable. Lower barrier.
+
+**Cons:** Lower completion rates. Less transformation. Need marketing.
+
+### Memberships/Subscriptions
+
+**Pros:** Recurring revenue. Ongoing relationship. Community.
+
+**Cons:** Retention challenges. Creating constant content. Dependency risk.
+
+### Writing/Books
+
+**Pros:** Wide reach. Established credibility. Passive income.
+
+**Cons:** Low per-unit revenue. Intense creation process. No guarantee of success.
+
+### Speaking/Workshops
+
+**Pros:** High impact. One-time events. Visible positioning.
+
+**Cons:** Requires travel. Inconsistent income. Energy-intensive.
+
+**The sustainable practice often combines several.** The mix depends on your energy, capacity, life stage, and what serves your audience.
+
+---
+
+## Field Note: The Mix That Worked
+
+She tried to do it all. One-on-one clients. A course. A membership. A podcast. Speaking.
+
+She was everywhere. And nowhere.
+
+Finally, she simplified. One-on-one as the anchor. One group program per year. Content that didn't require production value.
+
+Her income dropped slightly. Her life got immeasurably better. Her work got deeper.
+
+The multiple revenue streams weren't diversification—they were fragmentation. She needed focus more than scale.
+
+*More isn't always more. Sometimes less is finally enough.*
+
+---
+
+## The Burnout Prevention Budget
+
+Most helpers who burn out don't budget for sustainability.
+
+**Include in your pricing:**
+
+- Regular supervision (you need to be held to hold others)
+- Your own therapy (ongoing, not just crisis)
+- Rest days (not sick days—intentional rest)
+- Vacation weeks (multiple, actually taken)
+- Professional development (learning keeps you fresh)
+- Admin support (if possible—you don't have to do everything)
+- Buffer for dry spells (income fluctuates)
+
+**If your pricing doesn't allow for these, your pricing is too low.**
+
+You cannot sustain helping work from depletion. The extra you charge to care for yourself is not greed—it's survival.
+
+---
+
+## When Money Feels Wrong
+
+There are times when charging feels off. Listen to that.
+
+**It might mean:**
+- This person genuinely can't pay, and you want to help anyway
+- What they need is beyond your scope
+- You're not confident in what you're offering
+- Something about the relationship feels exploitative
+- They're not ready for the work
+
+**Questions to ask:**
+- Is this discomfort about them—or about my own money wound?
+- Am I avoiding charging because it's genuinely right, or because it's easier?
+- What does my body say?
+- What would I tell a colleague in this situation?
+
+**Sometimes the answer is:** don't charge this person. Do it pro bono. Refer them to someone else. Decline.
+
+**Sometimes the answer is:** my discomfort is my material, not a guide. Charge fairly.
+
+The skill is discernment.
+
+---
+
+## A Practice: The Annual Business Review
+
+Once a year, assess:
+
+**Financial sustainability:**
+- Am I making enough to live well?
+- Am I saving for the future?
+- Am I resenting my rates?
+- Is my income stable or unpredictable?
+
+**Energy sustainability:**
+- Is my caseload sustainable?
+- Am I taking real time off?
+- Am I investing in my own support?
+- Do I still love this work?
+
+**Ethical alignment:**
+- Am I proud of how I price and market?
+- Would I tell my best clients how I got my other clients?
+- Are my practices aligned with my values?
+- Where might I be rationalizing?
+
+**Growth and learning:**
+- Am I still developing as a practitioner?
+- Have I gotten new training or supervision?
+- Am I stuck at the level I started?
+- What do I need to learn next?
+
+---
+
+## The Integrity of Enough
+
+There's a moment where you have enough.
+
+Enough clients. Enough income. Enough reach.
+
+**This is a dangerous moment.** Because capitalism says there's never enough. Growth says more is always better. Comparison says someone else has more.
+
+**The practice:** Knowing your enough.
+
+What's actually sufficient for you? Not what's possible. Not what others have. What do you actually need to live well and serve well?
+
+Once you have that—can you stop chasing?
+
+This is where the spiritual practice lives. Not in poverty. Not in excess. In enough.
+
+---
+
+## Field Note: The Offer She Declined
+
+She was offered the book deal. The one that would have scaled everything. National platform. "Healing celebrity" status.
+
+She could see the path: more speaking, more visibility, more influence, more money.
+
+She said no.
+
+Not because it was wrong. But because she didn't want it. Because her practice was already full of people she loved working with. Because she had enough.
+
+Her agent was confused. Her peers were confused. She wasn't.
+
+She had found her enough. And she was staying there.
+
+*The business of helping includes knowing when to stop building.*
+
+---
+
+## Reader Reflection
+
+- What are my money wounds, and how do they show up in my business?
+- Am I charging what allows for sustainability?
+- Is my marketing aligned with my values?
+- Where am I overworking because I'm not charging enough?
+- What's my "enough"—and am I there?
+- What would change if I treated my livelihood as sacred?
+
+**Body cue to notice:** The tension around asking for money. The relief when you don't have to. What those say about your relationship with worth.
+
+**Practice:** The Pricing Inventory
+
+---
+
+## Integration Line
+
+> *"Sustainability is not selling out. It's what lets you keep showing up. Your business can be built on integrity—if you're willing to build slowly and honestly."*
+
+---
+
+## A Final Field Note: What She Wishes She'd Known
+
+Ten years in, she was asked to mentor a new practitioner.
+
+The young woman asked: "How do I make a living at this without compromising my values?"
+
+She thought about all the mistakes. The burnout. The undercharging. The marketing she regretted. The overwork.
+
+Then she said:
+
+"Charge enough to take care of yourself. Market like a human, not a funnel. Say no more than you say yes. Have boundaries with money like you have boundaries with everything else. And know your enough—the place where you stop chasing and start living."
+
+The young woman wrote it down.
+
+"One more thing," she added. "The healers who make it aren't the ones who sacrifice themselves. They're the ones who figured out how to stay. Your sustainability isn't selfish. It's what lets you keep doing this for decades instead of years."
+
+*Build for the long game. Your service depends on your survival.*
+
+---
+
+**[Continue to Chapter 22: When You Outgrow Your Audience →](./22-outgrowing-your-audience.md)**


### PR DESCRIPTION
Expand Part IV (Sustainable Practice) and Part V (The Path of the Guide):

- Ch 17: Supervision & Support Systems - Building the container that holds the helper
- Ch 18: Teaching Without Converting - Offering truth without needing it taken
- Ch 19: Content Creation as Service - Sharing healing without performing it
- Ch 20: Building Community, Not Dependency - Creating spaces that empower
- Ch 21: The Business of Helping - Money, ethics, and sustainability

Each chapter includes field notes, neuroscience foundations, practical
practices, and integration questions in the established series style.