### PR TITLE
Expand triangulation examples to include body comparison tactics

### DIFF
--- a/book/sovereignty-series/vol-1-see/appendices/appendix-b-glossary.md
+++ b/book/sovereignty-series/vol-1-see/appendices/appendix-b-glossary.md
@@ -301,7 +301,7 @@ A deep, pervasive sense that you're fundamentally flawed or defective as a perso
 An attachment you form through repeated cycles of abuse and intermittent reinforcement. This creates powerful psychological bonds that make leaving difficult. Similar to Stockholm Syndrome.
 
 ### Triangulation
-Bringing a third party into the dynamic to create jealousy, insecurity, or competition. Examples: comparing you unfavorably to an ex, flirting with others, or using children as messengers.
+Bringing a third party into the dynamic to create jealousy, insecurity, or competition. Examples: comparing you unfavorably to an ex, comparing your body or appearance to other women's — even when framed as a compliment ("*other men prefer X, but your body type is perfect for me*") — flirting with others, or using children as messengers.
 
 ### Trigger
 A stimulus (word, sensation, situation) that activates a trauma response in you, often bringing back emotions from past experiences.

--- a/book/sovereignty-series/vol-1-see/chapters/03-decoder-playbook.md
+++ b/book/sovereignty-series/vol-1-see/chapters/03-decoder-playbook.md
@@ -683,12 +683,14 @@ When someone constantly compares you to others—exes, friends, hypothetical alt
 - "You're not like other people I've dated"
 - "I could find someone who..."
 - Hints at attention from others
+- Comparing your body to other women's, even as a "compliment": *"Other men prefer big breasts, but your body type is perfect for me."* The structure is always the same — invoke the comparison, then exempt you from it. You're meant to feel both rated and reassured at once.
+- Pointing out, watching, or praising other women's bodies in your presence so you absorb the comparison without it ever being said directly
 
 **What's Really Happening:**
-They're importing competition into a space that should be collaborative. By reminding you that you're replaceable, they keep you insecure and compliant.
+They're importing competition into a space that should be collaborative. By reminding you that you're replaceable — or that your body, your style, your attractiveness sits on a scale they're holding — they keep you insecure and compliant. The "compliment" version is the most disorienting: you can't object without looking ungrateful, but the comparison has already done its work.
 
 **How It Hooks You:**
-You feel like you're auditioning for a role, not inhabiting a partnership. You measure yourself against phantoms—past relationships, hypothetical alternatives. You try harder to be worthy of being chosen.
+You feel like you're auditioning for a role, not inhabiting a partnership. You measure yourself against phantoms — past relationships, hypothetical alternatives, the women he just rated in front of you. You try harder to be worthy of being chosen. You start monitoring your own body through his eyes.
 
 **Your Power Move:**
 "I'm not in competition with anyone for this relationship. If you'd prefer to be with someone else, that's a choice you can make."


### PR DESCRIPTION
## Summary
Enhanced the documentation on triangulation tactics in the Decoder Playbook to explicitly address body and appearance comparisons as a form of manipulation, including the specific pattern of "compliment-framed" comparisons.

## Key Changes
- **Decoder Playbook (Chapter 03)**: Added two new bullet points under triangulation examples that detail:
  - The "compliment" framing of body comparisons ("Other men prefer X, but your body type is perfect for me") and how this structure creates simultaneous rating and reassurance
  - The tactic of pointing out or praising other women's bodies in the victim's presence as indirect comparison
  
- **Expanded "What's Really Happening" section**: Clarified that the manipulation extends to making the victim feel their body/attractiveness is being measured on a scale, and noted how the "compliment" version is particularly disorienting because it prevents objection

- **Expanded "How It Hooks You" section**: Added that victims internalize comparisons to women the abuser has rated in front of them, and begin monitoring their own body through the abuser's perceived perspective

- **Glossary (Appendix B)**: Updated the Triangulation definition to include body/appearance comparisons with the same "compliment-framed" example for consistency across the document

## Implementation Details
The changes maintain the existing structure and tone while making the documentation more specific about a common but often unrecognized form of triangulation. The additions help readers identify this tactic even when it's disguised as a compliment.

https://claude.ai/code/session_01CuunSatxEpLevNU98vjeaH