### PR TITLE
Remove M.S. credential from author name across all materials

### DIFF
--- a/book/release/09-substack-start-here-post.md
+++ b/book/release/09-substack-start-here-post.md
@@ -30,7 +30,7 @@ Let me show you around.
 
 ## Who I Am
 
-I'm Jae Lawless — though on the covers of my books you'll see my legal name, Jennifer Brooke Lawless, M.S. I hold a Bachelor's in Psychology and a Master's in Mental Health Counseling, and I spent years in traditional therapy—both as a practitioner and as someone trying to heal.
+I'm Jae Lawless — though in my books you'll see my legal name, Jennifer Brooke Lawless. I hold a Bachelor's in Psychology and a Master's in Mental Health Counseling, and I spent years in traditional therapy—both as a practitioner and as someone trying to heal.
 
 What I learned: insight alone doesn't heal. You can understand everything and still react the same way.
 

--- a/book/release/11-cover-specifications.md
+++ b/book/release/11-cover-specifications.md
@@ -304,7 +304,7 @@ series-mockup-all-eight.png
 
 ## Cover Text (For Designer Reference)
 
-> **Note on subtitles:** Each volume has two subtitle fields. The **Subtitle** is the descriptive / KDP-metadata subtitle (used on the spine, back-cover metadata block, and Amazon search indexing). The **Guide Subtitle** is the reader-facing marketing subtitle to be rendered on the front cover.
+> **Note on subtitles:** Each volume has two subtitle fields. The **Subtitle** is the descriptive subtitle used on the **front cover, spine, and KDP metadata** (and Amazon search indexing). The **Guide Subtitle** is reader-facing marketing language used in the **Amazon description, Gumroad hero text, and social cards** — it is NOT rendered on the cover.
 
 ### Volume 1
 

--- a/book/release/11-cover-specifications.md
+++ b/book/release/11-cover-specifications.md
@@ -310,72 +310,72 @@ series-mockup-all-eight.png
 
 **Title:** SEE
 **Subtitle:** Recognizing Narcissistic Manipulation in Relationships, Family, and Work
-**Guide Subtitle:** A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns
+**Guide Subtitle:** The Truth That Was Hidden in Plain Sight
 **Series:** The Sovereignty Series — Volume 1
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline:** "Every pattern you can name is a pattern that loses power over you."
 
 ### Volume 2
 
 **Title:** HEAL
 **Subtitle:** Nervous System Recovery and Attachment Repair After Narcissistic Abuse
-**Guide Subtitle:** A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection
+**Guide Subtitle:** The Body That Remembers the Way Home
 **Series:** The Sovereignty Series — Volume 2
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Secure attachment is not found—it is practiced."
 
 ### Volume 3
 
 **Title:** STAND
 **Subtitle:** Building Boundaries, Internal Authority, and Self-Trust After Trauma
-**Guide Subtitle:** A Guide for Those Ready to Stop Shrinking and Start Standing
+**Guide Subtitle:** The Ground That Was Always Yours
 **Series:** The Sovereignty Series — Volume 3
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "I am not small. I am learning to stand without fear."
 
 ### Volume 4
 
 **Title:** LIVE
 **Subtitle:** Reclaiming Presence, Intimacy, and Embodied Leadership
-**Guide Subtitle:** A Guide for Those Ready to Inhabit Their Full Power
+**Guide Subtitle:** The Presence That Changes Everything
 **Series:** The Sovereignty Series — Volume 4
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "My presence is erotic when it belongs to me."
 
 ### Volume 5
 
 **Title:** GIVE
 **Subtitle:** Conscious Parenting and Breaking Generational Trauma Cycles
-**Guide Subtitle:** A Guide for Those Ready to Give Their Children What They Never Received
+**Guide Subtitle:** The Chain That Ends with You
 **Series:** The Sovereignty Series — Volume 5
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "The chain breaks with you. Not because you're perfect, but because you're aware."
 
 ### Volume 6
 
 **Title:** SERVE
 **Subtitle:** Sustainable Helping Without Burnout for Trauma-Informed Guides
-**Guide Subtitle:** A Guide for Those Called to Help Others on This Path
+**Guide Subtitle:** The Light That Doesn't Consume
 **Series:** The Sovereignty Series — Volume 6
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Your healing is your credential. Your boundaries are your offering."
 
 ### Volume 7
 
 **Title:** THRIVE
 **Subtitle:** Financial Recovery, Career Rebuilding, and Prosperity After Abuse
-**Guide Subtitle:** A Guide for Those Ready to Thrive, Not Just Survive
+**Guide Subtitle:** The Life You Were Told You Couldn't Have
 **Series:** The Sovereignty Series — Volume 7
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Your prosperity is not a betrayal of your healing. It is a fruit of it."
 
 ### Volume 8
 
 **Title:** BECOME
 **Subtitle:** Integration, Identity, and Stepping Into Your Whole Self
-**Guide Subtitle:** A Guide for Those Ready to Unveil Their Infinite Self
+**Guide Subtitle:** The Self That Was Never Lost
 **Series:** The Sovereignty Series — Volume 8
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "You were never becoming someone new. You were always unveiling who you'd been all along."
 
 ---

--- a/book/release/11-cover-specifications.md
+++ b/book/release/11-cover-specifications.md
@@ -310,7 +310,7 @@ series-mockup-all-eight.png
 
 **Title:** SEE
 **Subtitle:** Recognizing Narcissistic Manipulation in Relationships, Family, and Work
-**Guide Subtitle:** The Truth That Was Hidden in Plain Sight
+**Guide Subtitle:** A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns
 **Series:** The Sovereignty Series — Volume 1
 **Author:** Jennifer Brooke Lawless
 **Tagline:** "Every pattern you can name is a pattern that loses power over you."
@@ -319,7 +319,7 @@ series-mockup-all-eight.png
 
 **Title:** HEAL
 **Subtitle:** Nervous System Recovery and Attachment Repair After Narcissistic Abuse
-**Guide Subtitle:** The Body That Remembers the Way Home
+**Guide Subtitle:** A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection
 **Series:** The Sovereignty Series — Volume 2
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Secure attachment is not found—it is practiced."
@@ -328,7 +328,7 @@ series-mockup-all-eight.png
 
 **Title:** STAND
 **Subtitle:** Building Boundaries, Internal Authority, and Self-Trust After Trauma
