### PR TITLE
✨ Create evolving author bios across trilogy volumes

### DIFF
--- a/book/release/07-author-bio-versions.md
+++ b/book/release/07-author-bio-versions.md
@@ -2,63 +2,41 @@
 
 ## Jennifer Brooke Lawless
 
-Use these versions across platforms. Customize as needed.
+Use these versions across platforms. Each volume has its own back-matter bio that evolves with the reader's journey.
 
 ---
 
-## Short Bio (100 words)
+## Volume-Specific Bios (Back of Book)
 
-*For: Amazon KDP, back of book, podcast introductions*
+Each volume has a dedicated author bio that matches where the reader is:
 
-Jennifer Brooke Lawless holds a Bachelor of Science in Psychology and a Master of Science in Mental Health Counseling. Her clinical work ranged from a locked psychiatric ward in Miami to in-home family therapy, individual sessions, and couples counseling. But her own healing journey led her beyond the therapy room. After surviving narcissistic relationships and navigating a profound spiritual awakening, she traveled globally—Cyprus, Greece, Nicaragua, Costa Rica, Mexico—seeking community and transformation. She now lives in Costa Rica, where she co-hosts transformative retreats at Zunya and trains in aura therapy through Escola da Aura. She wrote *The Narcissism Decoder* and *The Bridge* because she needed these books—and couldn't find them.
-
----
-
-## Medium Bio (200 words)
-
-*For: Gumroad, Substack About page, guest post bylines*
-
-Jennifer Brooke Lawless holds a Bachelor of Science in Psychology from Boston University and a Master of Science in Mental Health Counseling from Nova Southeastern University. Her clinical work spanned from a locked psychiatric ward in Miami to in-home family systems therapy, individual sessions, and couples counseling. Now she works at the intersection of traditional psychology and spiritual healing. Her journey from feardom to freedom began when she finally named the patterns that had kept her small—narcissistic relationships, approval-seeking, chronic self-doubt, and the belief that her sensitivity was a flaw rather than a gift.
-
-After the death of her father, Jennifer experienced a powerful Kundalini awakening that opened her to new levels of consciousness. What followed was three years of global travel—Cyprus, Greece, Nicaragua, Costa Rica, Mexico—searching for the spiritual community and healing modalities that would become her life's work.
-
-Today, Jennifer lives in Costa Rica surrounded by community, where she co-hosts transformative retreats at Zunya and trains in aura therapy through Escola da Aura. She is particularly passionate about helping emotionally sensitive adults move from survival to sovereign connection.
-
-She wrote *The Narcissism Decoder* and *The Bridge* because she needed them—and when she couldn't find the book that bridged insight and embodiment, she created it.
-
-**Connect:** [Newsletter] | [Instagram] | lightfieldpress@gmail.com
+| Volume | Theme | Bio Focus | Location |
+|--------|-------|-----------|----------|
+| **1** | Recognition | *Surviving & naming patterns* | `vol-1-decoder/back-matter-about-author.md` |
+| **2** | Healing | *Crossing from insight to embodiment* | `vol-2-bridge/back-matter-about-author.md` |
+| **3** | Sovereignty | *Living from embodied authority* | `vol-3-sovereignty/back-matter-about-author.md` |
 
 ---
 
-## Long Bio (400 words)
+## Short Bio (75 words)
 
-*For: Website, press kit, speaking engagements*
+*For: Amazon KDP, podcast introductions, event programs*
 
-Jennifer Brooke Lawless is a healer, writer, and event producer dedicated to helping emotionally sensitive adults recognize manipulation, heal attachment wounds, and build relationships that regulate rather than activate.
+Jennifer Brooke Lawless holds degrees in Psychology (Boston University) and Mental Health Counseling (Nova Southeastern University). Her clinical work ranged from psychiatric units to family therapy and couples counseling. After surviving narcissistic relationships and discovering that insight alone doesn't heal, she wrote the books she needed but couldn't find. She lives in Costa Rica, where she offers aura readings and healing work through Light Field Institute.
 
-She holds a Bachelor of Science in Psychology from Boston University and a Master of Science in Mental Health Counseling from Nova Southeastern University. Her clinical work ranged from the locked psychiatric ward in Miami to in-home family systems therapy, individual sessions, and couples counseling. But her own healing required more than insight—it required a complete rewiring of how she related to herself, others, and the world. Her journey from feardom to freedom became the foundation for everything she now teaches.
+---
 
