### PR TITLE
Add Auracle Substack about page copy and taglines

### DIFF
--- a/book/marketing/substack-about.md
+++ b/book/marketing/substack-about.md
@@ -1,0 +1,55 @@
+# Auracle Substack — About Page
+
+Final copy for the Substack "About" section, plus supporting taglines and bio variants.
+
+---
+
+## About Paragraph (primary)
+
+> Welcome to **Auracle** — a home for the work of seeing clearly, healing deeply, and coming home to yourself.
+>
+> If you've ever been gaslit, scapegoated, love-bombed, triangulated, or quietly erased — and you're tired of being told it wasn't that bad — you're in the right place. Auracle is where I write about the patterns that shape our relationships, the energy work that helps us move what got stuck, and the long arc of reclaiming sovereignty after manipulation and trauma.
+>
+> I'm currently writing **The Sovereignty Series** — an eight-book arc that takes you from naming what happened (*See*) all the way through to *Become*: **See → Heal → Stand → Live → Give → Serve → Thrive → Become.** More books are in the works beyond the series. This Substack is where the work happens in the open — patterns I'm decoding as I write, energy healing practices, reflections from the road, and the occasional excerpt or tool. A few chapters, workbooks, and tools will live on the website as they're ready.
+>
+> Subscribers get first notice when books launch, occasional excerpts and tools, and dispatches from the writing road.
+>
+> Read what you need. Skip what you don't. Your sovereignty is the point.
+
+---
+
+## Tagline
+
+> Auracle — patterns, energy, and the long road home to yourself.
+
+---
+
+## Short Bio (one-liner, for the Substack header / profile)
+
+> Auracle is a home for pattern recognition, energy healing, and sovereignty work — including The Sovereignty Series, an eight-book arc from *See* to *Become*.
+
+---
+
+## What Subscribers Get
+
+- First notice when each book launches (and pre-order links before the public)
+- Occasional excerpts and behind-the-scenes notes from the writing road
+- Free workbooks and tools as they're released
+- Reflections on patterns and energy healing between volumes
+
+---
+
+## The Sovereignty Series — Reference
+
+An eight-volume arc from recognition to reclamation:
+
+1. **See** — Recognizing narcissistic manipulation in relationships, family, and work
+2. **Heal** — Nervous system recovery and attachment repair
+3. **Stand** — Boundaries, internal authority, and self-trust
+4. **Live** — Reclaiming presence, intimacy, and embodied leadership
+5. **Give** — Conscious parenting and breaking generational cycles
+6. **Serve** — Sustainable helping without burnout
+7. **Thrive** — Financial recovery, career rebuilding, prosperity
+8. **Become** — Integration, identity, wholeness
+
+*Companion website hosts a selection of chapters, workbooks, and tools.*


### PR DESCRIPTION
## Summary
Added comprehensive marketing copy for the Auracle Substack "About" section, including the primary about paragraph, taglines, bio variants, and reference information for The Sovereignty Series.

## Changes
- **Primary about paragraph**: Welcoming introduction that positions Auracle as a resource for those recovering from manipulation and trauma, with overview of The Sovereignty Series (eight-book arc from *See* to *Become*)
- **Tagline**: Concise descriptor for marketing use ("patterns, energy, and the long road home to yourself")
- **Short bio**: One-liner optimized for Substack header/profile display
- **Subscriber benefits**: Clear list of what subscribers receive (early book launches, excerpts, workbooks, reflections)
- **Series reference**: Complete eight-volume breakdown with titles and descriptions for each book in The Sovereignty Series, plus note about companion website resources

## Details
This is final copy ready for publication on the Substack platform. The content establishes the brand voice, clarifies the value proposition for potential subscribers, and provides a complete reference for The Sovereignty Series structure and progression.

https://claude.ai/code/session_01TciHZiKPboyamkMzdtqJXb