-**Guide Subtitle:** The Ground That Was Always Yours
+**Guide Subtitle:** A Guide for Those Ready to Stop Shrinking and Start Standing
 **Series:** The Sovereignty Series — Volume 3
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "I am not small. I am learning to stand without fear."
@@ -337,7 +337,7 @@ series-mockup-all-eight.png
 
 **Title:** LIVE
 **Subtitle:** Reclaiming Presence, Intimacy, and Embodied Leadership
-**Guide Subtitle:** The Presence That Changes Everything
+**Guide Subtitle:** A Guide for Those Ready to Inhabit Their Full Power
 **Series:** The Sovereignty Series — Volume 4
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "My presence is erotic when it belongs to me."
@@ -346,7 +346,7 @@ series-mockup-all-eight.png
 
 **Title:** GIVE
 **Subtitle:** Conscious Parenting and Breaking Generational Trauma Cycles
-**Guide Subtitle:** The Chain That Ends with You
+**Guide Subtitle:** A Guide for Those Ready to Give Their Children What They Never Received
 **Series:** The Sovereignty Series — Volume 5
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "The chain breaks with you. Not because you're perfect, but because you're aware."
@@ -355,7 +355,7 @@ series-mockup-all-eight.png
 
 **Title:** SERVE
 **Subtitle:** Sustainable Helping Without Burnout for Trauma-Informed Guides
-**Guide Subtitle:** The Light That Doesn't Consume
+**Guide Subtitle:** A Guide for Those Called to Help Others on This Path
 **Series:** The Sovereignty Series — Volume 6
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Your healing is your credential. Your boundaries are your offering."
@@ -364,7 +364,7 @@ series-mockup-all-eight.png
 
 **Title:** THRIVE
 **Subtitle:** Financial Recovery, Career Rebuilding, and Prosperity After Abuse
-**Guide Subtitle:** The Life You Were Told You Couldn't Have
+**Guide Subtitle:** A Guide for Those Ready to Thrive, Not Just Survive
 **Series:** The Sovereignty Series — Volume 7
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Your prosperity is not a betrayal of your healing. It is a fruit of it."
@@ -373,7 +373,7 @@ series-mockup-all-eight.png
 
 **Title:** BECOME
 **Subtitle:** Integration, Identity, and Stepping Into Your Whole Self
-**Guide Subtitle:** The Self That Was Never Lost
+**Guide Subtitle:** A Guide for Those Ready to Unveil Their Infinite Self
 **Series:** The Sovereignty Series — Volume 8
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "You were never becoming someone new. You were always unveiling who you'd been all along."

--- a/book/release/14-designer-naming-spec.md
+++ b/book/release/14-designer-naming-spec.md
@@ -32,7 +32,7 @@ Each cover follows this exact text hierarchy:
 
 **Title:** SEE
 **Subtitle:** *Recognizing Narcissistic Manipulation in Relationships, Family, and Work*
-**Guide Subtitle:** *The Truth That Was Hidden in Plain Sight*
+**Guide Subtitle:** *A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns*
 **Series Line:** The Sovereignty Series — Volume 1
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Every pattern you can name is a pattern that loses power over you."
@@ -44,7 +44,7 @@ Each cover follows this exact text hierarchy:
 
 **Title:** HEAL
 **Subtitle:** *Nervous System Recovery and Attachment Repair After Narcissistic Abuse*
-**Guide Subtitle:** *The Body That Remembers the Way Home*
+**Guide Subtitle:** *A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection*
 **Series Line:** The Sovereignty Series — Volume 2
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Secure attachment is not found—it is practiced."
@@ -56,7 +56,7 @@ Each cover follows this exact text hierarchy:
 
 **Title:** STAND
 **Subtitle:** *Building Boundaries, Internal Authority, and Self-Trust After Trauma*
-**Guide Subtitle:** *The Ground That Was Always Yours*
+**Guide Subtitle:** *A Guide for Those Ready to Stop Shrinking and Start Standing*
 **Series Line:** The Sovereignty Series — Volume 3
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "I am not small. I am learning to stand without fear."
@@ -68,7 +68,7 @@ Each cover follows this exact text hierarchy:
 
 **Title:** LIVE
 **Subtitle:** *Reclaiming Presence, Intimacy, and Embodied Leadership*
-**Guide Subtitle:** *The Presence That Changes Everything*
+**Guide Subtitle:** *A Guide for Those Ready to Inhabit Their Full Power*
 **Series Line:** The Sovereignty Series — Volume 4
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "My presence is erotic when it belongs to me."
@@ -80,7 +80,7 @@ Each cover follows this exact text hierarchy:
 
 **Title:** GIVE
 **Subtitle:** *Conscious Parenting and Breaking Generational Trauma Cycles*
-**Guide Subtitle:** *The Chain That Ends with You*
+**Guide Subtitle:** *A Guide for Those Ready to Give Their Children What They Never Received*
 **Series Line:** The Sovereignty Series — Volume 5
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "The chain breaks with you. Not because you're perfect, but because you're aware."
@@ -92,7 +92,7 @@ Each cover follows this exact text hierarchy:
 
 **Title:** SERVE
 **Subtitle:** *Sustainable Helping Without Burnout for Trauma-Informed Guides*
-**Guide Subtitle:** *The Light That Doesn't Consume*
+**Guide Subtitle:** *A Guide for Those Called to Help Others on This Path*
 **Series Line:** The Sovereignty Series — Volume 6
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Your healing is your credential. Your boundaries are your offering."
@@ -104,7 +104,7 @@ Each cover follows this exact text hierarchy:
 
 **Title:** THRIVE
 **Subtitle:** *Financial Recovery, Career Rebuilding, and Prosperity After Abuse*
-**Guide Subtitle:** *The Life You Were Told You Couldn't Have*
+**Guide Subtitle:** *A Guide for Those Ready to Thrive, Not Just Survive*
 **Series Line:** The Sovereignty Series — Volume 7
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Your prosperity is not a betrayal of your healing. It is a fruit of it."
@@ -116,7 +116,7 @@ Each cover follows this exact text hierarchy:
 
 **Title:** BECOME
 **Subtitle:** *Integration, Identity, and Stepping Into Your Whole Self*
-**Guide Subtitle:** *The Self That Was Never Lost*
+**Guide Subtitle:** *A Guide for Those Ready to Unveil Their Infinite Self*
 **Series Line:** The Sovereignty Series — Volume 8
 **Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "You were never becoming someone new. You were always unveiling who you'd been all along."

