### PR TITLE
📝 Resolve copy editing issues from issue #131

### DIFF
--- a/book/vol-1-decoder/appendices/appendix-e-index.md
+++ b/book/vol-1-decoder/appendices/appendix-e-index.md
@@ -84,9 +84,9 @@ This index provides quick access to the major concepts, tactics, and tools discu
   - Responses .................... [pg. XX]
 
 **Decoder Cards** .................... [pg. XX]
-  - Advanced patterns (Chapter 12) .................... [pg. XX]
-  - Core patterns (Chapter 11) .................... [pg. XX]
-  - Emergency protocol (Chapter 13) .................... [pg. XX]
+  - Advanced patterns (Chapter 15) .................... [pg. XX]
+  - Core patterns (Chapter 14) .................... [pg. XX]
+  - Emergency protocol (Chapter 16) .................... [pg. XX]
   - How to use .................... [pg. XX]
 
 **Devalue** (phase) .................... [pg. XX]
@@ -123,7 +123,7 @@ This index provides quick access to the major concepts, tactics, and tools discu
   - In family systems .................... [pg. XX]
   - Recognition .................... [pg. XX]
 
-**Energetic Remapping** — See Chapter 14 .................... [pg. XX]
+**Energetic Remapping** — See Chapter 17 .................... [pg. XX]
   - Exercises .................... [pg. XX]
   - Nervous system tools .................... [pg. XX]
 
@@ -135,7 +135,7 @@ This index provides quick access to the major concepts, tactics, and tools discu
   - In family systems .................... [pg. XX]
   - Recovery from .................... [pg. XX]
 
-**Exposure Questions** — See Chapter 17 .................... [pg. XX]
+**Exposure Questions** — See Chapter 13 .................... [pg. XX]
 
 ---
 
@@ -144,10 +144,10 @@ This index provides quick access to the major concepts, tactics, and tools discu
 **False Self** .................... [pg. XX]
 
 **Family Systems** .................... [pg. XX]
-  - Breaking free (Chapter 8) .................... [pg. XX]
-  - Roles and triangulation (Chapter 6) .................... [pg. XX]
+  - Breaking free (Chapter 9) .................... [pg. XX]
+  - Roles and triangulation (Chapter 7) .................... [pg. XX]
 
-**Father Wound** — See Chapter 7 .................... [pg. XX]
+**Father Wound** — See Chapter 8 .................... [pg. XX]
 
 **FLEAS** (maladaptive behaviors) .................... [pg. XX]
 
@@ -243,8 +243,8 @@ This index provides quick access to the major concepts, tactics, and tools discu
 ## M
 
 **Manipulation** .................... [pg. XX]
-  - Across contexts (Chapter 10) .................... [pg. XX]
-  - In romantic relationships (Chapter 9) .................... [pg. XX]
+  - Across contexts (Chapter 12) .................... [pg. XX]
+  - In romantic relationships (Chapter 11) .................... [pg. XX]
   - Tactics (Chapter 3) .................... [pg. XX]
 
 **Masking** .................... [pg. XX]
@@ -253,7 +253,7 @@ This index provides quick access to the major concepts, tactics, and tools discu
   - During love-bombing .................... [pg. XX]
   - Recognition .................... [pg. XX]
 
-**Mother Wound** — See Chapter 7 .................... [pg. XX]
+**Mother Wound** — See Chapter 8 .................... [pg. XX]
 
 **Moving Goalposts** .................... [pg. XX]
 
@@ -312,7 +312,7 @@ This index provides quick access to the major concepts, tactics, and tools discu
   - Effects .................... [pg. XX]
   - In childhood .................... [pg. XX]
 
-**Parental Wounds** — See Chapter 7 .................... [pg. XX]
+**Parental Wounds** — See Chapter 8 .................... [pg. XX]
 
 **Projection** .................... [pg. XX]
   - Examples .................... [pg. XX]
