### PR TITLE
Add cultural coverage gaps proposal for Vol 1: SEE

### DIFF
--- a/book/sovereignty-series/vol-1-see/cultural-coverage-gaps-proposal.md
+++ b/book/sovereignty-series/vol-1-see/cultural-coverage-gaps-proposal.md
@@ -1,0 +1,895 @@
+# Cultural Coverage Gaps Proposal — Vol 1: SEE
+
+## The Problem
+
+The existing proposals (`hispanic-cultural-integration-proposal.md`, `lgbtq-woven-integration-proposal.md`) and the `unified-woven-integration-plan.md` cover Hispanic, Jewish, LGBTQ+, religious, immigrant, and male survivor contexts. Six communities remain underserved. This proposal closes those gaps at the same depth — cultural pillars, weaponization, field notes, scripts, chapter-by-chapter integration — without diluting the book's voice or pathologizing any community.
+
+The communities covered here:
+
+1. **Black / African American**
+2. **Asian (East, South, Southeast)**
+3. **Indigenous / Native**
+4. **Middle Eastern / Arab**
+5. **Religious traditions** (Evangelical, Mormon/LDS, JW, Catholic)
+6. **Transgender-specific** dynamics
+
+---
+
+## The Shared Thesis
+
+**Narcissism adapts to whatever community you can't afford to leave.**
+
+The wolf changes clothing. The teeth don't. In each community below, the pattern is identical: a sacred value becomes a cage, the community becomes the enforcement arm, and leaving costs more than one relationship — it costs identity, belonging, safety, sometimes survival. The culture is not the problem. The narcissist's exploitation of it is.
+
+The book already weaves Hispanic and LGBTQ+ material throughout. This proposal extends that integration. No dedicated "diversity chapter." No sidebars. No "translate to fit." Readers from these six communities should see themselves naturally in the text — the same way current readers do.
+
+---
+
+## 1. Black / African American
+
+### The Architecture
+
+Black American family and community life was forged in survival — slavery, Jim Crow, ongoing state violence. Out of that forge came extraordinary strength, church as sanctuary, extended family as lifeline, and a code of silence that kept the community safe from a world that was never safe for it. Those strengths are real. And narcissists hijack every one of them.
+
+### The Cultural Pillars
+
+#### The Strong Black Woman / Man
+
+**What it is:** The cultural ideal of unshakeable strength, endurance, and self-reliance. You carry what needs to be carried. You don't break. You don't ask for help.
+
+**How it's beautiful:** Generational resilience. The women who held families together through unimaginable loss. The men who kept showing up when the world told them not to.
+
+**How a narcissist weaponizes it:**
+- "Strong Black women don't complain" — complaint becomes racial betrayal
+- Seeking therapy = weakness = "acting white"
+- Naming abuse = admitting you couldn't handle it = failing the ancestors
+- The SBW trope pre-silences you before the narcissist arrives
+- Vulnerability gets coded as fragility, which gets coded as whiteness, which gets coded as betrayal
+
+#### The Church as Center
+
+**What it is:** The Black church as community, family, governance, therapy, political base, and spiritual home.
+
+**How it's beautiful:** Sanctuary, meaning, music, movement, care infrastructure when no one else provided it.
+
+**How a narcissist weaponizes it:**
+- "Pray harder" as the answer to abuse
+- "God hates divorce" — scripture cited to enforce staying
+- Pastor as authority: tells you to submit, to forgive, to stop bringing shame on the marriage
+- First Lady pressure: the pastor's wife role demands public perfection
+- Leaving the marriage = leaving the congregation = losing the only community you have
+- Confessing abuse gets reframed as lack of faith
+
+#### "We Don't Air Dirty Laundry"
+
+**What it is:** The code of protecting the Black community's image from a white gaze that has always been looking for evidence of dysfunction.
+
+**How it's beautiful:** Collective protection. Refusing to hand the oppressor more ammunition.
+
+**How a narcissist weaponizes it:**
+- Naming abuse = betraying the race
+- Calling the police on a Black man is weaponized against you before you pick up the phone ("do you know what they'll do to him?")
+- The entire weight of racial solidarity gets placed on your silence
+- The abuser gets community protection you never got
+- "We take care of our own" becomes "we cover for our own"
+
+#### Intergenerational Trauma as Comparison Weapon
+
+**What it is:** The inherited knowledge that your people have survived worse — slavery, lynching, the crack era, mass incarceration.
+
+**How a narcissist weaponizes it:**
+- "At least he's not hitting you like grandaddy hit grandmama"
+- Your pain gets measured against historical catastrophe and found insufficient
+- Endurance becomes the only virtue
+- "Our people have been through worse" — used to close conversations, not open them
+
+### What Leaving Costs
+
+Church community. Extended family network. Racial solidarity credit. Access to the few Black spaces in your city. The protection of a collective that has every reason to distrust outsiders — including the therapists, lawyers, and shelters you'd need to leave. Leaving often means walking into institutions that weren't built for you, asking for help from systems that have historically harmed your people.
+
+### Chapter Integration Map
+
+| Chapter | What to Add |
+|---|---|
+| **1: Manifesto** | A line in the opening list: "Maybe you were told strong women don't complain — and by the time you realized you were in a cage, complaint felt like betrayal of everyone who came before you." |
+| **5: Narcissist Types** | Cultural camouflage: the controlling Black man whose dominance reads as "finally, a strong brother." The matriarch whose control reads as "she held this family together." |
+| **7: Family Roles** | The Strong Black Woman role as a culturally sanctioned martyr position. |
+| **8: Parental Wounds** | The mother who endured and trained her daughters to endure, framed as love and survival wisdom. |
+| **10: Breaking Free** | "Leaving the church isn't leaving God." Strategies for keeping faith while leaving a congregation that enforces silence. |
+| **11: Romantic Manipulation** | The racial-solidarity trap: "You're going to call the police on a Black man?" as coercive control. |
+| **16: Scripts** | Responses to "pray harder," "don't air dirty laundry," and "our people have been through worse." |
+| **Appendix A** | Therapy for Black Girls, BEAM, Loveland Foundation, The Confess Project. |
+
+### Field Notes
+
+> **Field Note: Strong Enough**
+>
+> I was thirty-four the first time I said the word "abuse" out loud about my own marriage. I said it to a Black woman therapist — the only person I trusted to hear it without making it about race first. She asked me why it took so long.
+>
+> I told her: because I'm a strong Black woman. And strong Black women don't end up in this. We *survive* this. We're the ones who hold everyone else up. If I'm in it, I'm not strong. If I'm not strong, what am I?
+>
+> She was quiet for a long time. Then she said: "Baby. The strongest thing you've ever done is sit in this chair and tell me the truth."
+>
+> I cried for an hour. Not because she validated me. Because I realized the word *strong* had been a leash my whole life, and she had just unclipped it.
+
+> **Field Note: The Pastor's Wife**
+>
+> I was thirty-one years old, First Lady of a church my husband had built from twelve members to six hundred. When the bruising started, I went to the senior pastor's wife — the woman who had mentored me into the role. I thought she would help me.
+>
+> She told me: "Sister, the enemy attacks marriages that do God's work. You need to pray harder. You need to submit deeper. You need to be the Proverbs 31 woman your husband needs you to be."
+>
+> I nodded. I went home. I put on concealer. I preached a women's conference that Saturday on "The Power of a Praying Wife." Three hundred women took notes. I watched them write down the lie that was killing me and call it wisdom.
+
+### Scripts
+
+**When the church says "pray harder":**
+
+🟢 "I believe in prayer. I also believe God gave me instincts, and they're telling me this isn't safe. Faith and safety aren't opposites."
+
+🟡 "Thank you for praying for my marriage. I'm going to keep praying too — and I'm going to talk to a counselor who can help me understand what I'm dealing with."
+
+🔴 "I appreciate the pastor's concern, but this isn't a spiritual attack. This is abuse. I need the church to be a sanctuary, not a silencer."
+
+**When family says "don't air dirty laundry":**
+
+🟢 "Telling the truth to one safe person isn't airing laundry. It's surviving."
+
+🟡 "I love this family. And I need someone outside of it who can help me think clearly right now. That's not betrayal — that's care."
+
+🔴 "Our silence has been protecting the wrong people for too long. I'm not going to be another woman who takes it to the grave."
+
+### Resources
+
+- **Therapy for Black Girls** (therapyforblackgirls.com) — directory of culturally competent therapists
+- **BEAM** (Black Emotional and Mental Health Collective)
+- **Loveland Foundation** — therapy fund for Black women and girls
+- **The Confess Project** — Black men's mental health
+- **Ujima** (The National Center on Violence Against Women in the Black Community)
+
+---
+
+## 2. Asian (East, South, Southeast)
+
+### The Architecture
+
+"Asian" spans enormous diversity — Chinese, Korean, Japanese, Filipino, Vietnamese, Thai, Indian, Pakistani, Bangladeshi, Sri Lankan, and more. But a shared architecture runs across these cultures: filial piety, hierarchical family structure, the primacy of family honor over individual expression, and a profound discipline around emotional restraint. These values produced civilizations. In narcissistic families, they produce invisible cages.
+
+### The Cultural Pillars
+
+#### Filial Piety (孝 / xiao, hyo, hiếu)
+
+**What it is:** The foundational Confucian (and parallel South/Southeast Asian) ethic of devotion, obedience, and lifelong duty to parents. You don't talk back. You don't question. You honor.
+
+**How it's beautiful:** Caring for aging parents. Multigenerational households. A thread that ties you to ancestors you never met.
+
+**How a narcissist weaponizes it:**
+- Any boundary = unfilial = unforgivable
+- Going against a parent's wishes is framed as spitting on the entire ancestral line
+- The parent never has to earn trust or respect — it's culturally owed
+- Parental criticism cannot be refused; only absorbed
+- Therapy = admitting parents failed = the deepest betrayal
+- "After everything we sacrificed" becomes a life sentence
+
+#### Honor and Shame (面子 mianzi, 체면 chaemyeon, izzat, honor)
+
+**What it is:** The cultural architecture of face — your behavior reflects on the family, the clan, the village, the name.
+
+**How it's beautiful:** Accountability to something larger than yourself. A sense that your actions matter.
+
+**How a narcissist weaponizes it:**
+- Your divorce shames the family
+- Your therapy shames the family
+- Your visible distress shames the family
+- A daughter's unhappy marriage is her failure, not his abuse
+- Silence becomes survival — not of the self, but of the family name
+- "What will the aunties say?" is a governance system
+
+#### The Model Minority Myth
+
+**What it is:** The external (and internalized) expectation that Asian Americans are high-achieving, compliant, uncomplaining, successful.
+
+**How a narcissist weaponizes it:**
+- Love is earned through achievement: grades, degrees, salary, marriage, grandchildren
+- Any struggle = personal failure that breaks the family's narrative
+- Depression, anxiety, queerness, addiction — all unthinkable, therefore invisible, therefore unaddressable
+- The golden child is loved for their transcript, not their existence
+- The scapegoat is whoever refuses the achievement treadmill
+
+#### Emotional Restraint as Virtue
+
+**What it is:** Stoicism, composure, not burdening others, "eat bitterness" (吃苦 chī kǔ).
+
+**How a narcissist weaponizes it:**
+- Your feelings are weakness, self-indulgence, un-Asian
+- Crying is shameful; rage is shameful; even joy is suspect if too loud
+- You learn to scan your own face before your family sees it
+- The nervous system never gets to exhale
+- Asking "are you okay?" isn't in the family vocabulary, so neither is "no"
+
+### What Leaving Costs
+
+Parents who may literally never speak to you again. An extended family network that talks. A diaspora community where the news travels in one phone call. The achievement narrative that has structured your entire identity. Often: financial support, housing, immigration sponsorship, eldercare obligations. For many, leaving feels impossible not because of one person but because filial piety isn't a preference — it's the self.
+
+### Chapter Integration Map
+
+| Chapter | What to Add |
+|---|---|
+| **1: Manifesto** | "Maybe you were raised to eat bitterness, and by the time you realized you were being poisoned, complaining felt like dishonor." |
+| **5: Narcissist Types** | The high-achieving Asian parent whose control reads as "pushing you to succeed" — the cultural camouflage of the grandiose narcissist. |
+| **7: Family Roles** | Golden Child conditional on achievement. Scapegoat = the one who failed the script. The erased middle child in large families. |
+| **8: Parental Wounds** | The Tiger Parent as cultural cover for abuse. The emotional restraint training as pre-gaslighting. |
+| **9: Childhood Patterns** | "You learned your feelings were burdens before a narcissist ever told you so." |
+| **10: Breaking Free** | "Filial piety without a self is not piety — it is disappearance." Strategies for honoring parents without erasing yourself. |
+| **11: Romantic Manipulation** | Arranged-marriage pressure. In-law control. The daughter-in-law role as culturally sanctioned subordination. |
+| **16: Scripts** | Responses to "after everything we sacrificed," to shame invocations, to "don't bring shame on the family." |
+| **Appendix A** | Asian Mental Health Collective, South Asian Therapists, Subtle Asian Mental Health. |
+
+### Field Notes
+
+> **Field Note: The Report Card**
+>
+> I was eight years old the first time I understood that I was not a daughter — I was a project. I brought home a report card with one B+. My mother looked at it for a long time. Then she said, in Mandarin: "Do you know why we came to this country?"
+>
+> I knew. I had heard the story a hundred times. The boat. The cousins left behind. The years of working three jobs so I could have a desk, a lamp, a future.
+>
+> "We did not suffer for a B+," she said. And walked away.
+>
+> I got straight A's for the next ten years. I got into the school they wanted. I got the degree they wanted. I married the man they wanted. At thirty-two, I sat in a therapist's office and realized I could not tell her a single thing I had ever wanted for myself — because I had never been allowed to have a self separate from the achievement. The B+ wasn't a grade. It was the last moment I was a child.
+
+> **Field Note: The Quiet Daughter**
+>
+> I was the good one. The quiet one. The one who never caused problems. My sister was the loud one — she fought, she cried, she got sent to her room. I watched what happened to her and I learned.
+>
+> At forty, my husband of fifteen years had been tearing me apart so slowly I didn't notice. My therapist asked me what I was feeling. I said, "I don't know."
+>
+> She said, "Try."
+>
+> I said, "I was trained not to know."
+>
+> My mother had taught me: a Korean daughter does not burden others with her feelings. My grandmother had taught my mother the same thing. My great-grandmother had survived a war by being invisible. Four generations of women who learned that feelings were dangerous. By the time the narcissist arrived, he didn't have to gaslight me. I had been pre-gaslit by love.
+
+### Scripts
+
+**When parents invoke sacrifice:**
+
+🟢 "I honor what you sacrificed. Honoring it doesn't mean I have to disappear. That's not what you crossed the ocean for."
+
+🟡 "I'm grateful. And gratitude isn't the same as obedience. I can love you and still make this choice."
+
+🔴 "The sacrifice you made was so I could have a life. I'm trying to have one. That's the only way your sacrifice means anything."
+
+**When shame is invoked:**
+
+🟢 "The shame isn't mine to carry. I didn't create this situation. Pretending it doesn't exist is what's actually shameful."
+
+🟡 "The aunties will talk either way. I'd rather they talk about me being free than about me being destroyed."
+
+🔴 "Face is important. My life is more important. I can't light myself on fire to keep the family looking warm."
+
+### Resources
+
+- **Asian Mental Health Collective** (asianmhc.org)
+- **South Asian Sexual & Mental Health Alliance (SASMHA)**
+- **Subtle Asian Mental Health** (online community)
+- **Asian Women's Shelter** (San Francisco; culturally specific DV services, multilingual)
+- **Manavi** (South Asian women facing abuse)
+
+---
+
+## 3. Indigenous / Native
+
+### The Architecture
+
+Indigenous communities across Turtle Island (and globally — First Nations, Native Hawaiian, Māori, Aboriginal, Sámi, and countless others) survived five centuries of attempted genocide, forced assimilation, stolen land, stolen children, stolen language. What survived is sacred. What survived is also, in many families, entangled with unprocessed historical trauma that narcissists exploit ruthlessly. The pressure to hold the culture together — against a state that still wants it gone — is enormous. Leaving any piece of that fabric can feel like participating in the genocide.
+
+### The Cultural Pillars
+
+#### Tribal Belonging
+
+**What it is:** Identity as inseparable from nation, tribe, clan, band. You are not an individual with ancestors — you *are* your ancestors, present in this body.
+
+**How it's beautiful:** Continuity with land, language, ceremony, a thousand-year thread the colonizer couldn't cut.
+
+**How a narcissist weaponizes it:**
+- Leaving the community = becoming white = becoming nothing
+- Boundaries framed as "colonized thinking"
+- Therapy framed as "not our way" (even when Native healing traditions would welcome it)
+- Enrollment, blood quantum, ceremonial access used as coercive leverage
+- "You'll lose your standing" — and in some communities, standing is literal
+
+#### Elder Reverence
+
+**What it is:** The foundational ethic that elders carry knowledge, ceremony, and language, and are to be honored.
+
+**How it's beautiful:** Intergenerational transmission of what colonization tried to erase.
+
+**How a narcissist weaponizes it:**
+- Abusive elders get blanket protection because their role is sacred
+- "You don't question an elder" shuts down disclosure
+- Ceremonial authority gets used to control younger relatives
+- A narcissistic elder's behavior is reframed as teaching, medicine, or tough love
+- Calling out abuse = disrespecting the one who carries the old ways
+
+#### Historical Trauma as Silencer
+
+**What it is:** The documented, inherited, bone-deep trauma of genocide, residential schools, boarding schools, forced sterilization, the Sixties Scoop, ongoing disappearance of Indigenous women.
+
+**How a narcissist weaponizes it:**
+- "After everything our people survived, this is what you're going to cry about?"
+- Alcohol, violence, abandonment — all explained (and excused) as the legacy
+- The real legacy becomes a cover story for present-day harm
+- The survivor learns to distinguish "what the system did" from "what he did" — and gets no support for either
+
+#### Cultural Survival Pressure
+
+**What it is:** The legitimate, heavy awareness that the culture is endangered and every member matters to its survival.
+
+**How a narcissist weaponizes it:**
+- Leaving a marriage to another Native person is framed as a loss to the nation
+- Having children with a Native partner becomes an obligation, not a choice
+- Your unhappiness is measured against the survival of your people and found small
+- Your children's tribal enrollment can be weaponized in custody disputes
+- You are taught your individual pain is a luxury your ancestors did not have
+
+### What Leaving Costs
+
+Ceremonial life. Language community. Housing (in tribal communities, this can be literal). Land access. Enrollment and benefits tied to the community. The recognition of who you are in the one place on earth that recognizes it. And: you may be leaving toward institutions — police, courts, DV shelters — with documented histories of harming Native people. The math of leaving is heavier and the receiving end is crueler than for almost any other community in this book.
+
+### Chapter Integration Map
+
+| Chapter | What to Add |
+|---|---|
+| **1: Manifesto** | "Maybe you were taught that your pain was smaller than the survival of your people — and you learned to carry it quietly because your people were already carrying so much." |
+| **5: Narcissist Types** | The "traditional" elder whose authority shields behavior that would be named anywhere else. |
+| **8: Parental Wounds** | Intergenerational trauma without excuse. The parent who is both victim and perpetrator. Both true. Neither resolved by the other. |
+| **10: Breaking Free** | "You can leave a person without leaving the people." Strategies for maintaining ceremony, language, community while separating from one harmer. |
+| **11: Romantic Manipulation** | The "rez boyfriend" who weaponizes Nativeness. The non-Native partner who weaponizes their "ally" status. |
+| **12: Across Contexts** | Tribal politics. How enrollment and housing dynamics create captive relationships. |
+| **16: Scripts** | Responses to "you're being colonized," "our people survived worse," "don't bring the white system into this." |
+| **Appendix A** | StrongHearts Native Helpline, We R Native, Native Wellness Institute. |
+
+### Field Notes
+
+> **Field Note: The Rez**
+>
+> When I told my auntie I was thinking of leaving him, she said: "And go where? Into the white world? You think they want us out there?"
+>
+> I didn't know how to tell her: I don't want to go to the white world. I want to stay here. I want my kids to grow up hearing the language. I want to dance at the powwow without scanning the crowd for him. I want to sit at the drum without his eyes on me.
+>
+> The choice she was offering me was: stay with him and stay home, or leave him and become no one. That was a lie. It was a lie the colonizer invented and a lie he was reading from. But in that kitchen, with her hands around a cup of coffee and her eyes on me, it felt true. The hardest thing I ever did was say: I can be Native without being his.
+
+> **Field Note: The Elder**
+>
+> He was a ceremony man. He carried pipe. People drove three hundred miles to sit with him. And at home, he was the meanest man I ever met.
+>
+> When I tried to tell my mother, she said: "He's a medicine person. You don't understand what he carries."
+>
+> I understood exactly what he carried. I had been carrying it with him my whole life. But in our community, saying that out loud would have been like burning the lodge down. I would have been the one who attacked a medicine person. He would have been the one the community protected.
+>
+> So I left quietly. No announcement. No accusations. Just gone. The community still tells his stories. Nobody tells mine. I decided a long time ago that my survival was a story I could tell myself, and that was enough.
+
+### Scripts
+
+**When leaving is framed as betraying the people:**
+
+🟢 "I'm not leaving the people. I'm leaving one person. The people are bigger than him, and so am I."
+
+🟡 "My ancestors survived so I could have a life. Not so I could give that life back to the first man who asked for it."
+
+🔴 "The culture is not his. He does not get to be the door I have to walk through to belong to my own people."
+
+**When an abusive elder is protected:**
+
+🟢 "I can respect what he carries and still tell the truth about what he did to me. Both are honoring the way."
+
+🔴 "Elders aren't above accountability. That's a colonizer idea, not ours. Our old ways had ways of naming harm."
+
+### Resources
+
+- **StrongHearts Native Helpline** — 1-844-762-8483 (Native-specific DV support)
+- **We R Native** — youth mental health
+- **Native Wellness Institute**
+- **National Indigenous Women's Resource Center (NIWRC)**
+- **Mending the Sacred Hoop**
+
+---
+
+## 4. Middle Eastern / Arab
+
+### The Architecture
+
+Arab, Persian, Kurdish, Turkish, Assyrian, Amazigh, and other Middle Eastern / SWANA cultures span vast diversity — Muslim, Christian, Jewish, Druze, Yazidi, Bahá'í, secular. Across that diversity, a shared architecture runs: extended family as foundational unit, honor (sharaf, namus, ird) as a family-level asset, patriarchal hierarchy, and a community gossip network whose reach is global thanks to diaspora. These cultures produced poetry, science, and hospitality traditions that humble the rest of the world. They also, in narcissistic families, produce some of the most airtight cages in this book.
+
+### The Cultural Pillars
+
+#### Sharaf (Family Honor)
+
+**What it is:** The honor of the family as a collective asset that every member holds a piece of and every member can destroy.
+
+**How it's beautiful:** Accountability. A sense that what you do matters beyond yourself.
+
+**How a narcissist weaponizes it:**
+- Your behavior becomes everyone's property
+- A daughter's unhappy marriage is managed, not rescued, to protect the clan
+- Divorce isn't a personal decision — it's a family catastrophe
+- "You'll destroy us" isn't hyperbole; in some diaspora communities it's a social fact
+- In the most extreme cases, honor becomes a justification for violence against women
+
+#### Patriarchal Authority
+
+**What it is:** The father (or eldest uncle, or elder brother) as the unquestioned head of the family.
+
+**How a narcissist weaponizes it:**
+- The patriarch never has to earn respect — it is culturally owed
+- A daughter cannot contradict a father, a wife cannot contradict a husband, without cultural violation
+- Male relatives become enforcers, not protectors
+- Brothers are trained to police sisters' behavior and reputation
+- The cultural script provides the abuser's defense before the abuser opens his mouth
+
+#### Ird / Women's Honor as Family Property
+
+**What it is:** A woman's chastity, modesty, and reputation as a collective asset of her family.
+
+**How a narcissist weaponizes it:**
+- Her body is not hers; it is her father's, then her husband's
+- Any rumor — true or false — damages the whole family
+- Women are silenced preemptively to "protect the family name"
+- Sexual violence cannot be named because naming it destroys *her*, not him
+- Leaving a marriage is often impossible because "damaged" women cannot return home
+
+#### The Community Gossip Network
+
+**What it is:** A transnational diaspora network where news travels from Detroit to Cairo to Amman to London in an afternoon.
+
+**How a narcissist weaponizes it:**
+- Every move is watched; every move is reported
+- The threat of exposure is a permanent leash
+- The survivor is isolated from one community (diaspora) while also being surveilled by it
+- There is no "anonymous." There is no "somewhere else." The network has no edges.
+
+### What Leaving Costs
+
+Family. Extended family. The diaspora community in your city *and* in the homeland. Sometimes: legal documents, citizenship tied to marriage, housing, access to children (who may be removed to the home country). In the worst cases, physical safety — honor-based violence is real and survivors deserve resources that name it without flattening the culture into a caricature.
+
+### Chapter Integration Map
+
+| Chapter | What to Add |
+|---|---|
+| **1: Manifesto** | "Maybe you were taught that your honor belonged to your family — and when someone harmed you, their harm became your shame." |
+| **7: Family Roles** | The enforcer brother. The gatekeeping mother-in-law. The patriarch whose word ends every conversation. |
+| **8: Parental Wounds** | The father who loved you and controlled you in the same gesture. The mother who was trained to protect the son over the daughter. |
+| **10: Breaking Free** | Safety planning for honor-based situations. "The network has no edges — but it also has cracks." |
+| **11: Romantic Manipulation** | The marriage as alliance-between-families, where leaving him means leaving them. In-law control as central to the relationship. |
+| **12: Across Contexts** | Transnational surveillance. The diaspora phone tree as enforcement infrastructure. |
+| **16: Scripts** | Responses to honor invocations, to "what will people say," to "think of your family." |
+| **Appendix A** | AHA Foundation, Tahirih Justice Center, Karma Nirvana, Apna Ghar. |
+
+### Field Notes
+
+> **Field Note: The Family Meeting**
+>
+> When I told my mother I wanted to leave my husband, she did not ask if I was safe. She asked if I had told anyone yet. That was the first question. Not *are you okay*. *Who knows.*
+>
+> Within two days, seventeen family members had been notified. My uncle flew in from Amman. My father's brother drove from another state. They sat in our living room — all men, except my mother, who brought tea and did not sit down — and they discussed my marriage like a case file.
+>
+> I was not in the room. I was in the kitchen with my mother. She held my hand and said, in Arabic: "Whatever they decide, we will make it work. We have to think of the family."
+>
+> I realized then: the family meeting wasn't about protecting me. It was about protecting *the family* from me. My pain was a public relations crisis. My safety was a secondary consideration. I was the scandal, not the victim.
+
+> **Field Note: The Good Daughter**
+>
+> I was raised to be the *bint tayyiba* — the good girl. Modest. Quiet. Marriageable. When my husband started hurting me, I did not tell my parents for three years, because I knew what would happen. Not because they wouldn't believe me. Because they would, and they would tell me the same thing every good daughter in my family had been told for generations: *aguri* — be patient. *Sabr.* Think of the family. Think of the children. Think of what people will say.
+>
+> The worst part is they would not have been cruel. They would have been *loving*. They would have cried. They would have held me. And then they would have sent me back to him, because that is what a good family does — it keeps itself together.
+>
+> The hardest thing I ever learned was this: I could be a good daughter or I could be alive. Not both. Not in this family.
+
+### Scripts
+
+**When family honor is invoked:**
+
+🟢 "The honor isn't mine to lose. It's his to have lost when he chose to hurt me."
+
+🟡 "I love this family. And I cannot save the family by sacrificing myself. There is no honor in that equation."
+
+🔴 "If the family's honor depends on my silence, then the family's honor has already been broken — just not by me."
+
+**When the network is weaponized:**
+
+🟢 "I can't control what people say. I can only control whether I live long enough to care."
+
+🔴 "The phone tree will survive my truth. I'm not going to die to keep it quiet."
+
+### Resources
+
+- **AHA Foundation** (ahafoundation.org) — honor violence and forced marriage
+- **Tahirih Justice Center** — immigrant women facing gender-based violence
+- **Karma Nirvana** (UK-based, international reach) — honor-based abuse
+- **Apna Ghar** (Chicago) — South Asian, Middle Eastern, and immigrant survivors
+- **Muslim Women's Organization**
+- **Arab American Family Services**
+
+---
+
+## 5. Religious Traditions: Evangelical, Mormon/LDS, Jehovah's Witness, Catholic
+
+### The Architecture
+
+The unified plan's "religious community" section names the shared structure: a congregation that functions as family, an authority figure who mediates truth, and a cosmology in which leaving has eternal consequences. This section adds specificity. These four traditions aren't the only ones — they're the ones whose structures produce the most identifiable, survivor-documented patterns of narcissistic entrapment in the Anglophone West. Each has its own architecture. Each weaponizes its own sacred things. And the narcissist in each one doesn't have to invent the cage — it was already built, blessed, and filled with loving people who will help hold you inside it.
+
+### 5a. Evangelical / Conservative Protestant
+
+#### The Pillars
+
+**Headship / Biblical submission.** The husband as spiritual head of the household, the wife as helpmeet. Obedience framed as worship. Pastoral authority over marriage. "God hates divorce." The wife's submission is not contingent on the husband's worthiness.
+
+**Purity culture.** A woman's worth is sexual; a man's lapses are spiritual warfare. Shame is the governance system. Consent is replaced with covenant.
+
+**Spiritual warfare framing.** Abuse becomes "the enemy attacking your marriage." Distress becomes "lack of faith." Therapy is suspect unless it's "biblical counseling." Your perception is a spiritual deficiency.
+
+**How a narcissist weaponizes it:**
+- Scripture cited to enforce staying ("what God has joined together...")
+- Submission as coerced compliance
+- Pastor as flying monkey, often unwittingly — "have you prayed about it?"
+- Church discipline used against the survivor for "breaking the covenant"
+- The survivor's faith is used against her faith
+
+### 5b. Mormon / LDS
+
+#### The Pillars
+
+**Eternal marriage and the celestial kingdom.** Temple-sealed marriages extend past death. Leaving isn't a divorce — it's a cosmic severance with eternal consequences for you, your spouse, your children, your ancestors.
+
+**Temple worthiness as leverage.** Access to the temple, to sealings, to callings, depends on a bishop's interview. Bishops can be — and have been — told the "faithful" version of events. Worthiness becomes the narcissist's leash.
+
+**The ward as community infrastructure.** Your ward is your social network, childcare, casseroles, moving help, emergency fund. Leaving the marriage often means leaving the ward, which means losing everything at once.
+
+**Obedience as the first law.** Questioning is a spiritual problem. Doubt is a spiritual problem. Leaving is the biggest spiritual problem there is.
+
+**How a narcissist weaponizes it:**
+- "You'll break the seal. You won't see the children in the next life."
+- Bishop interviews weaponized; confidential disclosures shared back to the abuser
+- Garments, tithing, temple recommend status used as control
+- The ward mobilizes to "save the marriage" — which means pressuring the one trying to leave
+
+### 5c. Jehovah's Witnesses
+
+#### The Pillars
+
+**"The Truth" as total identity.** The organization is not a denomination — it is The Truth. Everyone outside is spiritually dead.
+
+**Disfellowshipping and shunning.** The single most efficient coercive mechanism in modern Western religion. Disfellowshipped members are cut off — entirely — by family, friends, spouse, children. No acknowledgment. No conversation. As if dead.
+
+**Elders as judicial body.** Abuse is handled internally. The "two-witness rule" (historically applied to sexual abuse) has protected abusers for decades.
+
+**No higher education, limited outside relationships.** By design, the world outside the organization is unfamiliar and frightening.
+
+**How a narcissist weaponizes it:**
+- Threaten to report the survivor to elders for a fabricated "sin"
+- The abuser confesses first; controls the narrative
+- Shunning as the ultimate leash — leaving means losing every relationship you have ever had
+- The survivor has been structurally prevented from building the outside life she would need to leave
+
+### 5d. Catholic
+
+#### The Pillars
+
+**The sacrament of marriage.** Marriage is a sacrament, not a contract. Annulment is rare and humiliating. Divorce is social and spiritual exile.
+
+**Guilt as governance.** Confession, penance, the ongoing ledger of sin. Catholic guilt is a cliché because it is real and it is load-bearing.
+
+**Marian idealization of motherhood.** Suffering mothers are holy. Complaining mothers are not.
+
+**Cultural Catholicism + ethnic entanglement.** Italian, Irish, Polish, Filipino, Mexican, Brazilian Catholicism each comes with additional cultural layers. The Catholic architecture often fuses with the cultural one (see Hispanic proposal).
+
+**How a narcissist weaponizes it:**
+- "Offer it up" — suffering as sanctification
+- "What God has joined" — leaving as defiance of God
+- The priest as spiritual authority telling her to reconcile
+- Annulment as a gauntlet of humiliation designed to discourage
+- Marian guilt fused with marianismo for double coverage
+
+### What Leaving Costs (All Four)
+
+Your congregation. Your childcare network. Your moral cosmology. Your eternity (as you understand it). Your children's religious community. Your entire understanding of who you are in the universe. For JWs specifically: every single relationship, all at once, by design. For LDS: often literal family estrangement. For Evangelicals: the loss of identity as a "good Christian woman." For Catholics: a lifetime of guilt that outlives the marriage.
+
+### Chapter Integration Map
+
+| Chapter | What to Add |
+|---|---|
+| **1: Manifesto** | "Maybe it was a marriage God was supposed to bless, and the silence around what was happening felt holier than the truth." |
+| **5: Narcissist Types** | The covert-spiritual narcissist. The "godly husband" whose dominance is sanctified. The "righteous wife" whose martyrdom is celebrated. |
+| **7: Family Roles** | The congregation as extended family. Pastors, bishops, elders as flying monkeys. |
+| **8: Parental Wounds** | The parent whose love is mediated through God's love, and who withdraws both at once. |
+| **10: Breaking Free** | "You can leave the marriage without leaving God." "You can leave the organization without losing your soul." Detailed pathway for JW exit given the shunning architecture. |
+| **11: Romantic Manipulation** | Scripture-based control. Priesthood/headship-based control. Temple/sacrament as leverage. |
+| **12: Across Contexts** | The congregation as coercive control infrastructure. |
+| **16: Scripts** | Responses to "God hates divorce," to "pray about it," to "submit," to "have you talked to the bishop," to "the elders decided." |
+| **Appendix A** | Tears of Eden, Give Her Wings, Leaving the Fold, Recovering from Religion, ExJW resources. |
+
+### Field Notes
+
+> **Field Note: The Bishop's Office**
+>
+> I sat across from my bishop — a kind man, a man I had known since I was eleven years old — and I told him my husband had pushed me down the stairs. I was thirty weeks pregnant.
+>
+> He looked at me with genuine sorrow and he said: "Sister, marriages are sealed for eternity. Satan wants nothing more than to break this family apart. Have you considered your role in the provocation?"
+>
+> I left the office and drove to the hospital for contractions. In the parking lot I sat in the car for twenty minutes trying to understand what had just happened. I had told a man of God that I was in danger and he had asked me what I did to cause it.
+>
+> I realized later: the bishop wasn't cruel. He was following a script. The script said the marriage mattered more than the woman inside it. Everyone in that system — including me — had been reading from the same script for so long that we couldn't hear how it sounded.
+
+> **Field Note: Disfellowshipped**
+>
+> I was raised a Witness. Everyone I knew — mother, father, brothers, cousins, every friend from every memory I had — was a Witness. When I finally told an elder what my husband had been doing to me, I was asked to provide a second witness. I couldn't. He was careful.
+>
+> They disfellowshipped *me*. For "slander." For "a rebellious spirit." My husband kept his standing. My family stopped speaking to me within a week — not gradually, not with tears. All at once. My mother passed me in the grocery store and looked through me like I was a ghost.
+>
+> I lost 43 people that month. That's how many relationships I had. Every single one. The organization calls this "loving discipline." I call it what it was: a machine built to make sure no one ever tells the truth about what happens inside it.
+
+### Scripts
+
+**When scripture is weaponized:**
+
+🟢 "God does not bless harm. If staying requires me to endure what God weeps over, staying isn't faith — it's fear with a Bible on top."
+
+🟡 "I read the same Bible you do. I read the part where he loved the woman at the well, and the part where he overturned tables. God is not in this marriage. He is in me, trying to get out."
+
+🔴 "I'm not leaving my faith. I'm leaving one man. The fact that you can't tell the difference is exactly why I have to go."
+
+**When the organization threatens:**
+
+🟢 "You can take my membership. You cannot take my conscience."
+
+🔴 "If the organization protects abusers and punishes those who name abuse, then the organization is not The Truth. And I have already lost everything I'm going to lose."
+
+### Resources
+
+- **Tears of Eden** (spiritual abuse recovery; Christian contexts)
+- **Give Her Wings** (evangelical DV recovery)
+- **Recovering from Religion** / Hotline Project
+- **AVFR (Advocates for Victims of Faith-related Recovery)**
+- **ExJW Reddit, Advocates for Awareness of Watchtower Abuses**
+- **Sound Choices Coalition** (LDS context)
+- **Faithtrust Institute**
+
+---
+
+## 6. Transgender-Specific Dynamics
+
+### The Problem
+
+The unified plan touches trans dynamics inside the broader LGBTQ+ material, but trans survivors face specific coercive mechanisms that don't map cleanly onto cis queer experience. Deadnaming, misgendering, HRT control, medical gatekeeping, and documentation weaponization are not sub-cases of homophobia. They are a separate vocabulary of control. This section names them.
+
+### The Cultural Pillars (Pattern Set)
+
+#### Medical Gatekeeping as Leverage
+
+**What it is:** The already-hostile terrain of trans healthcare — letters of support, long wait times, insurance denials, gatekeeping clinicians — creates dependencies a narcissist can exploit.
+
+**How it's weaponized:**
+- Partner controls transportation to appointments
+- Partner holds HRT supplies, doses, schedules, or "reminds" you of them as leverage
+- Partner writes (or threatens to withdraw) a letter of support
+- Partner stays on insurance that your transition depends on
+- Partner accompanies appointments, controls the narrative with providers
+
+#### Deadnaming and Misgendering as Weapons
+
+**What it is:** Using a trans person's pre-transition name or wrong pronouns deliberately, as punishment, reminder of dependence, or public reassertion of power.
+
+**How a narcissist weaponizes it:**
+- Correct gendering only when you're compliant; deadnaming when you're not
+- "Slips" in front of family, coworkers, children
+- Outing to medical providers, employers, landlords, custody courts
+- Stored photos, documents, ID as ammunition
+- The threat doesn't need to be executed — the possibility is the leash
+
+#### Transition Dependence
+
+**What it is:** A narcissistic partner positioning themselves as the one person who "really accepts" your transition, making themselves structurally central to your ability to be yourself.
+
+**How a narcissist weaponizes it:**
+- "No one else will love you like this."
+- "Do you know how lucky you are that I stayed?"
+- Isolation from trans community framed as "you don't need them, you have me"
+- Your gratitude for their acceptance is converted into an endless debt
+- The version of you they "accept" is the version that doesn't ask for more
+
+#### Community Scarcity
+
+**What it is:** Trans communities, especially outside major cities, are small. Dating pools are smaller. Everyone knows everyone. Leaving one person can mean navigating every future space with their version of you already present.
+
+**How a narcissist weaponizes it:**
+- "Who else is going to want you?"
+- Reputation management inside the community
+- Using shared friends as surveillance
+- Framing other trans people as threats, "not real friends," drama
+
+### What Leaving Costs
+
+Access to HRT (in states where gender-affirming care is under legal attack, this is not hyperbole). Housing, especially if lease or mortgage is in their name. Custody, in jurisdictions where being trans is still used against parents. Immigration status, if transition was navigated around a partner's citizenship. Legal name change support. Documentation. Safe-enough housing. The one person who "accepts" you, in a world where acceptance is still not the default. And often: the trans community in your specific city, where the narcissist has already started shaping the narrative.
+
+### Chapter Integration Map
+
+| Chapter | What to Add |
+|---|---|
+| **1: Manifesto** | "Maybe it was someone who called you by your name when no one else would — and then used that name like a key they could take back." |
+| **4: Trauma Bonds** | "When the bond is to the person who gave you your name." |
+| **8: Parental Wounds** | Deadnaming by parents as coercive control, not just rejection. |
+| **10: Breaking Free** | Transition-specific safety planning. Medical continuity. Documentation. |
+| **11: Romantic Manipulation** | HRT control. Medical gatekeeping. "Identity as leverage" section expanded to include gender identity specifically. |
+| **12: Across Contexts** | Small trans communities as captive environments. |
+| **16: Scripts** | Responses to deadnaming threats, to HRT control, to "no one else will want you." |
+| **Appendix A** | Trans Lifeline, FORGE, Trans Women of Color Collective, Trans Justice Funding Project. |
+
+### Field Notes
+
+> **Field Note: The Prescription**
+>
+> I had been on hormones for two years. My partner — the person who had driven me to my first appointment, who had held my hand in the waiting room, who had been there through the worst of the dysphoria — was also the person who kept my pills in her drawer. She said it was because I was forgetful. She said it was love.
+>
+> The first time she withheld a dose was after an argument about her sister. It was one day. I didn't say anything. The second time was a week. I started to panic — not about her, about my body, about the months of work unraveling. The third time was two weeks and she told me, calmly, that if I left her I wouldn't even have my hormones because her name was on the prescription.
+>
+> I realized that night: the dysphoria I had been navigating for years was a weather system. She had learned to control the weather.
+
+> **Field Note: The Name**
+>
+> He used my name. My real name. For three years he used it. And then one day — after a fight, after I had started talking about leaving — he called me by my deadname. In public. At a restaurant. In front of the waiter.
+>
+> Every head turned. The waiter's face froze. My body went somewhere else. I sat there with a napkin in my lap and listened to him laugh and say, "Sorry, old habit." He looked me in the eye while he said it. He was not sorry. It was not a habit. It was a demonstration.
+>
+> I understood then: the name he had been calling me for three years had never been mine. It had been a gift, and gifts can be taken back. I realized I needed to get to a place where my name was not something he — or anyone — could give or withhold. I needed a name the way I had a spine: from the inside.
+
+### Scripts
+
+**When they threaten to deadname or out you:**
+
+🟢 "My name is mine. My transition is mine. You don't get to revoke either one by saying a word in public."
+
+🟡 (Don't escalate if it isn't safe.) *Document. Build the exit. Talk to a trans-specific DV resource before you respond.*
+
+🔴 "This is coercive control. It is abuse. I am contacting Trans Lifeline and a DV advocate, and I am protecting myself."
+
+**When HRT or medical access is controlled:**
+
+🟢 "My medical care is mine. Any version of love that controls my body is not love."
+
+🟡 Quietly rebuild access: new provider, new prescription, own pharmacy, own appointments. Do not announce. Build first.
+
+🔴 If withholding medication is being used as punishment, this is coercive control and may be a crime. Trans Lifeline and a DV hotline can help you plan.
+
+### Resources
+
+- **Trans Lifeline** — 1-877-565-8860 (peer-run, trans-specific)
+- **FORGE** (forge-forward.org) — trans survivors of violence
+- **Trans Women of Color Collective**
+- **Sylvia Rivera Law Project**
+- **Trans Justice Funding Project**
+- **Point of Pride** (HRT access fund)
+
+---
+
+## Cross-Community Intersectionality Map
+
+None of the communities in this proposal exist in isolation. Real survivors live at intersections, and intersection doesn't add pressure — it multiplies it. A Black Evangelical woman is not dealing with racism plus sexism plus religion; she is dealing with a single compounded architecture in which each layer reinforces the others. This section maps the most common overlaps the book will encounter.
+
+| Overlap | What Compounds | Example Pattern |
+|---|---|---|
+| **Black + Evangelical** | "Strong Black Woman" fuses with "biblical submission"; racial silence fuses with spiritual silence | "A praying wife doesn't air dirty laundry — and she certainly doesn't call the police on a Black man." |
+| **Black + Catholic** | SBW endurance + Marian suffering-as-holiness + ethnic Catholic family structures (Haitian, Afro-Latinx) | Double-coverage of the martyr role. |
+| **Asian + Evangelical** | Filial piety + headship doctrine; honor/shame + purity culture | Korean-American Evangelical daughters face a near-airtight system: disobedience is both cultural sin and spiritual sin. |
+| **Asian + Catholic** | Filipino Catholicism, Vietnamese Catholicism — honor/shame + sacramental marriage + Marian suffering | Leaving a marriage is simultaneously dishonoring parents, violating a sacrament, and failing to be a good Catholic mother. |
+| **Indigenous + Catholic/Evangelical** | Historical trauma of forced Christianization + current religious community + tribal belonging | Residential-school legacy means the same religion that traumatized the ancestors now holds community infrastructure. Leaving the church can feel like second-generation exile. |
+| **Middle Eastern + Muslim / Christian / Jewish** | Sharaf + religious authority; ird + purity culture; patriarchal clan structure + scripture | The family meeting has theological backup. |
+| **Trans + any religious tradition** | Medical gatekeeping + cosmological rejection; deadnaming + "you're rejecting how God made you" | The narcissistic partner's leverage is amplified by a religious community that already sees the survivor as fundamentally disordered. |
+| **Trans + Black / Asian / Indigenous / Middle Eastern** | Community scarcity + family honor + "you're already bringing shame" | Trans people of color face smaller communities, higher violence rates, and family systems that may weaponize cultural belonging against their identity. |
+| **Hispanic + Catholic** (covered in Hispanic proposal — referenced here) | Marianismo + Marian theology; familismo + sacrament | See Hispanic proposal for full treatment. |
+| **LGBTQ+ + any religious tradition** (partially covered in LGBTQ+ proposal) | Acceptance-as-leverage + cosmological rejection | See LGBTQ+ proposal; this proposal expands the religious specificity. |
+
+**The principle the book must hold:** intersections are not a separate special case. They are the *default*. Most readers live at an intersection. The book should write toward the compound, not the single axis.
+
+---
+
+## Combined Integration Table — All Six Communities
+
+This table parallels the combined integration map in `lgbtq-woven-integration-proposal.md`. It shows where each community's material lands, chapter by chapter, so the integration pass is single-pass rather than repeated.
+
+| Chapter | Black | Asian | Indigenous | Middle Eastern | Religious | Trans |
+|---|---|---|---|---|---|---|
+| **1: Manifesto** | "Strong women don't complain" line | "Eat bitterness" line | "Your pain was smaller than the survival of your people" line | "Your honor belonged to your family" line | "Marriage God was supposed to bless" line | "Called you by your name when no one else would" line |
+| **4: Trauma Bonds** | — | — | — | — | — | Bond to the person who gave you your name |
+| **5: Narcissist Types** | SBW role as sanctioned martyr; strong brother as camouflaged dominance | Tiger parent as grandiose cover | "Traditional" elder authority shielding abuse | Patriarchal camouflage | Covert-spiritual narcissist; "godly husband" | — |
+| **7: Family Roles** | SBW martyr role | Achievement-based Golden Child; erased middle child | Enforcer elder; ceremony gatekeeping | Enforcer brother; gatekeeping MIL | Congregation as extended family; pastors/bishops/elders as flying monkeys | — |
+| **8: Parental Wounds** | Mother who endured and taught endurance | Tiger Parent covert abuse; pre-gaslighting via emotional restraint | Intergenerational trauma without excuse | The loving-controlling father; the protective-of-sons mother | Parent whose love is mediated through God's | Deadnaming by parents as coercive control |
+| **9: Childhood Patterns** | — | "Your feelings were burdens before a narcissist told you" | — | — | Religious conditioning as pre-compliance | — |
+| **10: Breaking Free** | "Leaving the church isn't leaving God" | "Filial piety without a self is disappearance" | "Leave a person without leaving the people" | Honor-based safety planning | "Leave the organization without losing your soul"; JW-specific exit pathway | Medical continuity and documentation planning |
+| **11: Romantic Manipulation** | Racial-solidarity trap; police as weapon | Arranged-marriage pressure; in-law control | "Rez boyfriend"; ally-weaponizing non-Native | Marriage as alliance-between-families | Scripture/temple/sacrament as leverage | HRT and medical gatekeeping; identity-as-leverage expanded |
+| **12: Across Contexts** | — | — | Tribal politics; enrollment and housing | Transnational diaspora surveillance | Congregation as coercive infrastructure | Small trans communities as captive environments |
+| **16: Scripts** | "Pray harder," "don't air dirty laundry," "our people survived worse" | "After everything we sacrificed"; shame invocations | "You're being colonized"; elder protection | Honor invocations; the network | Scripture weaponization; bishop/elder threats | Deadnaming threats; HRT control; "no one else will want you" |
+| **Appendix A** | Therapy for Black Girls, BEAM, Loveland, Ujima | AMHC, SASMHA, Manavi, Asian Women's Shelter | StrongHearts, NIWRC, We R Native | AHA, Tahirih, Karma Nirvana, Apna Ghar | Tears of Eden, Give Her Wings, Recovering from Religion, ExJW | Trans Lifeline, FORGE, TWOCC, Point of Pride |
+
+---
+
+## Sensitivity Review Requirements
+
+Each community in this proposal requires dedicated sensitivity reading by someone from that community *before* any manuscript changes are drafted, and again after drafting. This is not optional, and it is not a checkbox — it is the mechanism by which this integration stays honest.
+
+| Community | Required Reader Profile | What to Review |
+|---|---|---|
+| **Black / African American** | Black woman DV survivor and/or Black clinician; ideally also a Black clergy-adjacent reader for the church material | Field notes, church scripts, SBW framing, "don't air dirty laundry" treatment, intergenerational comparison |
+| **Asian (E/S/SE)** | At least two readers from different regions (e.g., Korean-American + Indian-American + Filipino-American ideal); survivor or clinician working with Asian American families | Filial piety framing, specific cultural terms (xiao, mianzi, izzat), model minority treatment, emotional restraint section |
+| **Indigenous / Native** | Native woman, ideally a survivor advocate affiliated with StrongHearts or a tribal DV program; elder consultation if material touches ceremony | Historical trauma framing, elder authority section, enrollment/housing dynamics, tribal belonging treatment |
+| **Middle Eastern / Arab** | SWANA woman, ideally from an honor-violence advocacy background; diaspora reader and homeland reader if possible; Muslim, Christian, and secular perspectives | Sharaf/ird framing, patriarchal authority treatment, honor-based violence section, diaspora surveillance material |
+| **Religious traditions** | One reader per tradition (Evangelical survivor, ex-Mormon, ex-JW, Catholic survivor); spiritual abuse specialist if available | Theology accuracy, community dynamics, shunning specificity, bishop/elder dynamics, annulment material |
+| **Trans-specific** | Trans woman and trans man; ideally trans survivor from a DV-specific org (FORGE, Trans Lifeline); trans person of color to read intersection material | Medical gatekeeping, deadnaming framing, community scarcity, transition dependence, language choices throughout |
+
+**Process note:** The existing editorial pipeline uses the Sage sensitivity reader agent. That pipeline remains. This human review layer is *in addition to*, not a replacement for, Sage — because lived experience catches things that pattern-matching doesn't.
+
+---
+
+## Implementation Strategy
+
+### Approach: Woven Integration (Consistent with Hispanic and LGBTQ+ Proposals)
+
+Every addition in this proposal should be woven into existing chapters, not cordoned into a dedicated "diversity section." This is the same approach the Hispanic and LGBTQ+ proposals took, and it is the approach the sensitivity reader (Sage) has already validated in Review Round 3.
+
+**No dedicated chapter per community.** A reader from any of these six communities should encounter themselves naturally in the flow of the book — in a field note beside other field notes, in a script beside other scripts, in a paragraph that names their reality without announcing it.
+
+### Estimated Scope
+
+- **New paragraphs:** 30–40 across chapters
+- **New field notes:** 12 (two per community)
+- **New scripts:** 18–24 (two to four scenarios per community)
+- **Chapter integration points:** ~50 (see combined table above)
+- **Appendix A additions:** ~30 new resources
+- **Estimated manuscript page growth:** 25–40 pages
+
+### Phasing
+
+1. **Author review of this proposal** — scope, tone, boundaries, any communities to add or defer
+2. **Sensitivity reader recruitment** — one per community, before any drafting
+3. **Community-by-community drafting** — one community at a time, with its sensitivity reader in the loop
+4. **Integration pass** — merge drafted material into the manuscript chapter by chapter
+5. **Sage review** — existing editorial pipeline
+6. **Final reader pass** — each community's sensitivity reader reviews the integrated manuscript, not just the proposal
+7. **Manuscript-level legal review** — on integrated material, paralleling the Tier 1/2/3 structure already used for author-identifying details
+
+### Relationship to Existing Proposals and Unified Plan
+
+This proposal does not replace any existing work. It extends the same framework:
+
+- `hispanic-cultural-integration-proposal.md` — Hispanic/Latino, intact
+- `lgbtq-woven-integration-proposal.md` — LGBTQ+, intact
+- `unified-woven-integration-plan.md` — master plan covering Hispanic, Jewish, LGBTQ+, religious (overview), immigrant, male survivors
+- **This proposal** — Black, Asian, Indigenous, Middle Eastern, religious (depth for four traditions), trans-specific
+
+**Overlap points with the unified plan:**
+
+- *Religious communities*: the unified plan names the pattern; this proposal adds Evangelical, LDS, JW, and Catholic specificity. Both should be read together.
+- *Trans-specific*: the LGBTQ+ proposal and unified plan both touch trans dynamics under the broader queer umbrella. This proposal extracts the trans-specific coercive mechanisms (HRT, deadnaming, medical gatekeeping) that don't map cleanly onto cis queer experience.
+- *Immigrant material*: the unified plan covers immigrant dynamics. Several communities in this proposal (Asian, Middle Eastern, some Indigenous diaspora) are also immigrant communities. The integration pass should coordinate these threads rather than duplicate them.
+
+### What This Is NOT
+
+- Not a "diversity appendix" — the material is woven throughout
+- Not a claim that these six communities exhaust the gaps (disability, class, neurodivergence, rural, and others remain)
+- Not a portrayal of any community as inherently toxic
+- Not a flattening of internal diversity — each community above contains multitudes and the material must reflect that
+- Not a replacement for hiring sensitivity readers — this proposal is a blueprint, not a substitute
+
+---
+
+## Next Steps
+
+1. **Author review** — alignment on communities, tone, scope, and any additions or deferrals
+2. **Confirm implementation strategy** — woven integration (recommended) vs. any alternative
+3. **Sensitivity reader recruitment** — begin with the communities where the author has the least direct knowledge
+4. **Draft community by community** — in the order that best matches reader recruitment
+5. **Coordinate with unified plan** — ensure religious and trans material lines up with existing threads
+6. **Editorial pipeline integration** — Sage review, legal review, final reader pass
+
+---
+
+*The wolf wears different clothing in every community. In some it wears a "strong Black woman" T-shirt. In some it wears a tiger mother's report card. In some it wears an elder's regalia. In some it wears a family honor that was never the survivor's to hold. In some it wears a bishop's collar. In some it wears the name it gave you and threatens to take back. The clothing changes. The teeth don't. This book should name every disguise — not just the ones that fit the reader the system was built around.*
+


