### PR TITLE
🔄 Move content creation to Vol 2 with readiness assessment

### DIFF
--- a/book/vol-1-decoder/README.md
+++ b/book/vol-1-decoder/README.md
@@ -33,11 +33,10 @@
 
 | Appendix | Title | Description |
 |----------|-------|-------------|
-| [Appendix A](./appendices/appendix-a-content-creation.md) | Content Creation Structure | Turning your experience into teaching |
-| [Appendix B](./appendices/appendix-b-childhood-patterns.md) | Understanding Your Childhood Patterns | How early experiences shape adult vulnerability |
-| [Appendix D](./appendices/appendix-d-resources.md) | Resources | Books, hotlines, and further reading |
-| [Appendix E](./appendices/appendix-e-glossary.md) | Glossary | Key terms defined |
-| [Appendix F](./appendices/appendix-f-bibliography.md) | Bibliography | Sources and references |
+| [Appendix A](./appendices/appendix-a-childhood-patterns.md) | Understanding Your Childhood Patterns | How early experiences shape adult vulnerability |
+| [Appendix B](./appendices/appendix-b-resources.md) | Resources | Books, hotlines, and further reading |
+| [Appendix C](./appendices/appendix-c-glossary.md) | Glossary | Key terms defined |
+| [Appendix D](./appendices/appendix-d-bibliography.md) | Bibliography | Sources and references |
 
 ---
 
@@ -67,7 +66,7 @@ Read the book in order starting from the [Front Matter](./00-front-matter.md). T
 The **Decoder Cards** in Chapters [11](./chapters/11-decoder-cards-core.md), [12](./chapters/12-decoder-cards-advanced.md), and [13](./chapters/13-decoder-cards-protocol.md) are designed to be shared—use them as conversation starters or teaching tools.
 
 ### 🎬 If You're Creating Content
-**[Appendix A: Content Creation Structure](./appendices/appendix-a-content-creation.md)** provides a framework for turning this material into videos, posts, and educational content.
+When you're ready to share what you've learned, **[Appendix D: Content Creation Structure](../vol-2-bridge/appendices/appendix-d-content-creation.md)** in Volume 2 provides a framework for turning this material into videos, posts, and educational content—including a readiness self-assessment to ensure you're speaking from healing, not from the wound.
 
 ---
 
@@ -139,11 +138,10 @@ PART IV: RESPONSE & RECOVERY
 └── Chapter 16 ............ Moving Forward
 
 APPENDICES
-├── Appendix A ............ Content Creation Structure
-├── Appendix B ............ Childhood Patterns
-├── Appendix D ............ Resources
-├── Appendix E ............ Glossary
-└── Appendix F ............ Bibliography
+├── Appendix A ............ Childhood Patterns
+├── Appendix B ............ Resources
+├── Appendix C ............ Glossary
+└── Appendix D ............ Bibliography
 ```
 
 ---

--- a/book/vol-1-decoder/appendices/appendix-a-childhood-patterns.md
+++ b/book/vol-1-decoder/appendices/appendix-a-childhood-patterns.md
@@ -1,4 +1,4 @@
-# Appendix C: Understanding Your Childhood Patterns
+# Appendix A: Understanding Your Childhood Patterns
 
 ## How Early Experiences Shape Adult Vulnerability
 

--- a/book/vol-1-decoder/appendices/appendix-b-resources.md
+++ b/book/vol-1-decoder/appendices/appendix-b-resources.md
@@ -1,4 +1,4 @@
-# Appendix D: Resources
+# Appendix B: Resources
 
 ## Support, Information, and Next Steps
 

--- a/book/vol-1-decoder/appendices/appendix-c-glossary.md
+++ b/book/vol-1-decoder/appendices/appendix-c-glossary.md
@@ -1,4 +1,4 @@
-# Appendix E: Glossary of Terms
+# Appendix C: Glossary of Terms
 
 ## Key Concepts and Definitions
 

--- a/book/vol-1-decoder/appendices/appendix-d-bibliography.md
+++ b/book/vol-1-decoder/appendices/appendix-d-bibliography.md
@@ -1,4 +1,4 @@
-# Appendix F: Bibliography & Further Reading
+# Appendix D: Bibliography & Further Reading
 
 ## Sources, Influences, and Recommended Reading
 

--- a/book/vol-2-bridge/README.md
+++ b/book/vol-2-bridge/README.md
@@ -69,6 +69,7 @@
 | [Appendix A](./appendices/appendix-a-grief-process.md) | The Grief Process | Navigating the waves of loss |
 | [Appendix B](./appendices/appendix-b-vignettes.md) | Composite Vignettes | Recognizable stories for reflection |
 | [Appendix C](./appendices/appendix-c-worksheets.md) | Self-Assessment Charts & Worksheets | Practical tools for application |
+| [Appendix D](./appendices/appendix-d-content-creation.md) | Content Creation Structure | Turning your experience into teaching (with readiness assessment) |
 
 ---
 
@@ -107,6 +108,10 @@ Think of this book as a place you can return to, not a task to complete.
 **🔹 You feel regulated but want to build something new**
 - [Chapter 20: The Secure Attachment Training Arc](./chapters/20-secure-attachment-training.md)
 - [Chapter 21: Role-Based Reparenting Practices](./chapters/21-reparenting-practices.md)
+
+**🔹 You want to create content about your healing journey**
+- Complete your healing work in this volume first
+- [Appendix D: Content Creation Structure](./appendices/appendix-d-content-creation.md) — Includes a readiness self-assessment to ensure you're speaking from integration, not activation
 
 ---
 
@@ -170,7 +175,8 @@ PART VII: INTEGRATION
 APPENDICES
 ├── Appendix A ............ The Grief Process
 ├── Appendix B ............ Composite Vignettes
-└── Appendix C ............ Self-Assessment Charts & Worksheets
+├── Appendix C ............ Self-Assessment Charts & Worksheets
+└── Appendix D ............ Content Creation (with Readiness Assessment)
 ```
 
 ---