--- a/book/release/14-designer-naming-spec.md
+++ b/book/release/14-designer-naming-spec.md
@@ -17,7 +17,7 @@ Each cover follows this exact text hierarchy:
 │    in Plain Sight                       │
 │                                         │
 │                                         │
-│    Jennifer Brooke Lawless, M.S.        │  ← Author (smallest)
+│    Jennifer Brooke Lawless              │  ← Author (smallest)
 │                                         │
 └─────────────────────────────────────────┘
 ```
@@ -32,9 +32,9 @@ Each cover follows this exact text hierarchy:
 
 **Title:** SEE
 **Subtitle:** *Recognizing Narcissistic Manipulation in Relationships, Family, and Work*
-**Guide Subtitle:** *A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns*
+**Guide Subtitle:** *The Truth That Was Hidden in Plain Sight*
 **Series Line:** The Sovereignty Series — Volume 1
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Every pattern you can name is a pattern that loses power over you."
 **Core Insight:** "This wasn't love—this was conditioning."
 
@@ -44,9 +44,9 @@ Each cover follows this exact text hierarchy:
 
 **Title:** HEAL
 **Subtitle:** *Nervous System Recovery and Attachment Repair After Narcissistic Abuse*
-**Guide Subtitle:** *A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection*
+**Guide Subtitle:** *The Body That Remembers the Way Home*
 **Series Line:** The Sovereignty Series — Volume 2
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Secure attachment is not found—it is practiced."
 **Core Insight:** "Leaving hurts because your body learned danger as connection."
 
@@ -56,9 +56,9 @@ Each cover follows this exact text hierarchy:
 
 **Title:** STAND
 **Subtitle:** *Building Boundaries, Internal Authority, and Self-Trust After Trauma*
-**Guide Subtitle:** *A Guide for Those Ready to Stop Shrinking and Start Standing*
+**Guide Subtitle:** *The Ground That Was Always Yours*
 **Series Line:** The Sovereignty Series — Volume 3
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "I am not small. I am learning to stand without fear."
 **Core Insight:** "You are safe to choose without urgency."
 
@@ -68,9 +68,9 @@ Each cover follows this exact text hierarchy:
 
 **Title:** LIVE
 **Subtitle:** *Reclaiming Presence, Intimacy, and Embodied Leadership*
-**Guide Subtitle:** *A Guide for Those Ready to Inhabit Their Full Power*
+**Guide Subtitle:** *The Presence That Changes Everything*
 **Series Line:** The Sovereignty Series — Volume 4
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "My presence is erotic when it belongs to me."
 **Core Insight:** "Your presence is yours when it belongs to you."
 
@@ -80,9 +80,9 @@ Each cover follows this exact text hierarchy:
 
 **Title:** GIVE
 **Subtitle:** *Conscious Parenting and Breaking Generational Trauma Cycles*
-**Guide Subtitle:** *A Guide for Those Ready to Give Their Children What They Never Received*
+**Guide Subtitle:** *The Chain That Ends with You*
 **Series Line:** The Sovereignty Series — Volume 5
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "The chain breaks with you. Not because you're perfect, but because you're aware."
 **Core Insight:** "You don't have to be healed to be a good parent. You have to be healing."
 
@@ -92,9 +92,9 @@ Each cover follows this exact text hierarchy:
 
 **Title:** SERVE
 **Subtitle:** *Sustainable Helping Without Burnout for Trauma-Informed Guides*
-**Guide Subtitle:** *A Guide for Those Called to Help Others on This Path*
+**Guide Subtitle:** *The Light That Doesn't Consume*
 **Series Line:** The Sovereignty Series — Volume 6
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Your healing is your credential. Your boundaries are your offering."
 **Core Insight:** "You cannot give what you don't have. Your healing is your offering."
 
@@ -104,9 +104,9 @@ Each cover follows this exact text hierarchy:
 
 **Title:** THRIVE
 **Subtitle:** *Financial Recovery, Career Rebuilding, and Prosperity After Abuse*
-**Guide Subtitle:** *A Guide for Those Ready to Thrive, Not Just Survive*
+**Guide Subtitle:** *The Life You Were Told You Couldn't Have*
 **Series Line:** The Sovereignty Series — Volume 7
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "Your prosperity is not a betrayal of your healing. It is a fruit of it."
 **Core Insight:** "You are allowed to thrive, not just survive."
 
@@ -116,9 +116,9 @@ Each cover follows this exact text hierarchy:
 
 **Title:** BECOME
 **Subtitle:** *Integration, Identity, and Stepping Into Your Whole Self*
-**Guide Subtitle:** *A Guide for Those Ready to Unveil Their Infinite Self*
+**Guide Subtitle:** *The Self That Was Never Lost*
 **Series Line:** The Sovereignty Series — Volume 8
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author:** Jennifer Brooke Lawless
 **Tagline (back cover):** "You were never becoming someone new. You were always unveiling who you'd been all along."
 **Core Insight:** "You were never becoming—you were always unveiling."
 
@@ -184,7 +184,7 @@ From **external recognition** (truth) through **somatic healing** (body) to **re
 ### Spine Text (Paperback)
 
 ```
-SEE  |  Recognizing Narcissistic Manipulation in Relationships, Family, and Work  |  Jennifer Brooke Lawless, M.S.
+SEE  |  Recognizing Narcissistic Manipulation in Relationships, Family, and Work  |  Jennifer Brooke Lawless
 ```
 
 When all 8 spines are lined up, the titles read:
@@ -235,7 +235,7 @@ The workbook designation should be:
 ### Workbook Spine Text
 
 ```
