### PR TITLE
Add standardized review workflow template to agents

### DIFF
--- a/book/agents/README.md
+++ b/book/agents/README.md
@@ -116,6 +116,17 @@ Invoke to coordinate the overall editing process. Use for:
 | Beta Reader | `beta-reader.md` | Reader response simulation |
 | Managing Editor | `managing-editor.md` | Workflow coordination |
 
+## Review Workflow Template
+
+Use [`review-workflow-template.md`](review-workflow-template.md) to track progress through any review round. The template provides:
+
+- **Phase-by-phase workflow** with the correct order for addressing feedback
+- **Parallel work guide** showing which reviews can be done simultaneously
+- **Progress tracking** with checkboxes for each stage
+- **Implementation notes** section for documenting decisions
+
+Copy the template to your review folder (e.g., `review-01/`, `review-02/`) and fill in the issue numbers for that round.
+
 ## Cost Expectations
 
 Different editing passes have different scope and cost:

--- a/book/agents/review-workflow-template.md
+++ b/book/agents/review-workflow-template.md
@@ -1,0 +1,138 @@
+# Editorial Review Workflow Template
+
+**Principle:** Big-picture changes first, fine details last — structural changes invalidate detailed polish work.
+
+Use this template to track progress through any review round. Copy to your review folder and fill in issue numbers.
+
+---
+
+## Phase 1: Strategic Decisions (Do First)
+
+Answer ALL questions in Phase 1 before implementing any changes.
+
+| Order | Status | Agent | Issue | Questions | Focus |
+|-------|--------|-------|-------|-----------|-------|
+| 1 | [ ] | **Diana** (Developmental Editor) | #___ | ___ | Structure, themes, narrative arc |
+| 2 | [ ] | **Morgan** (Managing Editor) | #___ | ___ | Priorities, conflicts, coordination |
+
+**Why first:** Structural decisions affect everything downstream. If you change chapter order or add/remove content, all detailed polish work becomes invalid.
+
+**Phase 1 Complete:** [ ]
+**Structural changes implemented:** [ ]
+
+---
+
+## Phase 2: Content & Experience
+
+Address after Phase 1 structural decisions are made. These three can be answered in parallel since they address different concerns.
+
+| Order | Status | Agent | Issue | Questions | Focus |
+|-------|--------|-------|-------|-----------|-------|
+| 3 | [ ] | **Bailey** (Beta Reader) | #___ | ___ | Reader engagement, pacing, clarity |
+| 4 | [ ] | **Sage** (Sensitivity Reader) | #___ | ___ | Representation, inclusion, trauma-informed |
+| 5 | [ ] | **Felix** (Fact-Checker) | #___ | ___ | Sources, accuracy, verification |
+
+**Why this order:** Reader experience and representation concerns may require content changes. Fact-checking verifies claims once content is stable.
+
+**Phase 2 Complete:** [ ]
+**Content changes implemented:** [ ]
+
+---
+
+## Phase 3: Polish
+
+Only begin after content is stable. Do Lydia's line edit first, then Clara's copy edit.
+
+| Order | Status | Agent | Issue | Questions | Focus |
+|-------|--------|-------|-------|-----------|-------|
+| 6 | [ ] | **Lydia** (Line Editor) | #___ | ___ | Prose craft, voice, rhythm |
+| 7 | [ ] | **Clara** (Copy Editor) | #___ | ___ | Style consistency, terminology |
+
+**Why this order:** Line editing improves prose quality; copy editing standardizes. Copy editing a passage that will be rewritten by line editing wastes effort.
+
+**Phase 3 Complete:** [ ]
+**Polish changes implemented:** [ ]
+
+---
+
+## Phase 4: Final Pass
+
+Absolutely last — any earlier changes could introduce new errors.
+
+| Order | Status | Agent | Issue | Questions | Focus |
+|-------|--------|-------|-------|-----------|-------|
+| 8 | [ ] | **Petra** (Proofreader) | #___ | ___ | Typos, formatting, final errors |
+
+**Why last:** Proofreading catches the small errors that slip through. Any content changes after proofreading require re-proofreading.
+
+**Phase 4 Complete:** [ ]
+**Final corrections applied:** [ ]
+
+---
+
+## Parallel Work Guide
+
+### Can Answer Together
+- **Diana + Morgan** — But answer both before implementing structural changes
+- **Bailey + Sage + Felix** — Different concerns with no dependencies
+- **Lydia + Clara** — But implement Lydia's suggestions first, then Clara's
+
+### Must Be Sequential
+```
+Phase 1 (Strategic)
+    → Phase 2 (Content)
+        → Phase 3 (Polish)
+            → Phase 4 (Final)
+```
+
+### Critical Rule
+**Petra (Proofreader) is always last.** No exceptions.
+
+---
+
+## Summary Table
+
+| Phase | Agents | Focus | Parallel OK? |
+|-------|--------|-------|--------------|
+| 1 - Strategic | Diana, Morgan | Structure, priorities | Yes (answer together) |
+| 2 - Content | Bailey, Sage, Felix | Experience, representation, accuracy | Yes |
+| 3 - Polish | Lydia, Clara | Prose, consistency | Yes (implement sequentially) |
+| 4 - Final | Petra | Typos, formatting | No (must be last) |
+
+---
+
+## Progress Log Template
+
+Use this section to track implementation progress for your review round.
+
+### Phase 1 Progress
+- [ ] Diana questions answered: ___/___
+- [ ] Morgan questions answered: ___/___
+- [ ] Structural decisions documented
+- [ ] Structural changes implemented
+- [ ] Ready for Phase 2
+
+### Phase 2 Progress
+- [ ] Bailey questions answered: ___/___
+- [ ] Sage questions answered: ___/___
+- [ ] Felix questions answered: ___/___
+- [ ] Content changes implemented
+- [ ] Ready for Phase 3
+
+### Phase 3 Progress
+- [ ] Lydia questions answered: ___/___
+- [ ] Line edit changes implemented
+- [ ] Clara questions answered: ___/___
+- [ ] Copy edit changes implemented
+- [ ] Ready for Phase 4
+
+### Phase 4 Progress
+- [ ] Petra questions answered: ___/___
+- [ ] Final corrections applied
+- [ ] **PUBLICATION READY**
+
+---
+
+## Notes
+
+_Add implementation notes, decisions, and observations here as you work through the review._