--- a/book/vol-2-bridge/appendices/appendix-d-content-creation.md
+++ b/book/vol-2-bridge/appendices/appendix-d-content-creation.md
@@ -1,10 +1,162 @@
-# Appendix A: Content Creation Structure
+# Appendix D: Content Creation Structure
 
 ## Turning Your Experience into Teaching
 
 ---
 
 If you feel called to share what you've learned—through YouTube, Instagram, TikTok, podcasts, or writing—this appendix provides structure for creating content that helps others recognize the patterns you've decoded.
+
+But first: a crucial question.
+
+---
+
+## Before You Begin: The Readiness Self-Assessment
+
+Content creation about trauma recovery requires speaking from healing, not from the wound. This assessment helps you determine if now is the right time.
+
+**Why This Matters:**
+
+Creating content while still in the acute phase of healing can:
+- Retraumatize you through repeated telling
+- Freeze your identity in "survivor" rather than allowing evolution
+- Attract audiences who mirror your unresolved material
+- Create parasocial dynamics that substitute for real connection
+- Make your healing performative rather than genuine
+
+The goal is to share from a place of integration, not processing.
+
+---
+
+### The 90-Day Rule
+
+**Before creating any public content about your healing journey, you should be at least 90 days past:**
+
+- Your last contact with the person who harmed you
+- Your last major emotional dysregulation episode related to this material
+- Your last significant relationship crisis stemming from these patterns
+- Any active safety concerns
+
+90 days allows your nervous system to settle enough that you're teaching from clarity, not activation.
+
+**If you're under 90 days:** Focus on private processing—journaling, therapy, trusted friends. The content will be better for waiting.
+
+---
+
+### Motivation Self-Check
+
+Answer honestly. There are no wrong answers, but some indicate "not yet."
+
+**Check your primary motivation:**
+
+| Motivation | Readiness Signal |
+|------------|------------------|
+| "I want to help others avoid what I went through" | Green: Healthy service orientation |
+| "I want to consolidate my learning by teaching" | Green: Integration through articulation |
+| "I want to create meaning from painful experience" | Green: Transmutation |
+| "I want to build community with people who understand" | Green: Connection-seeking |
+| "I want them to see what they did to me" | Red: Revenge energy—wait |
+| "I want validation that I'm not crazy" | Yellow: Seek this in therapy first |
+| "I want to feel important/special/seen" | Yellow: Explore this need privately first |
+| "I want to process what happened to me" | Red: Processing belongs in private containers |
+| "I want to warn everyone about this specific person" | Red: Legal risk and revenge energy—wait |
+
+**If you checked any Red items:** This isn't the right time. Return to this after more private processing.
+
+**If you checked Yellow items:** These motivations aren't disqualifying, but explore them in therapy first. They can coexist with green motivations once examined.
+
+---
+
+### Nervous System Self-Check
+
+Your body will tell you if you're ready. Rate each statement 1-5:
+
+*1 = Not true at all, 5 = Completely true*
+
+**Regulation Capacity:**
+
+- [ ] I can discuss my experience without my heart racing or feeling flooded ___
+- [ ] I can receive critical feedback without spiraling ___
+- [ ] I can take breaks from this material without feeling pulled back compulsively ___
+- [ ] I can set my phone down and not check engagement metrics for hours ___
+- [ ] I have experienced long stretches (days/weeks) where I don't think about what happened ___
+
+**Emotional Stability:**
+
+- [ ] My mood is not primarily determined by my trauma material ___
+- [ ] I have sources of joy unrelated to my healing journey ___
+- [ ] I can witness others' pain without absorbing it as my own ___
+- [ ] I don't need to talk about my trauma in every conversation ___
+- [ ] I can be with people who don't "get it" without feeling unseen ___
+
+**Identity Integration:**
+
+- [ ] Being a survivor/thriver is part of my identity, not all of it ___
+- [ ] I can introduce myself without referencing my trauma history ___
+- [ ] My vision of my future includes things unrelated to this material ___
+- [ ] I know who I am beyond what was done to me ___
+- [ ] I can celebrate wins in my life without immediately connecting them to my healing ___
+
+**Scoring:**
+- 60-75: Strong readiness signals. Proceed with awareness.
+- 45-59: Mixed readiness. Consider waiting, or start very slowly with strong support.
+- Below 45: Not yet. Focus on private healing. This content will be here when you're ready.
+
+---
+
+### Support System Self-Check
+
+Content creation about sensitive material requires support infrastructure:
+
+**Essential support (need all three):**
+
+- [ ] **Therapeutic support:** A therapist or counselor who knows about your content plans
+- [ ] **Personal support:** At least one person who will tell you honestly if you're dysregulated
+- [ ] **Practical support:** Someone who can help you take breaks when needed
+
+**Helpful support (having these reduces risk):**
+
+- [ ] Community of peers doing similar work
+- [ ] Mentor who has created content in this space
+- [ ] Boundaries around work hours and engagement
+- [ ] Financial stability not dependent on content success
+- [ ] Physical practices (exercise, yoga, somatic work) to process activation
+
+**Red flags in your support system:**
+
+- [ ] Your therapist thinks this is premature (listen to them)
+- [ ] Your support people express concern about your stability
+- [ ] You're isolated and this content is your main connection
+- [ ] You're in financial desperation and need this to work
+- [ ] You have no boundaries between content and personal life
+
+---
+
+### The Readiness Decision
+
+Based on your self-assessment:
+
+**Ready to proceed if:**
+- 90+ days since last activation
+- All or mostly green motivations
+- Nervous system score 60+
+- All three essential supports in place
+- No red flags in support system
+
+**Wait and reassess in 30 days if:**
+- Under 90 days but stable
+- Yellow motivations alongside green ones
+- Nervous system score 45-59
+- Missing one essential support
+- Working on red flags actively
+
+**Focus on private healing if:**
+- Under 90 days and still activated
+- Any red motivations
+- Nervous system score below 45
+- Missing two or more essential supports
+- Multiple support system red flags
+
+There is no shame in waiting. The content you create from a healed place will help more people than content created from a wounded place. And you matter more than any content you could create.
 
 ---
 