-### The Turning Point
+## Medium Bio (150 words)
 
-After her father's passing, Jennifer experienced a Kundalini awakening that cracked open her consciousness. What followed was three years of global travel—Cyprus, Greece, Nicaragua, Costa Rica, Mexico—in search of healing, community, and her soul's purpose. She wrote over 200 pages communicating with her father through clairaudience. She studied astrology with Kaypacha. She trained in shadow work through the Transitions program with Diego Dosal, a visionary leader from Mexican high society.
+*For: Gumroad, Substack, guest post bylines*
 
-Through this journey, she had to face her own patterns: passive-aggression, approval-seeking, shrinking in narcissistic relationships, years of depression and anxiety, and the mortally wounded self-esteem that came from a lifetime of emotional enmeshment.
+Jennifer Brooke Lawless is a mental health counselor, writer, and survivor of narcissistic abuse. She holds a Bachelor of Science in Psychology from Boston University and a Master of Science in Mental Health Counseling from Nova Southeastern University, with clinical experience spanning psychiatric care, family systems therapy, and couples work.
 
-### The Work Today
+Her healing journey led her beyond traditional therapy—through shadow work, nervous system regulation, and the slow practice of building secure attachment from the inside out. She discovered that naming patterns isn't enough; the body needs to learn something new.
 
-Jennifer now lives in Costa Rica, where she co-hosts transformative retreats at Zunya—immersive experiences combining energy healing, meditation, aura readings, and community. She continues her training in aura therapy through Escola da Aura under the guidance of Angelina Ataíde, a Portuguese spiritual teacher, and her daily practice includes Qi Gong, Tai Chi, Reiki, and meditation.
+Today, Jennifer lives in Costa Rica surrounded by community, where she offers aura readings, integration sessions, and spiritual guidance through Light Field Institute. Her books—*The Narcissism Decoder*, *The Bridge*, and *Sovereignty*—were written for the person she used to be: confused, self-doubting, and desperately needing someone to explain what was happening.
 
-Her books—*The Narcissism Decoder* and *The Bridge*—were born from lived experience, not clinical distance. She wrote them because she needed them. Because insight alone hadn't healed her. Because she couldn't find the book that bridged understanding and embodiment—so she created it.
-
-### Philosophy
-
-Jennifer believes that naming patterns breaks their power. That secure attachment is practiced, not found. That sensitivity is not a weakness but a survival adaptation that can be redirected. And that healing happens through consistent, gentle practice—not more analysis.
-
-### Connect
-
-- **Newsletter:** [Substack link]
-- **Aura Readings:** calendly.com/lightfield
-- **Events:** lightfieldpress@gmail.com
+**Connect:** lightfield.institute | @jae.lawless | lightfieldpress@gmail.com
 
 ---
 
@@ -66,7 +44,7 @@ Jennifer believes that naming patterns breaks their power. That secure attachmen
 
 *For: Social media bios, Twitter/X*
 
-Author of The Narcissism Decoder & The Bridge | BS Psychology, MS Mental Health Counseling | Helping you recognize control & build secure attachment | Costa Rica 🌴
+Author of The Narcissism Decoder trilogy | MS Mental Health Counseling | Helping sensitive adults recognize control & build secure attachment | Costa Rica
 
 ---
 
@@ -74,14 +52,15 @@ Author of The Narcissism Decoder & The Bridge | BS Psychology, MS Mental Health 
 
 *For: Quick podcast introductions*
 
-Jennifer Brooke Lawless is the author of *The Narcissism Decoder* and *The Bridge*. With degrees in Psychology and Mental Health Counseling—and clinical experience from psychiatric wards to family therapy—she helps emotionally sensitive adults move from survival to sovereign connection. She lives in Costa Rica.
+Jennifer Brooke Lawless is the author of *The Narcissism Decoder*, *The Bridge*, and *Sovereignty*. With degrees in Psychology and Mental Health Counseling—and clinical experience from psychiatric wards to family therapy—she helps emotionally sensitive adults move from survival to sovereign connection. She lives in Costa Rica.
 
 ---
 
 ## Notes for Customization
 
