### PR TITLE
✍️ Resolve Round 2 Action Plan items from issue #138

### DIFF
--- a/book/vol-1-decoder/chapters/06-narcissist-roles.md
+++ b/book/vol-1-decoder/chapters/06-narcissist-roles.md
@@ -430,6 +430,24 @@ Now you know: *the role was never about you.* The Victim needed someone to rescu
 
 This is painful to realize. It's also liberating. You can stop auditioning for their approval. The show was rigged from the beginning.
 
+### Reclaiming Your Authentic Role
+
+Now that you can recognize the roles they played, here's a practice for reclaiming your own:
+
+**The Role Release Exercise:**
+
+1. **Identify the role you were cast in.** Were you the Rescuer to their Victim? The Audience to their Hero? The Guilty One to their Martyr? Name it.
+
+2. **Feel where that role lives in your body.** The exhaustion of constant rescuing. The smallness of being audience. The weight of manufactured guilt. Let yourself feel it without fixing it.
+
+3. **Speak the release:** "I was cast in a role I didn't choose. That role served someone else's production. I am more than that casting. I release this role now."
+
+4. **Ask yourself:** "Who am I when I'm not performing for their approval?" Sit with the answer. It may feel unfamiliar at first. That unfamiliarity is freedom beginning.
+
+**The truth:** You were never the role they assigned you. You were a full person who got reduced to a function in someone else's story. Reclaiming yourself means stepping out of their narrative entirely.
+
+---
+
 ### What's Next
 
 The roles explored in this chapter—the masks narcissists wear in any context—take on particular significance in family systems. The next chapter examines how these patterns crystallize into assigned roles within families: the Golden Child, the Scapegoat, the Lost Child, the Mascot. You'll explore how triangulation divides family members, and why manipulation that begins in childhood cuts deeper than any other kind.


### PR DESCRIPTION
Add healing closure section to Chapter 6 (Narcissist Roles) with:
- "Reclaiming Your Authentic Role" subsection
- The Role Release Exercise for processing assigned roles
- Guidance for stepping out of narcissist's narrative

Most action items from the Round 2 Action Plan were already implemented:
- Gender pronoun standardization (Chapter 3)
- Content warnings (Chapters 3, 17, 10)
- Voice break fixes (Chapters 10, 19)
- Fact-check corrections (Chapter 1)
- Crisis reading path revision (Front matter)
- Glossary voice conversion
- Pause points in Chapter 3A/3B
- Bibliography updates (2020-2025 sources)
- Triage guidance (Chapter 13)
- Cross-references verified

Author's structural decisions applied: 1.A, 2.A, 3.B