@@ -129,7 +281,7 @@ Always end with agency. People should leave feeling equipped, not helpless.
 - Consistent visual branding
 - Readable fonts (not too small)
 - One point per slide
-- Use the decoder card format from Chapter 8
+- Use the decoder card format from Volume 1
 
 ### Long-Form Writing (Blog, Substack, Book)
 
@@ -434,6 +586,29 @@ Build from there based on response and questions.
 
 ---
 
+## Ongoing Self-Monitoring
+
+Once you begin creating content, maintain awareness:
+
+**Weekly check-in questions:**
+- Am I enjoying this, or does it feel compulsive?
+- Am I speaking from integration or from activation?
+- Is my content serving my audience or my ego?
+- Am I able to take breaks without anxiety?
+- Are my offline relationships nourished?
+
+**Warning signs to pause:**
+- Checking metrics compulsively
+- Mood determined by engagement
+- Feeling triggered by every troll
+- Neglecting therapy or support practices
+- Content becoming more about you than teaching
+- Losing joy in the work
+
+If you notice warning signs, take a planned break. The content will be there when you return. Your healing matters more.
+
+---
+
 ## Final Thoughts
 
 You don't have to create content to heal. This is optional.
@@ -444,7 +619,10 @@ The confusion you once felt can become clarity for someone else. The patterns yo
 
 That's alchemy. That's transmutation. That's turning pain into purpose.
 
+But the alchemy only works from a place of integration. Speak from healing, not from the wound. The content will be more powerful, you will be more protected, and the work will be sustainable.
+
 ---
 
 *Every time you help someone else name the pattern, you both get freer.*
 
+*Just make sure you're free enough first.*


### PR DESCRIPTION
Content creation about trauma recovery requires speaking from healing,
not from the wound. Moving this appendix to Volume 2 ensures readers
complete their healing journey first.

Changes:
- Move content creation from Vol 1 Appendix A to Vol 2 Appendix D
- Add comprehensive readiness self-assessment (motivation, nervous
  system, support checks, and 90-day rule)
- Re-letter Vol 1 appendices (childhood patterns now Appendix A)
- Update both volume READMEs with correct links and reading paths