-SEE  |  Companion Workbook  |  Jennifer Brooke Lawless, M.S.
+SEE  |  Companion Workbook  |  Jennifer Brooke Lawless
 ```
 
 ---

--- a/book/release/14-designer-naming-spec.md
+++ b/book/release/14-designer-naming-spec.md
@@ -13,8 +13,9 @@ Each cover follows this exact text hierarchy:
 │                                         │
 │    SEE                                  │  ← TITLE (largest, single word)
 │                                         │
-│    The Truth That Was Hidden            │  ← Subtitle (medium)
-│    in Plain Sight                       │
+│    Recognizing Narcissistic             │  ← Subtitle (medium)
+│    Manipulation in Relationships,       │
+│    Family, and Work                     │
 │                                         │
 │                                         │
 │    Jennifer Brooke Lawless              │  ← Author (smallest)
@@ -26,7 +27,7 @@ Each cover follows this exact text hierarchy:
 
 ## Complete Volume Naming
 
-> **Note on subtitles:** Each volume has two subtitle fields. The **Subtitle** is the descriptive / KDP-metadata subtitle (used on the spine and back-cover metadata block). The **Guide Subtitle** is the reader-facing marketing subtitle to be rendered on the front cover.
+> **Note on subtitles:** Each volume has two subtitle fields. The **Subtitle** is the descriptive subtitle used on the **front cover, spine, and KDP metadata**. The **Guide Subtitle** is reader-facing marketing language used in the **Amazon description, Gumroad hero text, and social cards** — it is NOT rendered on the cover.
 
 ### Volume 1: See
 

--- a/book/release/15-designer-brief.md
+++ b/book/release/15-designer-brief.md
@@ -2,13 +2,11 @@
 
 ## Complete Cover Design Package for All 8 Volumes
 
-**Author (cover):** Jennifer Brooke Lawless
+**Author:** Jennifer Brooke Lawless, M.S.
 **Series:** The Sovereignty Series
 **Volumes:** 8
 **Trim Size:** 6" x 9"
 **Paper Type:** White (black ink interior)
-
-> Credentials (M.S.) appear only in the back-cover author bio and other descriptions — not on the front cover or spine.
 
 ---
 

--- a/book/release/15-designer-brief.md
+++ b/book/release/15-designer-brief.md
@@ -89,7 +89,7 @@ Each front cover follows this exact structure:
 │    in Plain Sight                       │
 │                                         │
 │                                         │
-│    Jennifer Brooke Lawless, M.S.        │  ← Author (smallest, legible)
+│    Jennifer Brooke Lawless              │  ← Author (smallest, legible)
 │                                         │
 └─────────────────────────────────────────┘
 ```
@@ -100,16 +100,16 @@ Each front cover follows this exact structure:
 
 | Vol | Title | Subtitle (Spine / Metadata) | Guide Subtitle (Front Cover) |
 |:---:|:-----:|-----------------------------|-------------------------------|
-| 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns* |
-| 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection* |
-| 3 | **STAND** | *Building Boundaries, Internal Authority, and Self-Trust After Trauma* | *A Guide for Those Ready to Stop Shrinking and Start Standing* |
-| 4 | **LIVE** | *Reclaiming Presence, Intimacy, and Embodied Leadership* | *A Guide for Those Ready to Inhabit Their Full Power* |
-| 5 | **GIVE** | *Conscious Parenting and Breaking Generational Trauma Cycles* | *A Guide for Those Ready to Give Their Children What They Never Received* |
-| 6 | **SERVE** | *Sustainable Helping Without Burnout for Trauma-Informed Guides* | *A Guide for Those Called to Help Others on This Path* |
-| 7 | **THRIVE** | *Financial Recovery, Career Rebuilding, and Prosperity After Abuse* | *A Guide for Those Ready to Thrive, Not Just Survive* |
-| 8 | **BECOME** | *Integration, Identity, and Stepping Into Your Whole Self* | *A Guide for Those Ready to Unveil Their Infinite Self* |
+| 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *The Truth That Was Hidden in Plain Sight* |
+| 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *The Body That Remembers the Way Home* |
+| 3 | **STAND** | *Building Boundaries, Internal Authority, and Self-Trust After Trauma* | *The Ground That Was Always Yours* |
+| 4 | **LIVE** | *Reclaiming Presence, Intimacy, and Embodied Leadership* | *The Presence That Changes Everything* |
+| 5 | **GIVE** | *Conscious Parenting and Breaking Generational Trauma Cycles* | *The Chain That Ends with You* |
+| 6 | **SERVE** | *Sustainable Helping Without Burnout for Trauma-Informed Guides* | *The Light That Doesn't Consume* |
+| 7 | **THRIVE** | *Financial Recovery, Career Rebuilding, and Prosperity After Abuse* | *The Life You Were Told You Couldn't Have* |
+| 8 | **BECOME** | *Integration, Identity, and Stepping Into Your Whole Self* | *The Self That Was Never Lost* |
 
-**Author on all volumes:** Jennifer Brooke Lawless, M.S.
+**Author on all covers:** Jennifer Brooke Lawless
 
 ### The Two Through-Lines (Designer Should Know)
 
@@ -132,7 +132,7 @@ Each front cover follows this exact structure:
 Standard spine format for each volume:
 
 ```
-SEE  |  Recognizing Narcissistic Manipulation in Relationships, Family, and Work  |  Jennifer Brooke Lawless, M.S.
+SEE  |  Recognizing Narcissistic Manipulation in Relationships, Family, and Work  |  Jennifer Brooke Lawless
 ```
 
 When all 8 spines are shelved together, the titles read:
@@ -290,7 +290,7 @@ Amazon KDP gives the designer full control over the back cover as part of the fu
 
 ### Back Cover Author Bio (Short — for all volumes)
 
-> **Jennifer Brooke Lawless, M.S.** holds degrees in Psychology and Mental Health Counseling. Her clinical work ranged from psychiatric units to family therapy and couples counseling. After surviving narcissistic relationships and discovering that insight alone doesn't heal, she wrote the book she needed but couldn't find. She lives in Costa Rica.
+> **Jennifer Brooke Lawless, M.S.** holds degrees in Psychology and Mental Health Counseling. Her clinical work ranged from psychiatric units to family therapy and couples counseling. After surviving narcissistic relationships and discovering that insight alone doesn't heal, she wrote the book she needed but couldn't find.
 
 ### Back Cover Connect Info
 
@@ -503,7 +503,7 @@ Each volume has an accompanying **companion workbook**. The workbook covers shou
 - **Identical design to the main volume cover** — same background color, same title treatment, same layout structure
 - **Add a "Companion Workbook" designation** — placed below the subtitle or in the series line area, clearly visible but secondary to the title
 - **Same white title and subtitle text** as the main covers
-- **Same author name:** Jennifer Brooke Lawless, M.S.
+- **Same author name:** Jennifer Brooke Lawless
 
 ### Suggested Workbook Designation Treatment
 
@@ -522,7 +522,7 @@ Each volume has an accompanying **companion workbook**. The workbook covers shou
 │    ── Companion Workbook ──             │  ← Workbook designation (white, small,
 │                                         │     with decorative rules or lighter weight)
 │                                         │