-- Replace [Newsletter], [Instagram], [Substack link] with actual links
-- For platforms requiring shorter bios, use the one-line version
-- For more personal contexts, emphasize the lived experience; for professional contexts, lead with credentials
-- The Costa Rica detail humanizes and differentiates—use it
+- **Volume-specific contexts:** Use the back-matter bio from the relevant volume
+- **Platform-agnostic contexts:** Use the Short or Medium bio above
+- **Professional contexts:** Lead with credentials
+- **Personal contexts:** Emphasize lived experience
+- The Costa Rica detail humanizes and differentiates—keep it
 

--- a/book/vol-1-decoder/back-matter-about-author.md
+++ b/book/vol-1-decoder/back-matter-about-author.md
@@ -6,168 +6,34 @@
 
 ## Jennifer Brooke Lawless
 
-*Spiritual guide, aura reader, rose meditation guide, and researcher of consciousness in the auric and biofield.*
-
-*Founder of Light Field Institute*
-
 </div>
 
 ---
 
-## From Feardom to Freedom
+Jennifer Brooke Lawless holds a Bachelor of Science in Psychology from Boston University and a Master of Science in Mental Health Counseling from Nova Southeastern University. Her clinical work ranged from locked psychiatric units to family therapy, individual sessions, and couples counseling.
 
-Jennifer Brooke's path to helping others began with her own experience of narcissistic abuse—and the hard-won journey out of it.
+But none of her training prepared her for what she really needed to learn: how to recognize when love is actually control in disguise.
 
-A creative at heart, Jennifer has worn many hats: artist, event producer, singer, personal trainer, yoga instructor, psychotherapist, and sales professional. She holds a **Bachelor of Science in Psychology from Boston University** and a **Master of Science in Mental Health Counseling from Nova Southeastern University**. Her clinical work spanned the full spectrum—from the locked psychiatric ward in Miami to in-home family systems therapy, individual sessions, and couples counseling. But none of her credentials or clinical hours prepared her for what she really needed to learn: how to recognize when love is actually control in disguise.
+For years, she stayed in narcissistic relationships, mistaking intensity for intimacy and approval-seeking for connection. She was told she was "too sensitive"—when she was actually too perceptive. The confusion was real. The self-doubt was constant. She needed someone to explain what was happening.
 
-For years, she allowed herself to shrink in abusive and narcissistic relationships. Depression and anxiety became constant companions. Her self-esteem, in her own words, was "mortally wounded." Like many survivors, she had learned to seek external validation instead of trusting herself—a pattern that made her vulnerable to those who would exploit her empathy.
+She couldn't find that book. So she wrote it.
 
-The breakthrough came through deep Jungian shadow work. Through transformative experiences called "Transitions," Jennifer confronted the parts of herself that had enabled toxic dynamics to continue. She released passive-aggressive patterns, negativity, blame, and the desperate need for external approval. The work was uncomfortable. It required brutal honesty about her own part in staying. But on the other side was something she'd been looking for: herself.
+*The Narcissism Decoder* is the guide she wished she'd had—written for everyone still wondering if they're the problem.
 
-Through that ownership, she reclaimed her sovereignty.
-
----
-
-## The Awakening
-
-Jennifer's spiritual journey began in earnest with a powerful Kundalini awakening, guided by her coach **Peggy Butkus** and astrologer **Shira Beth Brenner**.
-
-A pivotal moment came when she received her Reiki I initiation at Maha Rose in New York—just two weeks before her father passed away. That initiation opened her clairvoyance, and on the night her father crossed over, she experienced her first psychic vision. In Cyprus, she began writing about her communications with him through clairaudience, producing over 200 pages documenting the healing that unfolded as she learned to listen beyond the veil.
-
-What followed was a three-year quest across the globe in search of spiritual community, healing, and self-discovery:
-
-**Cyprus** — Where she processed her grief and opened to clairaudience
-
-**Greece** — Where she studied astrology with **Kaypacha** (founder of Astrology for the Soul) and uncovered her soul's blueprint
-
-**Nicaragua** — Where she spent a year breaking free from societal constraints and US cultural conditioning, connecting with transformative communities and learning to think freely
-
-**Costa Rica & Mexico** — Where she found her spiritual home
-
-The turning point came when she met **Diego Dosal Stieglitz**, visionary spiritual leader from Mexican high society and founder of Zunya, Costa Rica. Diego introduced her to **Angelina Ataíde** (Angel), a Portuguese spiritual teacher and founder of **Escola da Aura**, centered in the chapadas region of Brazil.
-
-In that moment, Jennifer's path became crystal clear. She had found the modality that would become her life's work.
+They're not. And neither are you.
 
 ---
 