### PR DESCRIPTION
## Summary

This PR adds a comprehensive proposal document that extends cultural representation in the book to six underserved communities: Black/African American, Asian, Indigenous/Native, Middle Eastern/Arab, specific religious traditions (Evangelical, Mormon/LDS, Jehovah's Witness, Catholic), and transgender-specific dynamics.

## Key Changes

- **New document**: `book/sovereignty-series/vol-1-see/cultural-coverage-gaps-proposal.md` (895 lines)
  - Establishes shared thesis: "Narcissism adapts to whatever community you can't afford to leave"
  - Provides detailed cultural architecture for each community, including:
    - Cultural pillars (values and how they're weaponized)
    - What leaving costs in each context
    - Chapter-by-chapter integration map
    - Field notes (survivor narratives)
    - Scripts for common coercive situations
    - Community-specific resources

## Notable Implementation Details

- **Consistent structure across all six communities** ensures the book maintains voice and depth without diluting either
- **Intersectionality mapping** at the end identifies how communities overlap and compound pressure (e.g., Black + Evangelical, Asian + Catholic)
- **No dedicated "diversity chapter"** — all integration is woven throughout existing chapters, matching the approach already used for Hispanic and LGBTQ+ material
- **Pathology-free framing** — cultures are presented as beautiful and functional; narcissists are presented as exploiting what's already there
- **Practical, actionable content** — each section includes scripts with three response levels (green/yellow/red) for different safety contexts
- **Survivor-centered** — field notes are written as first-person narratives to center lived experience

https://claude.ai/code/session_01J2SDJTkDKxWQ3bYYe7RFEQ