-│    Jennifer Brooke Lawless, M.S.        │  ← Author
+│    Jennifer Brooke Lawless              │  ← Author
 │                                         │
 └─────────────────────────────────────────┘
 ```

--- a/book/release/15-designer-brief.md
+++ b/book/release/15-designer-brief.md
@@ -2,11 +2,13 @@
 
 ## Complete Cover Design Package for All 8 Volumes
 
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author (cover):** Jennifer Brooke Lawless
 **Series:** The Sovereignty Series
 **Volumes:** 8
 **Trim Size:** 6" x 9"
 **Paper Type:** White (black ink interior)
+
+> Credentials (M.S.) appear only in the back-cover author bio and other descriptions — not on the front cover or spine.
 
 ---
 

--- a/book/release/15-designer-brief.md
+++ b/book/release/15-designer-brief.md
@@ -85,8 +85,9 @@ Each front cover follows this exact structure:
 │                                         │
 │    SEE                                  │  ← TITLE (largest, single word, ALL CAPS, WHITE)
 │                                         │
-│    The Truth That Was Hidden            │  ← Subtitle (medium, mixed case, OFF-WHITE)
-│    in Plain Sight                       │
+│    Recognizing Narcissistic             │  ← Subtitle (medium, mixed case, OFF-WHITE)
+│    Manipulation in Relationships,       │
+│    Family, and Work                     │
 │                                         │
 │                                         │
 │    Jennifer Brooke Lawless              │  ← Author (smallest, legible)
@@ -96,9 +97,9 @@ Each front cover follows this exact structure:
 
 ### Volume Text Reference
 
-> **Note:** The **Subtitle** is the descriptive / KDP-metadata subtitle (used on the spine and back-cover metadata block). The **Guide Subtitle** is the reader-facing marketing subtitle to be rendered on the front cover.
+> **Note:** The **Subtitle** is the descriptive subtitle used on the **front cover, spine, and KDP metadata**. The **Guide Subtitle** is reader-facing marketing language used in the **Amazon description, Gumroad hero text, and social cards** — it is NOT rendered on the cover.
 
-| Vol | Title | Subtitle (Spine / Metadata) | Guide Subtitle (Front Cover) |
+| Vol | Title | Subtitle (Cover / Spine / Metadata) | Guide Subtitle (Amazon / Gumroad / Social) |
 |:---:|:-----:|-----------------------------|-------------------------------|
 | 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns* |
 | 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection* |
@@ -516,8 +517,9 @@ Each volume has an accompanying **companion workbook**. The workbook covers shou
 │                                         │
 │    SEE                                  │  ← TITLE (same as main cover)
 │                                         │
-│    The Truth That Was Hidden            │  ← Subtitle (same as main cover)
-│    in Plain Sight                       │
+│    Recognizing Narcissistic             │  ← Subtitle (same as main cover)
+│    Manipulation in Relationships,       │
+│    Family, and Work                     │
 │                                         │
 │    ── Companion Workbook ──             │  ← Workbook designation (white, small,
 │                                         │     with decorative rules or lighter weight)

--- a/book/release/15-designer-brief.md
+++ b/book/release/15-designer-brief.md
@@ -100,16 +100,16 @@ Each front cover follows this exact structure:
 
 | Vol | Title | Subtitle (Spine / Metadata) | Guide Subtitle (Front Cover) |
 |:---:|:-----:|-----------------------------|-------------------------------|
-| 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *The Truth That Was Hidden in Plain Sight* |
-| 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *The Body That Remembers the Way Home* |
-| 3 | **STAND** | *Building Boundaries, Internal Authority, and Self-Trust After Trauma* | *The Ground That Was Always Yours* |
-| 4 | **LIVE** | *Reclaiming Presence, Intimacy, and Embodied Leadership* | *The Presence That Changes Everything* |
-| 5 | **GIVE** | *Conscious Parenting and Breaking Generational Trauma Cycles* | *The Chain That Ends with You* |
-| 6 | **SERVE** | *Sustainable Helping Without Burnout for Trauma-Informed Guides* | *The Light That Doesn't Consume* |
-| 7 | **THRIVE** | *Financial Recovery, Career Rebuilding, and Prosperity After Abuse* | *The Life You Were Told You Couldn't Have* |
-| 8 | **BECOME** | *Integration, Identity, and Stepping Into Your Whole Self* | *The Self That Was Never Lost* |
+| 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns* |
+| 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection* |
+| 3 | **STAND** | *Building Boundaries, Internal Authority, and Self-Trust After Trauma* | *A Guide for Those Ready to Stop Shrinking and Start Standing* |
+| 4 | **LIVE** | *Reclaiming Presence, Intimacy, and Embodied Leadership* | *A Guide for Those Ready to Inhabit Their Full Power* |
+| 5 | **GIVE** | *Conscious Parenting and Breaking Generational Trauma Cycles* | *A Guide for Those Ready to Give Their Children What They Never Received* |
+| 6 | **SERVE** | *Sustainable Helping Without Burnout for Trauma-Informed Guides* | *A Guide for Those Called to Help Others on This Path* |
+| 7 | **THRIVE** | *Financial Recovery, Career Rebuilding, and Prosperity After Abuse* | *A Guide for Those Ready to Thrive, Not Just Survive* |
+| 8 | **BECOME** | *Integration, Identity, and Stepping Into Your Whole Self* | *A Guide for Those Ready to Unveil Their Infinite Self* |
 
-**Author on all covers:** Jennifer Brooke Lawless
+**Author on all volumes:** Jennifer Brooke Lawless
 
 ### The Two Through-Lines (Designer Should Know)
 

--- a/book/release/18-book-cover-design-guide.md
+++ b/book/release/18-book-cover-design-guide.md
@@ -4,11 +4,9 @@
 
 This guide captures the design philosophy and specific creative decisions for the 8-volume Sovereignty Series covers. It translates market research (see `bestseller-book-art-research.md`) into actionable direction and sits alongside the Designer Brief (`15-designer-brief.md`) as the "why" behind the "what."
 
-**Author (cover):** Jennifer Brooke Lawless
+**Author:** Jennifer Brooke Lawless, M.S.
 **Series:** The Sovereignty Series — 8 Volumes
 **Genre:** Self-help / Personal Transformation / Narcissistic Abuse Recovery
-
-> Credentials (M.S.) appear only in the back-cover author bio and other descriptions — not on the front cover or spine.
 
 ---
 

--- a/book/release/18-book-cover-design-guide.md
+++ b/book/release/18-book-cover-design-guide.md
@@ -72,7 +72,7 @@ Typography is no longer a separate layer — it IS the main visual. The single-w
 │    in Plain Sight                       │     Mixed case, italic or light
 │                                         │
 │                                         │
-│    Jennifer Brooke Lawless, M.S.        │  ← Author (small, legible, off-white)
+│    Jennifer Brooke Lawless              │  ← Author (small, legible, off-white)
 │                                         │
 └─────────────────────────────────────────┘
 ```

