### PR TITLE
📝 Draft sibling boundary additions for review

### DIFF
--- a/book/vol-1-decoder/drafts/sibling-boundary-additions.md
+++ b/book/vol-1-decoder/drafts/sibling-boundary-additions.md
@@ -1,0 +1,213 @@
+# Draft Additions: Sibling Boundary Setting
+
+These additions address gaps identified in the existing family/sibling content across Chapters 9, 16, and 18.
+
+---
+
+## Addition 1: Pattern Naming Framework
+
+**Suggested location:** Chapter 9, after line 93 (after "The pattern: Rupture → guilt → re-entry without repair")
+
+---
+
+### Naming the Pattern: Uncontained Disclosure
+
+When someone repeatedly shares emotional distress without a clear ask, without checking your capacity, and without taking responsibility for their own regulation afterward—this is **uncontained disclosure**.
+
+It often pairs with **relational gravity**: the pull you feel to hold what they've released, even when you didn't consent to receive it.
+
+**What it looks like:**
+
+- Late-night texts announcing distress ("I'm having a mental breakdown")
+- Vague, global framing that invites you to ask more
+- No specific request—just the assumption you'll absorb
+- Testing for access ("you up?") before content arrives
+- Positioning you as "the one who gets me" or "the one who doesn't ignore me"
+
+**What it does to you:**
+
+Your body receives the emotional content whether you agreed to or not. You feel responsible for their state. Guilt arrives even when you've done nothing wrong—because you're no longer absorbing what was never yours to carry.
+
+**The naming matters:**
+
+When you can see the pattern, you stop swimming in it.
+
+This isn't cruelty. It isn't villainy. It's a familiar family dynamic where you became the regulator of someone else's nervous system. Naming it returns the weight to where it belongs.
+
+> *"Uncontained disclosure isn't sharing—it's off-loading. The difference is consent."*
+
+---
+
+## Addition 2: When You Redirect to External Support
+
+**Suggested location:** Chapter 18, after line 628 (after the Sibling Scripts section, before "Scripts for Declining Symbolic Contact")
+
+---
+
+### When You Offer a Resource Instead of Yourself
+
+There's a specific moment that catches many people off guard:
+
+You redirect your sibling to external support—a book, a video, a practice, a therapist—and they go silent.
+
+No response. No "thanks." Just nothing.
+
+**What you did:**
+
+When you offered a resource instead of containment, you did three things simultaneously:
+
+1. You redirected support outward (away from you)
+2. You reframed regulation as self-responsibility
+3. You removed emotional exclusivity ("I'm the one who holds you")
+
+That's healthy. And it changes the dynamic.
+
+**Why they went silent:**
+
+Several possibilities—none of which mean you did something wrong:
+
+**The suggestion breaks the loop.** Until then, the pattern was: distress → you respond → relief/connection. Offering a resource ends the loop instead of feeding it. For someone unconsciously seeking relational soothing, that can feel like the floor dropping out.
+
+**They weren't asking for solutions.** They may have said "I just want to get the sentiment out." When you offered a tool, not containment, there was nothing to "do" next in the script they were running.
+
+**It removes specialness.** If they've positioned you as "someone who wouldn't ignore me," your response gently says: "I'm not the sole place this goes." That can trigger quiet withdrawal—not anger, just disengagement.
+
+**They may have genuinely gone offline.** Not every silence is symbolic. But even if that's the case, your nervous system noticed the shift—because the pattern changed.
+
+**What this is not:**
+
+- Not punishment
+- Not sarcasm
+- Not proof you were cold
+- Not proof you "missed" something
+
+It's simply a dynamic that no longer feeds itself.
+
+**The grounding sentence:**
+
+> *"If someone disappears when I stop carrying them, that tells me what the connection was built on."*
+
+That's information—not a failure.
+
+---
+
+## Addition 3: The Reframe That Releases
+
+**Suggested location:** Chapter 16 (Vol 3), after line 304 (after "The Self-Abandonment Loop" section)
+
+---
+
+### The Truth About Disappearance
+
+When you stop over-functioning and someone withdraws, the instinct is to blame yourself:
+
+*Did I say it wrong? Was I too cold? Should I have explained more?*
+
+But here's what's actually happening:
+
+You offered support that didn't require your body, your time, or your nervous system. That's adulthood, not abandonment.
+
+**The reframe:**
+
+> *"If someone disappears when I stop carrying them, that tells me what the connection was built on."*
+
+Read that again.
+
+Their withdrawal isn't rejection of *you*. It's a response to the absence of what they were actually seeking: your regulation, your absorption, your emotional labor.
+
+When that's no longer available, some people recalibrate. Others disengage.
+
+Both responses are information about capacity—not verdicts on your worth.
+
+**The discomfort you feel:**
+
+The discomfort after holding a boundary isn't evidence that you were wrong.
+
+It's the aftertaste of not over-functioning.
+
+Your nervous system is adjusting to a new pattern. That adjustment feels strange precisely because it's what you needed.
+
+---
+
+## Addition 4: The 60-Second Somatic Reset
+
+**Suggested location:** Chapter 18, after line 457 (after "The Somatic Cue" section), OR as a standalone practice box in Chapter 9
+
+---
+
+### The 60-Second Reset
+
+When guilt spikes after a boundary—or when you've just ended a conversation that pulled at old patterns—use this:
+
+**Step 1: Anchor**
+Place one hand on your chest, one hand on your belly.
+
+**Step 2: Exhale**
+Breathe out longer than you breathe in. Twice.
+(Example: Inhale for 4, exhale for 6. Repeat.)
+
+**Step 3: Name**
+Silently say: *"This guilt is conditioning. My choice is valid."*
+
+**Step 4: Release**
+Silently say: *"I am allowed to choose peace without explanation."*
+
+**Why this works:**
+
+- Hand placement activates the vagus nerve and signals safety
+- Extended exhale shifts the nervous system from sympathetic (fight/flight) to parasympathetic (rest)
+- Naming separates sensation from story
+- The final statement gives your body permission to settle
+
+**When to use:**
+- After setting a boundary via text
+- After declining an invitation
+- After a conversation that activated old guilt
+- Before responding to a late-night message
+- Anytime you notice the familiar tightness that says *"You're bad for protecting yourself"*
+
+You're not bad. You're different now.
+
+---
+
+## Addition 5: Mantras for Post-Boundary Guilt
+
+**Suggested location:** Chapter 18, addition to existing mantras (line 609-617), OR Chapter 9 after the sibling section
+
+---
+
+### When Guilt Arrives After Boundaries
+
+Add to your anchor phrases:
+
+- "I am allowed to choose peace without explanation."
+- "Guilt is the withdrawal symptom of stepping out of an old role."
+- "I am not abandoning them. I am refusing a role that costs me."
+- "The discomfort I feel is not proof I was wrong—it's proof I did something different."
+- "Their silence is information, not a verdict."
+
+**The deeper truth:**
+
+You were trained—implicitly—to be the listener, the stabilizer, the translator, the one who "gets it."
+
+When you stop doing that, the nervous system protests. That doesn't mean go back.
+
+Guilt ≠ wrongdoing here.
+
+Guilt is just the body's familiar response to unfamiliar freedom.
+
+---
+
+## Summary of Suggested Placements
+
+| Addition | Suggested Location |
+|----------|-------------------|
+| Pattern Naming (Uncontained Disclosure) | Chapter 9, after line 93 |
+| External Resource Redirect | Chapter 18, after line 628 |
+| Disappearance Reframe | Chapter 16 (Vol 3), after line 304 |
+| 60-Second Somatic Reset | Chapter 18, after line 457 |
+| Post-Boundary Guilt Mantras | Chapter 18, lines 609-617 (expand existing) |
+
+---
+
+*These additions maintain the book's voice: direct, embodied, non-pathologizing, with clear practical application.*


### PR DESCRIPTION
Add draft content addressing gaps in family boundary-setting coverage:
- Pattern naming framework (Uncontained Disclosure + Relational Gravity)
- External resource redirect scenario and silence response
- Disappearance reframe for post-boundary guilt
- 60-second somatic reset practice
- Post-boundary guilt mantras

Includes suggested placement locations across Chapters 9, 16, and 18.