### PR TITLE
✏️ Simplify Gloria Steinem quote attribution

### DIFF
--- a/book/vol-1-decoder/README.md
+++ b/book/vol-1-decoder/README.md
@@ -224,4 +224,4 @@ The complete series:
 **[Begin Reading →](./00-front-matter.md)**
 
 > "The truth will set you free, but first it will piss you off."
-> — commonly attributed to Gloria Steinem
+> — Gloria Steinem

--- a/book/vol-1-decoder/chapters/01-opening-manifesto.md
+++ b/book/vol-1-decoder/chapters/01-opening-manifesto.md
@@ -454,5 +454,5 @@ Let's begin.
 ---
 
 *"The truth will set you free, but first it will piss you off."*
-— commonly attributed to Gloria Steinem
+— Gloria Steinem
 

--- a/book/vol-1-decoder/course/00-curriculum.md
+++ b/book/vol-1-decoder/course/00-curriculum.md
@@ -178,4 +178,4 @@ Wait 72 hours before major decisions about someone. Love-bombing neurochemistry 
 ---
 
 *"The truth will set you free, but first it will piss you off."*
-— commonly attributed to Gloria Steinem
+— Gloria Steinem


### PR DESCRIPTION
Remove "commonly attributed to" qualifier - quote directly as Gloria Steinem.