--- a/book/release/18-book-cover-design-guide.md
+++ b/book/release/18-book-cover-design-guide.md
@@ -68,8 +68,9 @@ Typography is no longer a separate layer — it IS the main visual. The single-w
 │                                         │
 │    ──────────────────────               │  ← Subtle gold accent rule (optional)
 │                                         │
-│    The Truth That Was Hidden            │  ← Subtitle — OFF-WHITE, medium weight
-│    in Plain Sight                       │     Mixed case, italic or light
+│    Recognizing Narcissistic             │  ← Subtitle — OFF-WHITE, medium weight
+│    Manipulation in Relationships,       │     Mixed case, italic or light
+│    Family, and Work                     │
 │                                         │
 │                                         │
 │    Jennifer Brooke Lawless              │  ← Author (small, legible, off-white)

--- a/book/release/18-book-cover-design-guide.md
+++ b/book/release/18-book-cover-design-guide.md
@@ -4,9 +4,11 @@
 
 This guide captures the design philosophy and specific creative decisions for the 8-volume Sovereignty Series covers. It translates market research (see `bestseller-book-art-research.md`) into actionable direction and sits alongside the Designer Brief (`15-designer-brief.md`) as the "why" behind the "what."
 
-**Author:** Jennifer Brooke Lawless, M.S.
+**Author (cover):** Jennifer Brooke Lawless
 **Series:** The Sovereignty Series — 8 Volumes
 **Genre:** Self-help / Personal Transformation / Narcissistic Abuse Recovery
+
+> Credentials (M.S.) appear only in the back-cover author bio and other descriptions — not on the front cover or spine.
 
 ---
 

--- a/book/release/19-instagram-marketing-strategy.md
+++ b/book/release/19-instagram-marketing-strategy.md
@@ -18,7 +18,7 @@
 - The series account builds the audience with shareable content; the personal account builds trust and deeper connection through the Jae Lawless voice
 - Each drives followers to the other
 
-**Brand note:** **Jae Lawless is the voice behind Auracle** — the platform for sessions, courses, and the book series. The trust-layer author name (Jennifer Brooke Lawless, M.S.) lives on book covers and in back-matter bios; Jae is the front-facing name everywhere else. The Sovereignty Series remains its own book brand under @sovereigntyseries. Domain: **jaelawless.com**. See `docs/personal-brand-strategy.md` for the full architecture.
+**Brand note:** **Jae Lawless is the voice behind Auracle** — the platform for sessions, courses, and the book series. The trust-layer author name (Jennifer Brooke Lawless, M.S.) lives in back-matter bios and descriptions; Jae is the front-facing name everywhere else. The Sovereignty Series remains its own book brand under @sovereigntyseries. Domain: **jaelawless.com**. See `docs/personal-brand-strategy.md` for the full architecture.
 
 ---
 

--- a/book/release/github-issue-book-covers.md
+++ b/book/release/github-issue-book-covers.md
@@ -49,9 +49,9 @@ Each front cover follows this exact structure:
 
 ### All 8 Volumes — Titles and Subtitles
 
-> **Note:** The **Subtitle** is the descriptive / KDP-metadata subtitle (used on the spine and back-cover metadata block). The **Guide Subtitle** is the reader-facing marketing subtitle to be rendered on the front cover.
+> **Note:** The **Subtitle** is the descriptive subtitle used on the **front cover, spine, and KDP metadata**. The **Guide Subtitle** is reader-facing marketing language used in the **Amazon description, Gumroad hero text, and social cards** — it is NOT rendered on the cover.
 
-| Vol | Title | Subtitle (Spine / Metadata) | Guide Subtitle (Front Cover) |
+| Vol | Title | Subtitle (Cover / Spine / Metadata) | Guide Subtitle (Amazon / Gumroad / Social) |
 |:---:|:-----:|-----------------------------|-------------------------------|
 | 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns* |
 | 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection* |

--- a/book/release/github-issue-book-covers.md
+++ b/book/release/github-issue-book-covers.md
@@ -64,20 +64,6 @@ Each front cover follows this exact structure:
 
 **Author on all volumes:** Jennifer Brooke Lawless
 
-### The Two Through-Lines
-
-**The Titles form a mantra:** SEE → HEAL → STAND → LIVE → GIVE → SERVE → THRIVE → BECOME
-
-**The Subtitles form a poem when read together:**
-> *The truth that was hidden in plain sight...*
-> *The body that remembers the way home...*
-> *The ground that was always yours...*
-> *The presence that changes everything...*
-> *The chain that ends with you...*
-> *The light that doesn't consume...*
-> *The life you were told you couldn't have...*
-> *The self that was never lost.*
-
 ---
 
 ## Cover Layout Details

--- a/book/release/github-issue-book-covers.md
+++ b/book/release/github-issue-book-covers.md
@@ -4,21 +4,12 @@
 
 Design a cohesive cover system for **The Sovereignty Series** — an 8-volume nonfiction series about healing from narcissistic abuse and building personal sovereignty, plus **8 companion workbooks** (one per volume).
 
-- **Author:** Jennifer Brooke Lawless, M.S.
+- **Author (cover):** Jennifer Brooke Lawless
 - **Trim Size:** 6" x 9"
 - **Paper Type:** White (black ink interior)
 - **Volumes:** 8 main + 8 companion workbooks = **16 covers total**
 
----
-
-## What's Been Updated
-
-> Hi Andreas, I like the subtle images and the classy seriousness of it. I want it to cohesively go together on a shelf which I think this achieves.
-
-1. **Subtitles revised** — more grounded and specific (see volume text reference below)
-2. **Author credentials corrected** — M.S. and degrees reflected accurately
-3. **Companion workbook covers added** — 8 workbook covers matching their parent volumes
-4. **Font size consistency** — all 8 titles must be the same size across every cover, regardless of character count
+> Credentials (M.S.) appear only in the back-cover author bio and other descriptions — not on the front cover or spine.
 
 ---
 