@@ -335,11 +335,11 @@ This index provides quick access to the major concepts, tactics, and tools discu
   - After gaslighting .................... [pg. XX]
   - Methods .................... [pg. XX]
 
-**Recovery Tools** — See Chapter 14 .................... [pg. XX]
+**Recovery Tools** — See Chapter 17 .................... [pg. XX]
 
 **Reparenting** .................... [pg. XX]
 
-**Responses, Practical** — See Chapter 15 .................... [pg. XX]
+**Responses, Practical** — See Chapter 18 .................... [pg. XX]
   - Scripts .................... [pg. XX]
   - Strategies .................... [pg. XX]
 
@@ -356,7 +356,7 @@ This index provides quick access to the major concepts, tactics, and tools discu
   - Long-term effects .................... [pg. XX]
   - Recovery .................... [pg. XX]
 
-**Scripts** — See Chapter 15 .................... [pg. XX]
+**Scripts** — See Chapter 18 .................... [pg. XX]
 
 **Silent Treatment** .................... [pg. XX]
   - Responses .................... [pg. XX]

--- a/book/vol-1-decoder/chapters/03a-narcissist-playbook-part1.md
+++ b/book/vol-1-decoder/chapters/03a-narcissist-playbook-part1.md
@@ -50,7 +50,7 @@ These tactics are about establishing dominance: who has power, who sets the agen
 
 **Your power move:** "I'm going to finish this. We can talk when I'm done." Then finish. Do not explain, justify, or apologize for having your own activities.
 
-> *"He'll break your meditation to prove your focus belongs to him."*
+> *"They'll break your meditation to prove your focus belongs to them."*
 
 ---
 
@@ -76,7 +76,7 @@ These tactics are about establishing dominance: who has power, who sets the agen
 
 **Your power move:** Lower your voice instead of raising it. Or simply say: "I'm going to pause this conversation until we can both speak at normal volume." Then leave the room if needed.
 
-> *"He doesn't shout because he's angry—he shouts to rewrite the room's frequency."*
+> *"They don't shout because they're angry—they shout to rewrite the room's frequency."*
 
 ---
 