-## A Note on Privilege
+**Connect with Jennifer**
 
-Jennifer acknowledges that her healing journey required resources not everyone has access to: the ability to travel internationally, time away from traditional employment, funds for spiritual training and certifications, and a support network that made extended healing work possible.
-
-This path is not the only path. Healing doesn't require expensive retreats, international travel, or prestigious certifications. The core work—naming patterns, regulating your nervous system, reclaiming your worth—can happen with a library book, a journal, free online resources, and one safe person who believes you.
-
-If you're healing without those resources, your journey is no less valid. The practices in this book are designed to be accessible regardless of economic circumstances. Your healing matters whether you do it in Costa Rica or in your living room.
-
----
-
-## The Training
-
-Jennifer's journey with Escola da Aura has taken her deep into the practice of aura therapy—a unique modality utilizing clairvoyance to read the auric field and receive messages directly from Source.
-
-In 2025, this journey crystallized into the founding of the International School of Aura and Dreams, Rose OS.
-
-**Influences:**
-- Aaron Doughty (mindset and personal development)
-- Elizabeth April (psychic training)
-- Brandy Joy (Magickal Mystery School, Traditional Hermetic Secret Society)
-- Abraham-Hicks, Dr. Michael Newton, Brian Weiss, and Caroline Myss
-
----
-
-## Living in Community
-
-Today, Jennifer lives her dream in Costa Rica, on a hill surrounded by lemon trees. She shares this sacred space with her partner **Daniel** (her tech wizard).
-
-Living in community starts with an open heart, and Jennifer is grateful every day for the soul family that surrounds her—including the howler monkeys.
-
----
-
-## The Work
-
-Through **Light Field Institute**, Jennifer offers:
-
-**Aura Readings**
-- General readings that touch the soul using clairvoyant techniques
-- Theme-based specialized readings
-- Relationship readings
-
-**Integration Sessions**
-- Follow-up sessions to help integrate insights from readings
-- Support for ongoing healing and transformation
-
-**Rose Meditation**
-- A signature practice for grounding, self-connection, and nervous system regulation
-
----
-
-## The Philosophy
-
-At the heart of Jennifer's work is a simple belief:
-
-**Your sensitivity is not your weakness. It's your superpower.**
-
-The same capacity that made you vulnerable to manipulation—your empathy, your attunement, your willingness to see the best in others—is the capacity that will guide you toward healing and help you build the relationships you deserve.
-
-She believes that:
-
-- **Naming patterns creates power.** What you can identify, you can address.
-- **The body knows before the mind.** Learning to trust somatic signals is essential.
-- **Healing is possible.** No matter how deep the wound, recovery is within reach.
-- **Your experience matters.** What happened to you was real, and you deserve validation.
-- **Sensitivity is sacred.** It's a gift to be protected, not a flaw to be fixed.
-- **Community heals.** We are not meant to do this work alone.
-
----
-
-## The Book
-
-*The Narcissism Decoder* represents the distillation of everything Jennifer has learned—from her own journey through narcissistic relationships, from her training in mental health counseling, from years of working with clients, and from the wisdom of survivor communities.
-
-She wrote it for the person she was years ago: confused, self-doubting, and desperately needing someone to explain what was happening. She wrote it for everyone who has been told they were "too sensitive" when they were actually too perceptive. She wrote it as the guide she wished she had found.
-
-Her hope is that these pages bring clarity to your confusion, language to your experience, and—ultimately—freedom from the patterns that have held you.
-
----
-
-## Connect with Jennifer
-
-**Light Field Institute**
 - Website: lightfield.institute
-- Aura readings, integration sessions, and spiritual guidance
 - Instagram: @jae.lawless
-
-**Book an Aura Reading**
-- Calendly: calendly.com/lightfield
 - Email: lightfieldpress@gmail.com