--- a/book/release/github-issue-book-covers.md
+++ b/book/release/github-issue-book-covers.md
@@ -4,12 +4,10 @@
 
 Design a cohesive cover system for **The Sovereignty Series** — an 8-volume nonfiction series about healing from narcissistic abuse and building personal sovereignty, plus **8 companion workbooks** (one per volume).
 
-- **Author (cover):** Jennifer Brooke Lawless
+- **Author:** Jennifer Brooke Lawless, M.S.
 - **Trim Size:** 6" x 9"
 - **Paper Type:** White (black ink interior)
 - **Volumes:** 8 main + 8 companion workbooks = **16 covers total**
-
-> Credentials (M.S.) appear only in the back-cover author bio and other descriptions — not on the front cover or spine.
 
 ---
 

--- a/book/release/github-issue-book-covers.md
+++ b/book/release/github-issue-book-covers.md
@@ -37,8 +37,9 @@ Each front cover follows this exact structure:
 │                                         │
 │    SEE                                  │  ← TITLE (largest, single word, ALL CAPS, WHITE)
 │                                         │
-│    The Truth That Was Hidden            │  ← Subtitle (medium, mixed case, OFF-WHITE)
-│    in Plain Sight                       │
+│    Recognizing Narcissistic             │  ← Subtitle (medium, mixed case, OFF-WHITE)
+│    Manipulation in Relationships,       │
+│    Family, and Work                     │
 │                                         │
 │                                         │
 │    Jennifer Brooke Lawless              │  ← Author (smallest, legible)
@@ -52,16 +53,16 @@ Each front cover follows this exact structure:
 
 | Vol | Title | Subtitle (Spine / Metadata) | Guide Subtitle (Front Cover) |
 |:---:|:-----:|-----------------------------|-------------------------------|
-| 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *The Truth That Was Hidden in Plain Sight* |
-| 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *The Body That Remembers the Way Home* |
-| 3 | **STAND** | *Building Boundaries, Internal Authority, and Self-Trust After Trauma* | *The Ground That Was Always Yours* |
-| 4 | **LIVE** | *Reclaiming Presence, Intimacy, and Embodied Leadership* | *The Presence That Changes Everything* |
-| 5 | **GIVE** | *Conscious Parenting and Breaking Generational Trauma Cycles* | *The Chain That Ends with You* |
-| 6 | **SERVE** | *Sustainable Helping Without Burnout for Trauma-Informed Guides* | *The Light That Doesn't Consume* |
-| 7 | **THRIVE** | *Financial Recovery, Career Rebuilding, and Prosperity After Abuse* | *The Life You Were Told You Couldn't Have* |
-| 8 | **BECOME** | *Integration, Identity, and Stepping Into Your Whole Self* | *The Self That Was Never Lost* |
+| 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns* |
+| 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection* |
+| 3 | **STAND** | *Building Boundaries, Internal Authority, and Self-Trust After Trauma* | *A Guide for Those Ready to Stop Shrinking and Start Standing* |
+| 4 | **LIVE** | *Reclaiming Presence, Intimacy, and Embodied Leadership* | *A Guide for Those Ready to Inhabit Their Full Power* |
+| 5 | **GIVE** | *Conscious Parenting and Breaking Generational Trauma Cycles* | *A Guide for Those Ready to Give Their Children What They Never Received* |
+| 6 | **SERVE** | *Sustainable Helping Without Burnout for Trauma-Informed Guides* | *A Guide for Those Called to Help Others on This Path* |
+| 7 | **THRIVE** | *Financial Recovery, Career Rebuilding, and Prosperity After Abuse* | *A Guide for Those Ready to Thrive, Not Just Survive* |
+| 8 | **BECOME** | *Integration, Identity, and Stepping Into Your Whole Self* | *A Guide for Those Ready to Unveil Their Infinite Self* |
 
-**Author on all covers:** Jennifer Brooke Lawless
+**Author on all volumes:** Jennifer Brooke Lawless
 
 ### The Two Through-Lines
 
@@ -247,8 +248,9 @@ Each volume has a **companion workbook**. The workbook covers should look like t
 │                                         │
 │    SEE                                  │  ← TITLE (same as main cover)
 │                                         │
-│    The Truth That Was Hidden            │  ← Subtitle (same as main cover)
-│    in Plain Sight                       │
+│    Recognizing Narcissistic             │  ← Subtitle (same as main cover)
+│    Manipulation in Relationships,       │
+│    Family, and Work                     │
 │                                         │
 │    ── Companion Workbook ──             │  ← Workbook designation (white, small,
 │                                         │     with decorative rules or lighter weight)

--- a/book/release/github-issue-book-covers.md
+++ b/book/release/github-issue-book-covers.md
@@ -37,12 +37,11 @@ Each front cover follows this exact structure:
 │                                         │
 │    SEE                                  │  ← TITLE (largest, single word, ALL CAPS, WHITE)
 │                                         │
-│    Recognizing Narcissistic             │  ← Subtitle (medium, mixed case, OFF-WHITE)
-│    Manipulation in Relationships,       │
-│    Family, and Work                     │
+│    The Truth That Was Hidden            │  ← Subtitle (medium, mixed case, OFF-WHITE)
+│    in Plain Sight                       │
 │                                         │
 │                                         │
