### PR TITLE
✏️ Update author contact email across all bios

### DIFF
--- a/book/release/07-author-bio-versions.md
+++ b/book/release/07-author-bio-versions.md
@@ -36,7 +36,7 @@ Her healing journey led her beyond traditional therapy—through shadow work, ne
 
 Today, Jennifer lives in Costa Rica surrounded by community, where she offers aura readings, integration sessions, and spiritual guidance through Light Field Institute. Her books—*The Narcissism Decoder*, *The Bridge*, and *Sovereignty*—were written for the person she used to be: confused, self-doubting, and desperately needing someone to explain what was happening.
 
-**Connect:** lightfield.institute | @jae.lawless | lightfieldpress@gmail.com
+**Connect:** lightfield.institute | @jae.lawless | lightwavesenergy@gmail.com
 
 ---
 

--- a/book/vol-1-decoder/back-matter-about-author.md
+++ b/book/vol-1-decoder/back-matter-about-author.md
@@ -28,7 +28,7 @@ They're not. And neither are you.
 
 - Website: lightfield.institute
 - Instagram: @jae.lawless
-- Email: lightfieldpress@gmail.com
+- Email: lightwavesenergy@gmail.com
 
 ---
 

--- a/book/vol-2-bridge/back-matter-about-author.md
+++ b/book/vol-2-bridge/back-matter-about-author.md
@@ -28,7 +28,7 @@ She now lives in Costa Rica, where she offers aura readings, integration session
 
 - Website: lightfield.institute
 - Instagram: @jae.lawless
-- Email: lightfieldpress@gmail.com
+- Email: lightwavesenergy@gmail.com
 
 ---
 

--- a/book/vol-3-sovereignty/back-matter-about-author.md
+++ b/book/vol-3-sovereignty/back-matter-about-author.md
@@ -28,7 +28,7 @@ The answer is here. And so are you.
 
 - Website: lightfield.institute
 - Instagram: @jae.lawless
-- Email: lightfieldpress@gmail.com
+- Email: lightwavesenergy@gmail.com
 
 ---
 


### PR DESCRIPTION
Change email from lightfieldpress@gmail.com to lightwavesenergy@gmail.com
to align with Light Field Institute counseling services branding.