-
----
-
-## A Personal Note
-
-*To everyone who reads this book:*
-
-*Thank you for trusting me with your healing journey. Thank you for having the courage to look directly at patterns that were designed to remain invisible. Thank you for choosing yourself.*
-
-*The road ahead may not be easy, but I promise you: It leads somewhere beautiful. On the other side of this understanding is freedom—real, embodied, and sovereign freedom.*
-
-*You are not broken. You are not too much. You are not the problem.*
-
-*You are coming home to yourself. And that home has been waiting for you all along.*
-
-*This is a journey from fear to freedom. From shadow to light. From separation to unity.*
-
-*With love and fierce protection,*
-
-**Jae**
-*Jennifer Brooke Lawless*
 
 ---
 
 <div align="center">
 
-*"Every soul carries a unique energetic signature, a sacred story written in light.*
-*My gift is helping you read that story and understand its beautiful message."*
-
-**Aho.** 🙏
+*Your sensitivity is not your weakness. It's your superpower.*
 
 </div>

--- a/book/vol-2-bridge/back-matter-about-author.md
+++ b/book/vol-2-bridge/back-matter-about-author.md
@@ -1,0 +1,39 @@
+# About the Author
+
+---
+
+<div align="center">
+
+## Jennifer Brooke Lawless
+
+</div>
+
+---
+
+Jennifer Brooke Lawless is a mental health counselor, writer, and survivor of narcissistic abuse. She holds degrees in Psychology (Boston University) and Mental Health Counseling (Nova Southeastern University), with clinical experience spanning psychiatric units, family therapy, and couples counseling.
+
+In *The Narcissism Decoder* (Volume 1), she helped readers name the patterns. Now, in *The Bridge*, she guides you across the gap between insight and embodiment—because she had to cross it herself.
+
+After recognizing her own patterns, Jennifer discovered that understanding wasn't enough. Her body still reacted. Guilt still pulled her back. She knew the patterns intellectually but couldn't stop living them.
+
+What followed was years of nervous system work, shadow integration, and the slow practice of building secure attachment from the inside out. Not through more analysis—but through training.
+
+She wrote *The Bridge* because she needed it. Because insight alone hadn't healed her. Because the book that bridged understanding and embodiment didn't exist—so she created it.
+
+She now lives in Costa Rica, where she offers aura readings, integration sessions, and healing work through Light Field Institute.
+
+---
+
+**Connect with Jennifer**
+
+- Website: lightfield.institute
+- Instagram: @jae.lawless
+- Email: lightfieldpress@gmail.com
+
+---
+
+<div align="center">
+
+*Secure attachment is not found—it is practiced.*
+
+</div>

--- a/book/vol-3-sovereignty/back-matter-about-author.md
+++ b/book/vol-3-sovereignty/back-matter-about-author.md
@@ -1,0 +1,39 @@
+# About the Author
+
+---
+
+<div align="center">
+
+## Jennifer Brooke Lawless
+
+</div>
+
+---
+
+Jennifer Brooke Lawless is a healer, writer, and guide for emotionally sensitive adults learning to lead from a regulated nervous system. She holds degrees in Psychology and Mental Health Counseling, with clinical experience spanning psychiatric care, family systems, and couples work.
+
+Her journey to sovereignty began in the wreckage of narcissistic relationships. In *The Narcissism Decoder* (Volume 1), she named the patterns. In *The Bridge* (Volume 2), she crossed from insight to embodiment. This book is what she found on the other side.
+
+Today, Jennifer lives in Costa Rica surrounded by community—on a hill with lemon trees and howler monkeys—practicing what she teaches: sovereignty without force, leadership without performing, and care without carrying.
+
+She no longer seeks permission to take up space. She no longer confuses intensity with connection. She chooses without urgency, desires without fear, and separates without guilt.
+
+This book is for everyone who has done the healing work and is now asking: *Who am I when I stop shrinking?*
+
+The answer is here. And so are you.
+
+---
+
+**Connect with Jennifer**
+
+- Website: lightfield.institute
+- Instagram: @jae.lawless
+- Email: lightfieldpress@gmail.com
+
+---
+
+<div align="center">
+
+*Sovereignty is not hardening. It is steadiness.*
+
+</div>


### PR DESCRIPTION
Shorten back-matter author bios to book-blurb length and create
volume-specific versions that evolve with the reader's journey:
- Vol 1: Focus on surviving and naming patterns
- Vol 2: Focus on crossing from insight to embodiment
- Vol 3: Focus on living from embodied authority