### PR TITLE
Remove content warning from chapter 11

### DIFF
--- a/book/vol-1-decoder/chapters/11-romantic-manipulation.md
+++ b/book/vol-1-decoder/chapters/11-romantic-manipulation.md
@@ -1,7 +1,5 @@
 # Chapter 11: Romantic Manipulation
 
-> **Content Warning:** This chapter contains detailed discussions of domestic violence, sexual coercion, physical intimidation, trauma bonding, and suicide threats. If you are currently experiencing intimate partner violence or are in an unsafe relationship, please ensure you have support available before continuing. Crisis resources are available in Appendix A, including the National Domestic Violence Hotline: 1-800-799-7233.
-
 ## How Control Adapts to Intimacy
 
 ---


### PR DESCRIPTION
The content warning at the start of the romantic manipulation chapter
has been removed as requested.