--- a/book/vol-1-decoder/review-03/REVIEW-WORKFLOW-ORDER.md
+++ b/book/vol-1-decoder/review-03/REVIEW-WORKFLOW-ORDER.md
@@ -1,0 +1,121 @@
+# Review Round 3 - Implementation Workflow Order
+
+**Created:** January 4, 2026
+**Template:** Based on [`book/agents/review-workflow-template.md`](../../agents/review-workflow-template.md)
+**Principle:** Big-picture changes first, fine details last — structural changes invalidate detailed polish work.
+
+---
+
+## Phase 1: Strategic Decisions (Do First)
+
+These set the direction. Answer ALL questions in Phase 1 before implementing changes.
+
+| Order | Status | Agent | Issue | Questions | Focus |
+|-------|--------|-------|-------|-----------|-------|
+| 1 | [ ] | **Diana** (Developmental Editor) | [#214](https://github.com/danlawless/auracle/issues/214) | 25 | Structure, themes, narrative arc |
+| 2 | [ ] | **Morgan** (Managing Editor) | [#211](https://github.com/danlawless/auracle/issues/211) | 14 | Priorities, conflicts, coordination |
+
+**Phase 1 Complete:** [ ]
+**Structural changes implemented:** [ ]
+
+---
+
+## Phase 2: Content & Experience
+
+Address after Phase 1 structural decisions are made. These can be answered in parallel.
+
+| Order | Status | Agent | Issue | Questions | Focus |
+|-------|--------|-------|-------|-----------|-------|
+| 3 | [ ] | **Bailey** (Beta Reader) | [#212](https://github.com/danlawless/auracle/issues/212) | 56 | Reader engagement, pacing, clarity |
+| 4 | [ ] | **Sage** (Sensitivity Reader) | [#216](https://github.com/danlawless/auracle/issues/216) | 18 | Representation, inclusion, trauma-informed |
+| 5 | [ ] | **Felix** (Fact-Checker) | [#209](https://github.com/danlawless/auracle/issues/209) | 6 | Sources, accuracy, verification |
+
+**Phase 2 Complete:** [ ]
+**Content changes implemented:** [ ]
+
+---
+
+## Phase 3: Polish
+
+Only begin after content is stable. Lydia first, then Clara.
+
+| Order | Status | Agent | Issue | Questions | Focus |
+|-------|--------|-------|-------|-----------|-------|
+| 6 | [ ] | **Lydia** (Line Editor) | [#210](https://github.com/danlawless/auracle/issues/210) | 18 | Prose craft, voice, rhythm |
+| 7 | [ ] | **Clara** (Copy Editor) | [#213](https://github.com/danlawless/auracle/issues/213) | 28 | Style consistency, terminology |
+
+**Phase 3 Complete:** [ ]
+**Polish changes implemented:** [ ]
+
+---
+
+## Phase 4: Final Pass
+
+Absolutely last — any earlier changes could introduce new errors.
+
+| Order | Status | Agent | Issue | Questions | Focus |
+|-------|--------|-------|-------|-----------|-------|
+| 8 | [ ] | **Petra** (Proofreader) | [#215](https://github.com/danlawless/auracle/issues/215) | 5 | Typos, formatting, final errors |
+
+**Phase 4 Complete:** [ ]
+**Final corrections applied:** [ ]
+
+---
+
+## Summary
+
+| Phase | Issues | Total Questions | Status |
+|-------|--------|-----------------|--------|
+| 1 - Strategic | #214, #211 | 39 | [ ] |
+| 2 - Content | #212, #216, #209 | 80 | [ ] |
+| 3 - Polish | #210, #213 | 46 | [ ] |
+| 4 - Final | #215 | 5 | [ ] |
+| **TOTAL** | **8 issues** | **170 questions** | |
+
+---
+
+## Parallel Work Guide
+
+**Can answer together:**
+- Diana + Morgan (but answer both before implementing)
+- Bailey + Sage + Felix (different concerns)
+- Lydia + Clara (but implement Lydia's first)
+
+**Must be sequential:**
+- Phase 1 → Phase 2 → Phase 3 → Phase 4
+- Petra absolutely last
+
+---
+
+## Progress Log
+
+Use this section to track implementation progress.
+
+### Phase 1 Progress
+- [ ] Diana #214 questions answered
+- [ ] Morgan #211 questions answered
+- [ ] Structural decisions documented
+- [ ] Structural changes implemented
+
+### Phase 2 Progress
+- [ ] Bailey #212 questions answered
+- [ ] Sage #216 questions answered
+- [ ] Felix #209 questions answered
+- [ ] Content changes implemented
+
+### Phase 3 Progress
+- [ ] Lydia #210 questions answered
+- [ ] Line edit changes implemented
+- [ ] Clara #213 questions answered
+- [ ] Copy edit changes implemented
+
+### Phase 4 Progress
+- [ ] Petra #215 questions answered
+- [ ] Final corrections applied
+- [ ] **PUBLICATION READY**
+
+---
+
+## Notes
+
+_Add implementation notes, decisions, and observations here as you work through the reviews._


### PR DESCRIPTION
## Summary

- Add `review-workflow-template.md` to `book/agents/` for tracking any review round
- Update agents `README.md` to reference the template
- Update review-03 workflow to link to the template

## What the template provides

- **Phase-by-phase workflow** with correct order (strategic → content → polish → final)
- **Parallel work guide** showing which reviews can be done simultaneously
- **Progress tracking** with checkboxes for each stage
- **Implementation notes** section for documenting decisions

## Test plan

- [ ] Verify template renders correctly
- [ ] Verify links work in README.md
- [ ] Verify review-03 references the template correctly