### PR TITLE
📝 Remove Sacred Laws integration reference from Vol. 1

### DIFF
--- a/book/raw/01-04-26-council-sacred-exit.md
+++ b/book/raw/01-04-26-council-sacred-exit.md
@@ -263,7 +263,6 @@ The discomfort you feel is not your values objecting to your exit. It's the dyin
 ## Integration Notes
 
 **Relevant to:**
-- Vol. 1 Decoder: Covert narcissist patterns, 3-3-3 Rule, exploitation in partnerships
 - Vol. 3 Sovereignty: Sacred exit, honoring free will, breaking exploitative agreements
 
 **Key Teachings for Volume Integration:**


### PR DESCRIPTION
The Council guidance on sacred exit contains Sacred Laws framework content that should remain with Vol. 3 Sovereignty rather than Vol. 1 Decoder.