@@ -104,7 +104,7 @@ These tactics are about establishing dominance: who has power, who sets the agen
 
 **Your power move:** Stop trying to organize their chaos. Create clear, protected space for yourself (even if it's just one room, one corner, one hour). Chaos is their problem, not yours to solve.
 
-> *"His environment reflects the chaos he refuses to clean inside."*
+> *"Their environment reflects the chaos they refuse to clean inside."*
 
 ---
 

--- a/book/vol-1-decoder/chapters/07-family-roles-triangulation.md
+++ b/book/vol-1-decoder/chapters/07-family-roles-triangulation.md
@@ -50,13 +50,13 @@ The roles are not about who you are. They're about what the system needed you to
 
 **The hidden cost:** Being loved conditionally, for performance and compliance rather than for self. Carrying the weight of the narcissist's projected perfection. Never being seen as a real person with flaws. Fear of falling from grace.
 
-**What it feels like to be the golden child:**
+**What it feels like to be the Golden Child:**
 
-On the surface, you have everything. Approval. Attention. The parent's warmth—when you perform. But underneath, you feel the precariousness. You know the love can be withdrawn. You've seen what happens to the scapegoat when they displease.
+On the surface, you have everything. Approval. Attention. The parent's warmth—when you perform. But underneath, you feel the precariousness. You know the love can be withdrawn. You've seen what happens to the Scapegoat when they displease.
 
 So you perform. Perfectly. Exhaustingly. You become who they need you to be. And somewhere in there, you lose track of who you actually are.
 
-The worst part: you might not even realize you're suffering. Everyone tells you how lucky you are. The scapegoat resents you. You're supposed to be grateful. But the cage is still a cage, even when it's gold.
+The worst part: you might not even realize you're suffering. Everyone tells you how lucky you are. The Scapegoat resents you. You're supposed to be grateful. But the cage is still a cage, even when it's gold.
 
 **Adult patterns:** May struggle with perfectionism, fear of failure, difficulty with authentic relationships (accustomed to performing rather than being), or may become narcissistic themselves. Often has imposter syndrome—the praise never felt deserved because it was for the performance, not the person.
 
@@ -70,11 +70,11 @@ The worst part: you might not even realize you're suffering. Everyone tells you 
 
 **The hidden gift:** Scapegoats often see the truth that others deny. Their "problematic" behavior may be healthy rebellion against a sick system. They're often the first to break free.
 
-**What it feels like to be the scapegoat:**
+**What it feels like to be the Scapegoat:**
 
 You carry the family's shadow. Their dysfunction, their shame, their failures—all projected onto you. You're the reason things are hard. You're too sensitive, too angry, too difficult, too much.
 
-You may have internalized it. Believed you really were the problem. Spent years trying to be "better," to finally earn the love that flowed so easily to the golden child. Or you stopped trying and became what they said you were—because at least that was something.
+You may have internalized it. Believed you really were the problem. Spent years trying to be "better," to finally earn the love that flowed so easily to the Golden Child. Or you stopped trying and became what they said you were—because at least that was something.
 
 The crazy-making part: when you point out what's wrong, you become proof of what's wrong. Your accurate perception becomes your pathology.
 
@@ -129,11 +129,11 @@ And when you try to be serious, to share something real, it feels wrong. They ex
 Important: these roles aren't fixed identities. They're positions in a system.
 
 The same person might be:
-- Golden child with one parent, scapegoat with the other
-- Golden child as a kid, scapegoat after setting boundaries as an adult
+- Golden Child with one parent, Scapegoat with the other
+- Golden Child as a kid, Scapegoat after setting boundaries as an adult
 - Different roles at different ages based on the narcissist's needs
 
-Roles can also shift when family composition changes—when one child leaves, another may be reassigned their role. When the scapegoat goes no-contact, watch the golden child suddenly start being criticized.
+Roles can also shift when family composition changes—when one child leaves, another may be reassigned their role. When the Scapegoat goes no-contact, watch the Golden Child suddenly start being criticized.
 
 **The moment the role shifts:**
 

--- a/book/vol-1-decoder/chapters/09-family-breaking-free.md
+++ b/book/vol-1-decoder/chapters/09-family-breaking-free.md
@@ -245,7 +245,7 @@ Complete cessation of relationship. May be necessary if:
 - No calls, texts, emails, or visits
 - Blocking on social media and phone
 - Potentially moving without sharing your address
-- Having plans for flying monkeys (people sent to contact you on their behalf)
+- Having plans for Flying Monkeys (people sent to contact you on their behalf)
 - Grieving the relationship as if they died (because functionally, they have)
 
 ### What No Contact Isn't

--- a/book/vol-1-decoder/chapters/13-exposure-questions.md
+++ b/book/vol-1-decoder/chapters/13-exposure-questions.md
@@ -39,11 +39,11 @@ These questions are designed to reveal what's underneath the mask—not through 
 
 **What you're listening for:**
 
-- **Deflection:**—Turning the question back on you or others
-- **Projection:**—Accusing you of what they do
-- **Rage/Contempt:**—Disproportionate emotional reaction to simple questions
-- **Word salad:**—Confusing non-answers that sound like answers
-- **Victimhood pivot:**—Making themselves the injured party
+- **Deflection:** Turning the question back on you or others
+- **Projection:** Accusing you of what they do
+- **Rage/Contempt:** Disproportionate emotional reaction to simple questions
+- **Word salad:** Confusing non-answers that sound like answers
+- **Victimhood pivot:** Making themselves the injured party
 - **Grandiosity leak:** Revealing special-treatment beliefs
 - **Absence of genuine reflection:** Surface answers with no depth
 

--- a/book/vol-1-decoder/chapters/17-energetic-remapping.md
+++ b/book/vol-1-decoder/chapters/17-energetic-remapping.md
@@ -327,7 +327,7 @@ Practice this daily when calm so it becomes automatic when triggered.
 
 For sustained recovery, commit to this daily protocol for 21 days:
 
-**Morning (5-10 min):**
+**Morning (5–10 min):**
 - Grounding exercise before phone
 - Set intention: "I choose safety in my body today"
 - Three qualities affirmation: "I am [discerning], [strong], [clear]"
@@ -337,7 +337,7 @@ For sustained recovery, commit to this daily protocol for 21 days:
 - Release one area deliberately (drop your shoulders, unclench your jaw, soften your stomach—wherever you found tightness)
 - Drink water
 
-**After any activation (5-15 min):**
+**After any activation (5–15 min):**
 - Four-step remapping process
 - Journal briefly: What happened? Which pattern? How did I respond?
 

--- a/book/vol-1-decoder/chapters/18-practical-responses.md
+++ b/book/vol-1-decoder/chapters/18-practical-responses.md
@@ -338,7 +338,7 @@ Sometimes you'll be tempted to give them a taste of their own medicine. Say "Huh
 - It extends the engagement rather than ending it
 - It feeds the dynamic rather than starving it
 
-**The exception:** Brief, strategic gray rock responses that deflect without engaging. Saying "Huh?" once to refuse elaboration is different from entering a "Huh?" war.
+**The exception:** Brief, strategic Gray Rock responses that deflect without engaging. Saying "Huh?" once to refuse elaboration is different from entering a "Huh?" war.
 
 **Your actual power move:** You win by not playing. Confusion tactics work on people who try to make sense of them. If you simply don't engage—don't explain, don't mirror, don't react—there's nothing for them to work with.
 
@@ -357,7 +357,7 @@ At events where they'll be present:
 **Before:**
 - Set your intention (e.g., "I will stay grounded regardless of what happens")
 - Visualize a boundary or shield of golden white or luminescent energy around you
-- Plan your gray rock responses for likely provocations
+- Plan your Gray Rock responses for likely provocations
 - Identify your escape route if needed
 
 **During:**
@@ -557,7 +557,7 @@ Often the need is to express, not to be received by them. You can meet that need
 **Key Strategies:**
 - Spiritual aikido: redirect, don't combat
 - Close conversations on your terms
-- Gray rock when you must interact
+- Gray Rock when you must interact
 - Somatic and social cues for protection
 - Describe behavior to authorities, not labels
 

--- a/book/vol-1-decoder/chapters/pause-after-part-1.md
+++ b/book/vol-1-decoder/chapters/pause-after-part-1.md
@@ -1,6 +1,6 @@
 # Pause and Integrate
 
-You've completed **Part I: Recognition** (Chapters 1-4)
+You've completed **Part I: Recognition** (Chapters 1–4)
 
 ---
 

--- a/book/vol-1-decoder/chapters/pause-after-part-2.md
+++ b/book/vol-1-decoder/chapters/pause-after-part-2.md
@@ -1,6 +1,6 @@
 # Pause and Integrate
 
-You've completed **Part II: Understanding Origins** (Chapters 5-12)
+You've completed **Part II: Understanding Origins** (Chapters 5–12)
 
 ---
 

--- a/book/vol-1-decoder/chapters/pause-after-part-3.md
+++ b/book/vol-1-decoder/chapters/pause-after-part-3.md
@@ -1,6 +1,6 @@
 # Pause and Integrate
 
-You've completed **Part III: Tools & Recognition** (Chapters 13-16)
+You've completed **Part III: Tools & Recognition** (Chapters 13–16)
 
 ---
 


### PR DESCRIPTION
Editorial review fixes including:
- Fix chapter reference errors in appendix-e-index.md (10 corrections)
- Convert gendered pronouns to gender-neutral in Chapter 3A
- Capitalize role names consistently (Golden Child, Scapegoat, Flying Monkeys, Gray Rock)
- Fix punctuation redundancy in Chapter 13 (remove colon+em dash duplicates)
- Use en dashes for numeric ranges in pause files and Chapter 17