-│    Jennifer Brooke Lawless, M.S.        │  ← Author (smallest, legible)
+│    Jennifer Brooke Lawless              │  ← Author (smallest, legible)
 │                                         │
 └─────────────────────────────────────────┘
 ```
@@ -53,16 +52,16 @@ Each front cover follows this exact structure:
 
 | Vol | Title | Subtitle (Spine / Metadata) | Guide Subtitle (Front Cover) |
 |:---:|:-----:|-----------------------------|-------------------------------|
-| 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *A Guide to Recognizing, Understanding, and Breaking Free from Manipulation Patterns* |
-| 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *A Guide for Emotionally Sensitive Adults Moving from Survival to Sovereign Connection* |
-| 3 | **STAND** | *Building Boundaries, Internal Authority, and Self-Trust After Trauma* | *A Guide for Those Ready to Stop Shrinking and Start Standing* |
-| 4 | **LIVE** | *Reclaiming Presence, Intimacy, and Embodied Leadership* | *A Guide for Those Ready to Inhabit Their Full Power* |
-| 5 | **GIVE** | *Conscious Parenting and Breaking Generational Trauma Cycles* | *A Guide for Those Ready to Give Their Children What They Never Received* |
-| 6 | **SERVE** | *Sustainable Helping Without Burnout for Trauma-Informed Guides* | *A Guide for Those Called to Help Others on This Path* |
-| 7 | **THRIVE** | *Financial Recovery, Career Rebuilding, and Prosperity After Abuse* | *A Guide for Those Ready to Thrive, Not Just Survive* |
-| 8 | **BECOME** | *Integration, Identity, and Stepping Into Your Whole Self* | *A Guide for Those Ready to Unveil Their Infinite Self* |
+| 1 | **SEE** | *Recognizing Narcissistic Manipulation in Relationships, Family, and Work* | *The Truth That Was Hidden in Plain Sight* |
+| 2 | **HEAL** | *Nervous System Recovery and Attachment Repair After Narcissistic Abuse* | *The Body That Remembers the Way Home* |
+| 3 | **STAND** | *Building Boundaries, Internal Authority, and Self-Trust After Trauma* | *The Ground That Was Always Yours* |
+| 4 | **LIVE** | *Reclaiming Presence, Intimacy, and Embodied Leadership* | *The Presence That Changes Everything* |
+| 5 | **GIVE** | *Conscious Parenting and Breaking Generational Trauma Cycles* | *The Chain That Ends with You* |
+| 6 | **SERVE** | *Sustainable Helping Without Burnout for Trauma-Informed Guides* | *The Light That Doesn't Consume* |
+| 7 | **THRIVE** | *Financial Recovery, Career Rebuilding, and Prosperity After Abuse* | *The Life You Were Told You Couldn't Have* |
+| 8 | **BECOME** | *Integration, Identity, and Stepping Into Your Whole Self* | *The Self That Was Never Lost* |
 
-**Author on all volumes:** Jennifer Brooke Lawless, M.S.
+**Author on all covers:** Jennifer Brooke Lawless
 
 ### The Two Through-Lines
 
@@ -87,7 +86,7 @@ Each front cover follows this exact structure:
 Standard spine format for each volume:
 
 ```
-SEE  |  Recognizing Narcissistic Manipulation in Relationships, Family, and Work  |  Jennifer Brooke Lawless, M.S.
+SEE  |  Recognizing Narcissistic Manipulation in Relationships, Family, and Work  |  Jennifer Brooke Lawless
 ```
 
 When all 8 spines are shelved together, the titles read:
@@ -224,7 +223,7 @@ SEE | HEAL | STAND | LIVE | GIVE | SERVE | THRIVE | BECOME
 
 ## Back Cover Author Bio (All Volumes)
 
-> **Jennifer Brooke Lawless, M.S.** holds degrees in Psychology and Mental Health Counseling. Her clinical work ranged from psychiatric units to family therapy and couples counseling. After surviving narcissistic relationships and discovering that insight alone doesn't heal, she wrote the book she needed but couldn't find. She lives in Costa Rica.
+> **Jennifer Brooke Lawless, M.S.** holds degrees in Psychology and Mental Health Counseling. Her clinical work ranged from psychiatric units to family therapy and couples counseling. After surviving narcissistic relationships and discovering that insight alone doesn't heal, she wrote the book she needed but couldn't find.
 
 ### Back Cover Connect Info
 
@@ -248,14 +247,13 @@ Each volume has a **companion workbook**. The workbook covers should look like t
 │                                         │
 │    SEE                                  │  ← TITLE (same as main cover)
 │                                         │
-│    Recognizing Narcissistic             │  ← Subtitle (same as main cover)
-│    Manipulation in Relationships,       │
-│    Family, and Work                     │
+│    The Truth That Was Hidden            │  ← Subtitle (same as main cover)
+│    in Plain Sight                       │
 │                                         │
 │    ── Companion Workbook ──             │  ← Workbook designation (white, small,
 │                                         │     with decorative rules or lighter weight)
 │                                         │
-│    Jennifer Brooke Lawless, M.S.        │  ← Author
+│    Jennifer Brooke Lawless              │  ← Author
 │                                         │
 └─────────────────────────────────────────┘
 ```
@@ -267,7 +265,7 @@ Each volume has a **companion workbook**. The workbook covers should look like t
 - Consider lighter font weight, smaller size, or decorative rules above/below "Companion Workbook"
 - When shelved together (main volume + workbook side by side), they should look like a **matched pair**
 - The spine should also include "Companion Workbook" or "Workbook" after the title
-- Same author name: **Jennifer Brooke Lawless, M.S.**
+- Same author name: **Jennifer Brooke Lawless**
 
 ---
 


### PR DESCRIPTION
## Summary
Updated author name from "Jennifer Brooke Lawless, M.S." to "Jennifer Brooke Lawless" across all book cover specifications, design briefs, and marketing materials. The M.S. credential is retained in the back cover author bio where it provides context for her qualifications.

## Key Changes
- **Cover text updates**: Removed "M.S." from author name on all front covers, spines, and workbook covers across all 8 volumes
- **Design specifications**: Updated naming specs and designer briefs to reflect the simplified author name
- **Marketing materials**: Removed credential from Substack intro and Instagram brand strategy
- **Subtitle clarification**: Improved documentation to clearly distinguish between:
  - **Subtitle** (descriptive text used on front cover, spine, and KDP metadata)
  - **Guide Subtitle** (marketing language for Amazon description, Gumroad, and social media only)
- **Removed outdated section**: Deleted "What's Been Updated" section from main issue brief
- **Removed poetic through-lines**: Removed the subtitle poetry section as it referenced the old marketing subtitles

## Notable Details
- The M.S. credential remains in the back cover author bio: "Jennifer Brooke Lawless, M.S. holds degrees in Psychology and Mental Health Counseling..."
- This change simplifies the front-facing brand while maintaining professional credibility in the detailed bio
- All 8 volumes and their companion workbooks updated consistently
- Personal brand distinction maintained: Jae Lawless (voice/platform) vs. Jennifer Brooke Lawless (book author name)

https://claude.ai/code/session_01A95ZGvjtT7dSqqW3VXQHpn